### PR TITLE
fix(openclaw): reduce block streaming coalesce delays for Shadow channels

### DIFF
--- a/packages/openclaw/src/plugin.ts
+++ b/packages/openclaw/src/plugin.ts
@@ -516,7 +516,11 @@ export const shadowPlugin: ChannelPlugin<ShadowAccountConfig> = {
 
   /** Streaming defaults */
   streaming: {
-    blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
+    // Lower minChars and idleMs for Shadow channels to improve responsiveness.
+    // Unlike Discord/Slack where message density matters, Shadow users expect
+    // near-real-time message delivery. High minChars (1500) causes messages
+    // to be buffered and delayed, creating a poor user experience.
+    blockStreamingCoalesceDefaults: { minChars: 100, idleMs: 100 },
   },
 
   /** Target normalization */


### PR DESCRIPTION
## Problem

Shadow/OpenClaw 插件的消息发送存在明显的缓冲延迟问题。用户反馈消息被推迟到最后集中发出，而不是有进展就立刻同步，体验很差，看上去就像被 buffered 了一样。

## Root Cause

在 `packages/openclaw/src/plugin.ts` 中，`blockStreamingCoalesceDefaults` 的配置值为：

```typescript
blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 }
```

这表示：
- **minChars: 1500** - 消息必须累积到至少 1500 个字符才会被发送
- **idleMs: 1000** - 如果没有达到 minChars，会等待 1000ms 的 idle 时间后才发送

这导致消息被缓冲并推迟发送，造成用户体验不佳。

## Solution

将配置修改为：

```typescript
blockStreamingCoalesceDefaults: { minChars: 100, idleMs: 100 }
```

## Rationale

- Shadow 用户期望接近实时的消息传递，不像 Discord/Slack 那样需要考虑消息密度和速率限制
- 降低 minChars 到 100 可以确保消息更快地被发送
- 降低 idleMs 到 100ms 可以确保即使消息较短也能快速发送

## Changes

- `packages/openclaw/src/plugin.ts`: 修改 `blockStreamingCoalesceDefaults` 配置

## Testing

- [ ] 在 Shadow 频道中测试消息发送的实时性
- [ ] 验证长消息仍然正确分块发送
- [ ] 验证短消息能够立即发送