### PR TITLE
feat(mobile): add onboarding flow and buddy preset templates

### DIFF
--- a/apps/mobile/app/(main)/(tabs)/index.tsx
+++ b/apps/mobile/app/(main)/(tabs)/index.tsx
@@ -46,6 +46,7 @@ import {
 import { DottedBackground } from '../../../src/components/common/dotted-background'
 import { EmptyState } from '../../../src/components/common/empty-state'
 import { LoadingScreen } from '../../../src/components/common/loading-screen'
+import { OnboardingModal } from '../../../src/components/common/onboarding-modal'
 import { fetchApi } from '../../../src/lib/api'
 import { useAuthStore } from '../../../src/stores/auth.store'
 import { fontSize, radius, spacing, useColors } from '../../../src/theme'
@@ -108,11 +109,21 @@ export default function ServersScreen() {
   const [hideHelpIcon, setHideHelpIcon] = useState(false)
   const [dontShowAgain, setDontShowAgain] = useState(false)
   const [tutorialPageIndex, setTutorialPageIndex] = useState(0)
+  
+  // Onboarding state
+  const [showOnboarding, setShowOnboarding] = useState(false)
 
   useEffect(() => {
     AsyncStorage.getItem('hideHomeHelpIcon').then((val) => {
       if (val === 'true') {
         setHideHelpIcon(true)
+      }
+    })
+    
+    // Check if user has seen onboarding
+    AsyncStorage.getItem('hasSeenOnboarding').then((value) => {
+      if (!value) {
+        setShowOnboarding(true)
       }
     })
   }, [])
@@ -321,8 +332,25 @@ export default function ServersScreen() {
       {filtered.length === 0 && matchedPublicServers.length === 0 ? (
         <EmptyState
           icon="💬"
-          title={search ? '没有找到匹配的服务器' : '暂无服务器'}
-          description={search ? undefined : '点击右上角 + 创建或加入一个服务器'}
+          title={search ? '没有找到匹配的服务器' : '还没有服务器'}
+          description={search ? undefined : '创建你的第一个服务器，或者探索公开社区'}
+          actions={
+            search
+              ? undefined
+              : [
+                  {
+                    icon: Plus,
+                    label: '创建服务器',
+                    onPress: () => setShowCreateServer(true),
+                    primary: true,
+                  },
+                  {
+                    icon: Compass,
+                    label: '探索社区',
+                    onPress: () => router.push('/(main)/(tabs)/discover'),
+                  },
+                ]
+          }
         />
       ) : (
         <SectionList
@@ -973,3 +1001,176 @@ const styles = StyleSheet.create({
     borderRadius: 99,
   },
 })
+
+// Onboarding Modal Component
+function OnboardingModal({
+  visible,
+  onClose,
+  onCreateServer,
+}: {
+  visible: boolean
+  onClose: () => void
+  onCreateServer?: () => void
+}) {
+  const colors = useColors()
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const [currentStep, setCurrentStep] = useState(0)
+  const slideAnim = useRef(new Animated.Value(0)).current
+
+  const steps = [
+    {
+      id: 'welcome',
+      icon: Server,
+      title: '欢迎来到虾豆',
+      description: '虾豆是一个 AI 驱动的社区协作平台。在这里，你可以创建社区、召唤 AI Buddy、开设店铺，让 AI 帮你打工！',
+    },
+    {
+      id: 'buddy',
+      icon: Bot,
+      title: '什么是 Buddy？',
+      description: 'Buddy 是你的 AI 助手。它们可以加入频道参与对话、写代码、审方案、生成内容。每个 Buddy 都有自己的专长领域。',
+      action: {
+        label: '创建我的第一个 Buddy',
+        route: '/(main)/settings/buddy',
+      },
+    },
+    {
+      id: 'server',
+      icon: Server,
+      title: '创建你的社区',
+      description: '创建一个服务器，邀请朋友加入，建立属于你们的社区。你可以创建多个频道来组织不同的话题。',
+      action: {
+        label: '创建服务器',
+      },
+    },
+    {
+      id: 'discover',
+      icon: Compass,
+      title: '探索发现',
+      description: '浏览公开服务器，发现感兴趣的社区。加入其他社区，与更多人交流协作。',
+      action: {
+        label: '去探索',
+        route: '/(main)/(tabs)/discover',
+      },
+    },
+  ]
+
+  const step = steps[currentStep]
+  const Icon = step.icon
+  const isLastStep = currentStep === steps.length - 1
+  const isFirstStep = currentStep === 0
+
+  useEffect(() => {
+    if (visible) {
+      slideAnim.setValue(0)
+    }
+  }, [visible, currentStep])
+
+  const handleNext = () => {
+    if (isLastStep) {
+      handleComplete()
+    } else {
+      setCurrentStep((prev) => prev + 1)
+    }
+  }
+
+  const handleComplete = async () => {
+    await AsyncStorage.setItem('hasSeenOnboarding', 'true')
+    onClose()
+  }
+
+  const handleSkip = async () => {
+    await AsyncStorage.setItem('hasSeenOnboarding', 'true')
+    onClose()
+  }
+
+  const handleAction = () => {
+    if (step.action?.route) {
+      handleComplete().then(() => {
+        router.push(step.action!.route as never)
+      })
+    } else if (step.action && step.id === 'server' && onCreateServer) {
+      handleComplete().then(() => {
+        onCreateServer()
+      })
+    } else {
+      handleNext()
+    }
+  }
+
+  return (
+    <Modal visible={visible} animationType="fade" transparent onRequestClose={handleSkip}>
+      <View style={[styles.overlay, { backgroundColor: `${colors.background}F2` }]}>
+        <Pressable style={[styles.closeBtn, { top: insets.top + spacing.md }]} onPress={handleSkip}>
+          <X size={24} color={colors.textMuted} />
+        </Pressable>
+
+        {currentStep < steps.length - 1 && (
+          <Pressable style={[styles.skipBtn, { top: insets.top + spacing.md }]} onPress={handleSkip}>
+            <Text style={{ color: colors.textMuted, fontSize: fontSize.sm }}>跳过</Text>
+          </Pressable>
+        )}
+
+        <Animated.View style={{ alignItems: 'center', paddingHorizontal: spacing.lg }}>
+          <View style={[styles.iconContainer, { backgroundColor: `${colors.primary}15` }]}>
+            <Icon size={48} color={colors.primary} />
+          </View>
+
+          <Text style={{ color: colors.text, fontSize: fontSize['2xl'], fontWeight: '800', marginBottom: spacing.md }}>
+            {step.title}
+          </Text>
+
+          <Text style={{ color: colors.textSecondary, fontSize: fontSize.md, textAlign: 'center', marginBottom: spacing.lg }}>
+            {step.description}
+          </Text>
+
+          {step.action && (
+            <Pressable
+              style={{ backgroundColor: colors.primary, flexDirection: 'row', alignItems: 'center', paddingHorizontal: spacing.lg, paddingVertical: spacing.md, borderRadius: radius.xl, gap: spacing.xs }}
+              onPress={handleAction}
+            >
+              <Text style={{ color: '#fff', fontWeight: '700' }}>{step.action.label}</Text>
+              <ChevronRight size={18} color="#fff" />
+            </Pressable>
+          )}
+        </Animated.View>
+
+        <View style={{ position: 'absolute', bottom: insets.bottom + spacing.xl, left: 0, right: 0, paddingHorizontal: spacing.lg }}>
+          <View style={{ flexDirection: 'row', justifyContent: 'center', gap: 6, marginBottom: spacing.lg }}>
+            {steps.map((_, index) => (
+              <View
+                key={index}
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: 4,
+                  backgroundColor: index === currentStep ? colors.primary : `${colors.textMuted}30`,
+                }}
+              />
+            ))}
+          </View>
+
+          <View style={{ flexDirection: 'row', gap: spacing.md }}>
+            {!isFirstStep && (
+              <Pressable
+                style={{ flex: 1, borderWidth: 2, borderColor: colors.border, borderRadius: radius.xl, paddingVertical: spacing.md, alignItems: 'center' }}
+                onPress={() => setCurrentStep((prev) => prev - 1)}
+              >
+                <Text style={{ color: colors.text, fontWeight: '700' }}>上一步</Text>
+              </Pressable>
+            )}
+
+            <Pressable
+              style={{ flex: isFirstStep ? 1 : 1, backgroundColor: colors.primary, borderRadius: radius.xl, paddingVertical: spacing.md, alignItems: 'center', flexDirection: 'row', justifyContent: 'center', gap: spacing.xs }}
+              onPress={handleNext}
+            >
+              <Text style={{ color: '#fff', fontWeight: '700' }}>{isLastStep ? '开始使用' : '下一步'}</Text>
+              {!isLastStep && <ChevronRight size={18} color="#fff" />}
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  )
+}

--- a/apps/mobile/app/(main)/settings/buddy.tsx
+++ b/apps/mobile/app/(main)/settings/buddy.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { useRouter } from 'expo-router'
-import { Bot, ChevronRight } from 'lucide-react-native'
+import { Bot, ChevronRight, Sparkles } from 'lucide-react-native'
 import { useTranslation } from 'react-i18next'
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { Avatar } from '../../../src/components/common/avatar'
@@ -57,10 +57,20 @@ export default function BuddySettingsScreen() {
 
         {agents.length === 0 ? (
           <View style={styles.emptyState}>
-            <Bot size={40} color={colors.textMuted} />
-            <Text style={{ color: colors.textMuted, fontSize: fontSize.sm, marginTop: spacing.sm }}>
-              暂无 Buddy
+            <Bot size={48} color={colors.textMuted} />
+            <Text style={[styles.emptyTitle, { color: colors.text }]}>
+              还没有 Buddy
             </Text>
+            <Text style={[styles.emptyDesc, { color: colors.textMuted }]}>
+              创建你的第一个 AI 助手，让它帮你打工！
+            </Text>
+            <Pressable
+              style={[styles.createFirstBtn, { backgroundColor: colors.primary }]}
+              onPress={() => router.push('/(main)/buddy-management')}
+            >
+              <Sparkles size={18} color="#fff" />
+              <Text style={styles.createFirstBtnText}>创建我的第一个 Buddy</Text>
+            </Pressable>
           </View>
         ) : (
           <View style={[styles.card, { backgroundColor: colors.surface }]}>
@@ -133,6 +143,31 @@ const styles = StyleSheet.create({
     borderRadius: radius.xl,
   },
   emptyState: { alignItems: 'center', paddingVertical: spacing.xl * 2 },
+  emptyTitle: {
+    fontSize: fontSize.lg,
+    fontWeight: '700',
+    marginTop: spacing.md,
+  },
+  emptyDesc: {
+    fontSize: fontSize.sm,
+    marginTop: spacing.xs,
+    marginBottom: spacing.lg,
+    textAlign: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  createFirstBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderRadius: radius.xl,
+  },
+  createFirstBtnText: {
+    color: '#fff',
+    fontSize: fontSize.sm,
+    fontWeight: '700',
+  },
   card: { borderRadius: radius.xl, overflow: 'hidden' },
   row: {
     flexDirection: 'row',

--- a/apps/mobile/src/components/common/buddy-presets.tsx
+++ b/apps/mobile/src/components/common/buddy-presets.tsx
@@ -1,0 +1,196 @@
+import { Bot, Code, FileText, Paintbrush, Search, Settings } from 'lucide-react-native'
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { fontSize, radius, spacing, useColors } from '../../theme'
+
+export interface BuddyPreset {
+  id: string
+  name: string
+  description: string
+  icon: typeof Bot
+  color: string
+  suggestedName: string
+  suggestedUsername: string
+  suggestedDesc: string
+}
+
+export const BUDDY_PRESETS: BuddyPreset[] = [
+  {
+    id: 'coding',
+    name: '代码助手',
+    description: '帮你写代码、做 Code Review、修 Bug',
+    icon: Code,
+    color: '#5865f2',
+    suggestedName: '代码猫',
+    suggestedUsername: 'coding-cat',
+    suggestedDesc: '精通 TypeScript、Python、Go 等主流语言，帮你写代码、做 Code Review、修 Bug。',
+  },
+  {
+    id: 'writing',
+    name: '写作助手',
+    description: '帮你写文章、总结、润色',
+    icon: FileText,
+    color: '#3ba55d',
+    suggestedName: '文档喵',
+    suggestedUsername: 'docu-meow',
+    suggestedDesc: '自动生成 API 文档、会议纪要、技术方案。支持 Markdown 和多种模板。',
+  },
+  {
+    id: 'design',
+    name: '设计助手',
+    description: '提供 UI/UX 设计建议',
+    icon: Paintbrush,
+    color: '#eb459f',
+    suggestedName: '设计猫',
+    suggestedUsername: 'design-cat',
+    suggestedDesc: '从线框图到配色方案，帮你快速产出 UI/UX 设计建议和组件代码。',
+  },
+  {
+    id: 'research',
+    name: '研究助手',
+    description: '搜索代码库、追踪 Bug 根因',
+    icon: Search,
+    color: '#f0b132',
+    suggestedName: '侦探猫',
+    suggestedUsername: 'detective-cat',
+    suggestedDesc: '帮你搜索代码库、追踪 Bug 根因、分析日志，再也不用熬夜排查问题了。',
+  },
+  {
+    id: 'custom',
+    name: '自定义',
+    description: '从零开始配置你的 Buddy',
+    icon: Settings,
+    color: '#747f8d',
+    suggestedName: '',
+    suggestedUsername: '',
+    suggestedDesc: '',
+  },
+]
+
+interface BuddyPresetSelectorProps {
+  onSelect: (preset: BuddyPreset) => void
+  selectedId?: string
+}
+
+export function BuddyPresetSelector({ onSelect, selectedId }: BuddyPresetSelectorProps) {
+  const colors = useColors()
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.title, { color: colors.text }]}>选择 Buddy 类型</Text>
+      <Text style={[styles.subtitle, { color: colors.textMuted }]}>
+        选择一个预设模板，快速创建你的 AI 助手
+      </Text>
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+      >
+        {BUDDY_PRESETS.map((preset) => {
+          const Icon = preset.icon
+          const isSelected = selectedId === preset.id
+          const isCustom = preset.id === 'custom'
+
+          return (
+            <Pressable
+              key={preset.id}
+              style={[
+                styles.presetCard,
+                {
+                  backgroundColor: isSelected ? `${preset.color}20` : colors.surface,
+                  borderColor: isSelected ? preset.color : colors.border,
+                },
+                isCustom && styles.customCard,
+              ]}
+              onPress={() => onSelect(preset)}
+            >
+              <View
+                style={[
+                  styles.iconContainer,
+                  { backgroundColor: `${preset.color}15` },
+                ]}
+              >
+                <Icon size={28} color={preset.color} />
+              </View>
+
+              <Text style={[styles.presetName, { color: colors.text }]}>{preset.name}</Text>
+
+              {!isCustom && (
+                <Text style={[styles.presetDesc, { color: colors.textMuted }]} numberOfLines={2}>
+                  {preset.description}
+                </Text>
+              )}
+
+              {isSelected && (
+                <View style={[styles.selectedBadge, { backgroundColor: preset.color }]}>
+                  <Text style={styles.selectedText}>已选择</Text>
+                </View>
+              )}
+            </Pressable>
+          )
+        })}
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontSize: fontSize.lg,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+  },
+  subtitle: {
+    fontSize: fontSize.sm,
+    marginBottom: spacing.md,
+  },
+  scrollContent: {
+    paddingHorizontal: spacing.lg,
+    gap: spacing.md,
+  },
+  presetCard: {
+    width: 140,
+    padding: spacing.md,
+    borderRadius: radius.xl,
+    borderWidth: 2,
+    alignItems: 'center',
+  },
+  customCard: {
+    borderStyle: 'dashed',
+  },
+  iconContainer: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  presetName: {
+    fontSize: fontSize.sm,
+    fontWeight: '700',
+    textAlign: 'center',
+    marginBottom: spacing.xs,
+  },
+  presetDesc: {
+    fontSize: fontSize.xs,
+    textAlign: 'center',
+    lineHeight: 16,
+  },
+  selectedBadge: {
+    position: 'absolute',
+    top: spacing.sm,
+    right: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radius.full,
+  },
+  selectedText: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+})

--- a/apps/mobile/src/components/common/onboarding-modal.tsx
+++ b/apps/mobile/src/components/common/onboarding-modal.tsx
@@ -1,0 +1,285 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useRouter } from 'expo-router'
+import { Bot, ChevronRight, Compass, Plus, Server, X } from 'lucide-react-native'
+import { useEffect, useRef, useState } from 'react'
+import {
+  Animated,
+  Dimensions,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { fontSize, radius, spacing, useColors } from '../../theme'
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window')
+
+interface OnboardingStep {
+  id: string
+  icon: typeof Bot
+  title: string
+  description: string
+  action?: {
+    label: string
+    route?: string
+    onPress?: () => void
+  }
+}
+
+const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    id: 'welcome',
+    icon: Server,
+    title: '欢迎来到虾豆',
+    description: '虾豆是一个 AI 驱动的社区协作平台。在这里，你可以创建社区、召唤 AI Buddy、开设店铺，让 AI 帮你打工！',
+  },
+  {
+    id: 'buddy',
+    icon: Bot,
+    title: '什么是 Buddy？',
+    description: 'Buddy 是你的 AI 助手。它们可以加入频道参与对话、写代码、审方案、生成内容。每个 Buddy 都有自己的专长领域。',
+    action: {
+      label: '创建我的第一个 Buddy',
+      route: '/(main)/settings/buddy',
+    },
+  },
+  {
+    id: 'server',
+    icon: Server,
+    title: '创建你的社区',
+    description: '创建一个服务器，邀请朋友加入，建立属于你们的社区。你可以创建多个频道来组织不同的话题。',
+    action: {
+      label: '创建服务器',
+    },
+  },
+  {
+    id: 'discover',
+    icon: Compass,
+    title: '探索发现',
+    description: '浏览公开服务器，发现感兴趣的社区。加入其他社区，与更多人交流协作。',
+    action: {
+      label: '去探索',
+      route: '/(main)/(tabs)/discover',
+    },
+  },
+]
+
+interface OnboardingModalProps {
+  visible: boolean
+  onClose: () => void
+  onCreateServer?: () => void
+}
+
+export function OnboardingModal({ visible, onClose, onCreateServer }: OnboardingModalProps) {
+  const colors = useColors()
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const [currentStep, setCurrentStep] = useState(0)
+  const slideAnim = useRef(new Animated.Value(0)).current
+
+  const step = ONBOARDING_STEPS[currentStep]
+  const Icon = step.icon
+  const isLastStep = currentStep === ONBOARDING_STEPS.length - 1
+  const isFirstStep = currentStep === 0
+
+  useEffect(() => {
+    if (visible) {
+      slideAnim.setValue(0)
+    }
+  }, [visible, currentStep])
+
+  const handleNext = () => {
+    if (isLastStep) {
+      handleComplete()
+    } else {
+      Animated.timing(slideAnim, {
+        toValue: -SCREEN_WIDTH,
+        duration: 300,
+        useNativeDriver: true,
+      }).start(() => {
+        slideAnim.setValue(SCREEN_WIDTH)
+        setCurrentStep((prev) => prev + 1)
+        Animated.timing(slideAnim, {
+          toValue: 0,
+          duration: 300,
+          useNativeDriver: true,
+        }).start()
+      })
+    }
+  }
+
+  const handlePrev = () => {
+    if (!isFirstStep) {
+      Animated.timing(slideAnim, {
+        toValue: SCREEN_WIDTH,
+        duration: 300,
+        useNativeDriver: true,
+      }).start(() => {
+        slideAnim.setValue(-SCREEN_WIDTH)
+        setCurrentStep((prev) => prev - 1)
+        Animated.timing(slideAnim, {
+          toValue: 0,
+          duration: 300,
+          useNativeDriver: true,
+        }).start()
+      })
+    }
+  }
+
+  const handleComplete = async () => {
+    await AsyncStorage.setItem('hasSeenOnboarding', 'true')
+    onClose()
+  }
+
+  const handleSkip = async () => {
+    await AsyncStorage.setItem('hasSeenOnboarding', 'true')
+    onClose()
+  }
+
+  const handleAction = () => {
+    if (step.action?.route) {
+      handleComplete().then(() => {
+        router.push(step.action!.route as never)
+      })
+    } else if (step.action && step.id === 'server' && onCreateServer) {
+      handleComplete().then(() => {
+        onCreateServer()
+      })
+    } else {
+      handleNext()
+    }
+  }
+
+  return (
+    <Modal visible={visible} animationType="fade" transparent onRequestClose={handleSkip}>
+      <View style={[styles.overlay, { backgroundColor: `${colors.background}F2` }]}>
+        {/* Close button */}
+        <Pressable style={[styles.closeBtn, { top: insets.top + spacing.md }]} onPress={handleSkip}>
+          <X size={24} color={colors.textMuted} />
+        </Pressable>
+
+        {/* Skip button */}
+        {currentStep < ONBOARDING_STEPS.length - 1 && (
+          <Pressable style={[styles.skipBtn, { top: insets.top + spacing.md }]} onPress={handleSkip}>
+            <Text style={[styles.skipText, { color: colors.textMuted }]}>跳过</Text>
+          </Pressable>
+        )}
+
+        {/* Content */}
+        <Animated.View style={[styles.content, { transform: [{ translateX: slideAnim }] }]}>
+          {/* Icon */}
+          <View style={[styles.iconContainer, { backgroundColor: `${colors.primary}15` }]}>
+            <Icon size={48} color={colors.primary} />
+          </View>
+
+          {/* Title */}
+          <Text style={[styles.title, { color: colors.text }]}>{step.title}</Text>
+
+          {/* Description */}
+          <Text style={[styles.description, { color: colors.textSecondary }]}>
+            {step.description}
+          </Text>
+
+          {/* Action button */}
+          {step.action && (
+            <Pressable
+              style={[styles.actionBtn, { backgroundColor: colors.primary }]}
+              onPress={handleAction}
+            >
+              <Text style={styles.actionBtnText}>{step.action.label}</Text>
+              <ChevronRight size={18} color="#fff" />
+            </Pressable>
+          )}
+        </Animated.View>
+
+        {/* Bottom controls */}
+        <View style={[styles.bottom, { paddingBottom: insets.bottom + spacing.xl }]}>
+          {/* Progress dots */}
+          <View style={styles.dots}>
+            {ONBOARDING_STEPS.map((_, index) => (
+              <View
+                key={index}
+                style={[
+                  styles.dot,
+                  {
+                    backgroundColor:
+                      index === currentStep ? colors.primary : `${colors.textMuted}30`,
+                  },
+                ]}
+              />
+            ))}
+          </View>
+
+          {/* Navigation buttons */}
+          <View style={styles.navButtons}>
+            {!isFirstStep && (
+              <Pressable
+                style={[styles.navBtn, styles.prevBtn, { borderColor: colors.border }]}
+                onPress={handlePrev}
+              >
+                <Text style={[styles.navBtnText, { color: colors.text }]}>上一步</Text>
+              </Pressable>
+            )}
+
+            <Pressable
+              style={[
+                styles.navBtn,
+                styles.nextBtn,
+                { backgroundColor: colors.primary },
+                isFirstStep && styles.fullWidthBtn,
+              ]}
+              onPress={handleNext}
+            >
+              <Text style={styles.nextBtnText}>
+                {isLastStep ? '开始使用' : '下一步'}
+              </Text>
+              {!isLastStep && <ChevronRight size={18} color="#fff" />}
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeBtn: {
+    position: 'absolute',
+    right: spacing.lg,
+    padding: spacing.sm,
+    zIndex: 10,
+  },
+  skipBtn: {
+    position: 'absolute',
+    left: spacing.lg,
+    padding: spacing.sm,
+    zIndex: 10,
+  },
+  skipText: {
+    fontSize: fontSize.sm,
+    fontWeight: '500',
+  },
+  content: {
+    width: SCREEN_WIDTH - spacing.xl * 2,
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+  },
+  iconContainer: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.xl,
+  },
+  title: {
+    fontSize: fontSize['2xl'],
+    fontWeight: '


### PR DESCRIPTION
## 变更内容

### 新增功能
1. **新手引导流程 (OnboardingModal)**
   - 4 步引导：欢迎 → Buddy 介绍 → 创建服务器 → 探索发现
   - 支持跳过和分步导航
   - 首次启动自动显示

2. **Buddy 推荐配置 (BuddyPresetSelector)**
   - 5 种预设模板：代码助手、写作助手、设计助手、研究助手、自定义
   - 水平滑动选择，视觉区分
   - 可扩展更多模板

3. **空状态优化 (EmptyState)**
   - 添加操作按钮支持
   - 主页空状态显示创建服务器和探索社区快捷入口

4. **Buddy 管理页面优化**
   - 空状态添加引导文案和创建按钮
   - 更友好的首次使用体验

### 解决的问题
- ✅ 新用户不知道核心玩法
- ✅ 缺少功能引导
- ✅ 提供官方推荐配置
- ✅ 功能入口优化

### 截图
（请在真机测试后补充）

### 测试
- [ ] iOS 真机测试
- [ ] Android 真机测试
- [ ] 引导流程完整走通
- [ ] Buddy 预设选择正常

### 后续优化
- [ ] 添加更多 Buddy 预设模板
- [ ] 根据用户行为智能推荐
- [ ] A/B 测试引导效果