### PR TITLE
feat(web): add onboarding flow and buddy preset templates

### DIFF
--- a/apps/web/src/components/common/buddy-presets.tsx
+++ b/apps/web/src/components/common/buddy-presets.tsx
@@ -1,0 +1,128 @@
+import { Bot, Code, FileText, Paintbrush, Search, Settings } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+export interface BuddyPreset {
+  id: string
+  name: string
+  description: string
+  icon: typeof Bot
+  color: string
+  suggestedName: string
+  suggestedUsername: string
+  suggestedDesc: string
+}
+
+export const BUDDY_PRESETS: BuddyPreset[] = [
+  {
+    id: 'coding',
+    name: '代码助手',
+    description: '帮你写代码、做 Code Review、修 Bug',
+    icon: Code,
+    color: '#5865f2',
+    suggestedName: '代码猫',
+    suggestedUsername: 'coding-cat',
+    suggestedDesc: '精通 TypeScript、Python、Go 等主流语言，帮你写代码、做 Code Review、修 Bug。',
+  },
+  {
+    id: 'writing',
+    name: '写作助手',
+    description: '帮你写文章、总结、润色',
+    icon: FileText,
+    color: '#3ba55d',
+    suggestedName: '文档喵',
+    suggestedUsername: 'docu-meow',
+    suggestedDesc: '自动生成 API 文档、会议纪要、技术方案。支持 Markdown 和多种模板。',
+  },
+  {
+    id: 'design',
+    name: '设计助手',
+    description: '提供 UI/UX 设计建议',
+    icon: Paintbrush,
+    color: '#eb459f',
+    suggestedName: '设计猫',
+    suggestedUsername: 'design-cat',
+    suggestedDesc: '从线框图到配色方案，帮你快速产出 UI/UX 设计建议和组件代码。',
+  },
+  {
+    id: 'research',
+    name: '研究助手',
+    description: '搜索代码库、追踪 Bug 根因',
+    icon: Search,
+    color: '#f0b132',
+    suggestedName: '侦探猫',
+    suggestedUsername: 'detective-cat',
+    suggestedDesc: '帮你搜索代码库、追踪 Bug 根因、分析日志，再也不用熬夜排查问题了。',
+  },
+  {
+    id: 'custom',
+    name: '自定义',
+    description: '从零开始配置你的 Buddy',
+    icon: Settings,
+    color: '#747f8d',
+    suggestedName: '',
+    suggestedUsername: '',
+    suggestedDesc: '',
+  },
+]
+
+interface BuddyPresetSelectorProps {
+  onSelect: (preset: BuddyPreset) => void
+  selectedId?: string
+}
+
+export function BuddyPresetSelector({ onSelect, selectedId }: BuddyPresetSelectorProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="mb-6">
+      <h3 className="text-lg font-bold text-text-primary mb-2">选择 Buddy 类型</h3>
+      <p className="text-sm text-text-muted mb-4">选择一个预设模板，快速创建你的 AI 助手</p>
+
+      <div className="flex gap-4 overflow-x-auto pb-2 -mx-2 px-2">
+        {BUDDY_PRESETS.map((preset) => {
+          const Icon = preset.icon
+          const isSelected = selectedId === preset.id
+          const isCustom = preset.id === 'custom'
+
+          return (
+            <button
+              key={preset.id}
+              onClick={() => onSelect(preset)}
+              className={`flex-shrink-0 w-36 p-4 rounded-2xl border-2 text-center transition-all ${
+                isSelected
+                  ? `bg-[${preset.color}]/10 border-[${preset.color}]`
+                  : 'bg-bg-secondary border-border-subtle hover:border-border-default'
+              } ${isCustom ? 'border-dashed' : ''}`}
+              style={{
+                backgroundColor: isSelected ? `${preset.color}15` : undefined,
+                borderColor: isSelected ? preset.color : undefined,
+              }}
+            >
+              <div
+                className="w-14 h-14 mx-auto mb-3 rounded-full flex items-center justify-center"
+                style={{ backgroundColor: `${preset.color}15` }}
+              >
+                <Icon size={28} style={{ color: preset.color }} />
+              </div>
+
+              <h4 className="font-bold text-text-primary mb-1">{preset.name}</h4>
+
+              {!isCustom && (
+                <p className="text-xs text-text-muted line-clamp-2">{preset.description}</p>
+              )}
+
+              {isSelected && (
+                <span
+                  className="absolute top-2 right-2 px-2 py-0.5 text-[10px] font-bold text-white rounded-full"
+                  style={{ backgroundColor: preset.color }}
+                >
+                  已选择
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/common/onboarding-modal.tsx
+++ b/apps/web/src/components/common/onboarding-modal.tsx
@@ -1,0 +1,205 @@
+import { Bot, ChevronRight, Compass, Plus, Server, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from '@tanstack/react-router'
+
+interface OnboardingStep {
+  id: string
+  icon: typeof Bot
+  title: string
+  description: string
+  action?: {
+    label: string
+    route?: string
+    onClick?: () => void
+  }
+}
+
+const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    id: 'welcome',
+    icon: Server,
+    title: '欢迎来到虾豆',
+    description: '虾豆是一个 AI 驱动的社区协作平台。在这里，你可以创建社区、召唤 AI Buddy、开设店铺，让 AI 帮你打工！',
+  },
+  {
+    id: 'buddy',
+    icon: Bot,
+    title: '什么是 Buddy？',
+    description: 'Buddy 是你的 AI 助手。它们可以加入频道参与对话、写代码、审方案、生成内容。每个 Buddy 都有自己的专长领域。',
+    action: {
+      label: '创建我的第一个 Buddy',
+      route: '/settings',
+    },
+  },
+  {
+    id: 'server',
+    icon: Server,
+    title: '创建你的社区',
+    description: '创建一个服务器，邀请朋友加入，建立属于你们的社区。你可以创建多个频道来组织不同的话题。',
+    action: {
+      label: '创建服务器',
+    },
+  },
+  {
+    id: 'discover',
+    icon: Compass,
+    title: '探索发现',
+    description: '浏览公开服务器，发现感兴趣的社区。加入其他社区，与更多人交流协作。',
+    action: {
+      label: '去探索',
+      route: '/discover',
+    },
+  },
+]
+
+interface OnboardingModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onCreateServer?: () => void
+}
+
+export function OnboardingModal({ isOpen, onClose, onCreateServer }: OnboardingModalProps) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [currentStep, setCurrentStep] = useState(0)
+  const [isVisible, setIsVisible] = useState(false)
+
+  const step = ONBOARDING_STEPS[currentStep]
+  const Icon = step.icon
+  const isLastStep = currentStep === ONBOARDING_STEPS.length - 1
+  const isFirstStep = currentStep === 0
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => setIsVisible(true), 10)
+    } else {
+      setIsVisible(false)
+      setCurrentStep(0)
+    }
+  }, [isOpen])
+
+  const handleNext = () => {
+    if (isLastStep) {
+      handleComplete()
+    } else {
+      setCurrentStep((prev) => prev + 1)
+    }
+  }
+
+  const handleComplete = () => {
+    localStorage.setItem('hasSeenOnboarding', 'true')
+    onClose()
+  }
+
+  const handleSkip = () => {
+    localStorage.setItem('hasSeenOnboarding', 'true')
+    onClose()
+  }
+
+  const handleAction = () => {
+    if (step.action?.route) {
+      handleComplete()
+      navigate({ to: step.action.route as never })
+    } else if (step.action && step.id === 'server' && onCreateServer) {
+      handleComplete()
+      onCreateServer()
+    } else {
+      handleNext()
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-bg-primary/95 backdrop-blur-sm transition-opacity duration-300 ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      {/* Close button */}
+      <button
+        onClick={handleSkip}
+        className="absolute top-6 right-6 p-2 text-text-muted hover:text-text-primary transition-colors"
+      >
+        <X size={24} />
+      </button>
+
+      {/* Skip button */}
+      {currentStep < ONBOARDING_STEPS.length - 1 && (
+        <button
+          onClick={handleSkip}
+          className="absolute top-6 left-6 text-sm font-medium text-text-muted hover:text-text-primary transition-colors"
+        >
+          跳过
+        </button>
+      )}
+
+      {/* Content */}
+      <div
+        className={`w-full max-w-md px-8 text-center transition-all duration-300 transform ${
+          isVisible ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'
+        }`}
+      >
+        {/* Icon */}
+        <div className="w-24 h-24 mx-auto mb-8 rounded-full bg-primary/10 flex items-center justify-center">
+          <Icon size={48} className="text-primary" />
+        </div>
+
+        {/* Title */}
+        <h2 className="text-2xl font-bold text-text-primary mb-4">{step.title}</h2>
+
+        {/* Description */}
+        <p className="text-text-secondary mb-8 leading-relaxed">{step.description}</p>
+
+        {/* Action button */}
+        {step.action && (
+          <button
+            onClick={handleAction}
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-hover text-white rounded-xl font-semibold transition-colors"
+          >
+            {step.action.label}
+            <ChevronRight size={18} />
+          </button>
+        )}
+      </div>
+
+      {/* Bottom controls */}
+      <div className="absolute bottom-8 left-0 right-0 px-8">
+        {/* Progress dots */}
+        <div className="flex justify-center gap-2 mb-8">
+          {ONBOARDING_STEPS.map((_, index) => (
+            <div
+              key={index}
+              className={`w-2 h-2 rounded-full transition-colors ${
+                index === currentStep ? 'bg-primary' : 'bg-text-muted/30'
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Navigation buttons */}
+        <div className="flex gap-4 max-w-md mx-auto">
+          {!isFirstStep && (
+            <button
+              onClick={() => setCurrentStep((prev) => prev - 1)}
+              className="flex-1 py-3 border-2 border-border-subtle rounded-xl text-text-primary font-semibold hover:bg-bg-secondary transition-colors"
+            >
+              上一步
+            </button>
+          )}
+
+          <button
+            onClick={handleNext}
+            className={`flex-1 py-3 bg-primary hover:bg-primary-hover text-white rounded-xl font-semibold flex items-center justify-center gap-1 transition-colors ${
+              isFirstStep ? 'w-full' : ''
+            }`}
+          >
+            {isLastStep ? '开始使用' : '下一步'}
+            {!isLastStep && <ChevronRight size={18} />}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/buddy-management.tsx
+++ b/apps/web/src/pages/buddy-management.tsx
@@ -1176,6 +1176,8 @@ function EmptyState({
 
 /* ── Create Agent Dialog ──────────────────────────────── */
 
+import { BuddyPreset, BuddyPresetSelector, BUDDY_PRESETS } from '../components/common/buddy-presets'
+
 function CreateAgentDialog({
   onClose,
   onSuccess,
@@ -1191,6 +1193,16 @@ function CreateAgentDialog({
   const [username, setUsername] = useState('')
   const [description, setDescription] = useState('')
   const [selectedAvatar, setSelectedAvatar] = useState<string | null>(null)
+  const [selectedPreset, setSelectedPreset] = useState<BuddyPreset | null>(null)
+
+  const handlePresetSelect = (preset: BuddyPreset) => {
+    setSelectedPreset(preset)
+    if (preset.id !== 'custom') {
+      setName(preset.suggestedName)
+      setUsername(preset.suggestedUsername)
+      setDescription(preset.suggestedDesc)
+    }
+  }
 
   const createMutation = useMutation({
     mutationFn: (data: {
@@ -1216,8 +1228,14 @@ function CreateAgentDialog({
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-      <div className="bg-bg-secondary rounded-xl p-6 w-full max-w-[480px] mx-4 max-h-[80vh] overflow-y-auto border border-border-subtle">
+      <div className="bg-bg-secondary rounded-xl p-6 w-full max-w-[600px] mx-4 max-h-[85vh] overflow-y-auto border border-border-subtle">
         <h2 className="text-xl font-bold text-text-primary mb-6">{t('agentMgmt.createTitle')}</h2>
+
+        {/* Preset Selector */}
+        <BuddyPresetSelector
+          onSelect={handlePresetSelect}
+          selectedId={selectedPreset?.id}
+        />
 
         {/* Name */}
         <div className="mb-4">

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from 'react-i18next'
 import { UserAvatar } from '../components/common/avatar'
 import { AvatarEditor } from '../components/common/avatar-editor'
 import { LanguageSwitcher } from '../components/common/language-switcher'
+import { OnboardingModal } from '../components/common/onboarding-modal'
 import { PriceDisplay } from '../components/shop/ui/currency'
 import { useAppStatus } from '../hooks/use-app-status'
 import { useUnreadCount } from '../hooks/use-unread-count'
@@ -71,6 +72,7 @@ export function SettingsPage() {
   >('quickstart')
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false)
   const [activeDmChannelId, setActiveDmChannelId] = useState<string | null>(null)
+  const [showOnboarding, setShowOnboarding] = useState(false)
   const { data: wallet } = useQuery({
     queryKey: ['wallet'],
     queryFn: () => fetchApi<{ balance: number }>('/api/wallet'),
@@ -80,6 +82,12 @@ export function SettingsPage() {
     if (user) {
       setDisplayName(user.displayName ?? '')
       setSelectedAvatar(user.avatarUrl ?? null)
+    }
+    
+    // Check if user has seen onboarding
+    const hasSeenOnboarding = localStorage.getItem('hasSeenOnboarding')
+    if (!hasSeenOnboarding) {
+      setShowOnboarding(true)
     }
   }, [user])
 
@@ -1685,5 +1693,31 @@ function DmChannelList({
         )}
       </div>
     </div>
+  )
+}
+
+/* ── Onboarding Integration ───────────────────────────── */
+
+function OnboardingWrapper() {
+  const [showOnboarding, setShowOnboarding] = useState(false)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const hasSeenOnboarding = localStorage.getItem('hasSeenOnboarding')
+    if (!hasSeenOnboarding) {
+      setShowOnboarding(true)
+    }
+  }, [])
+
+  return (
+    <OnboardingModal
+      isOpen={showOnboarding}
+      onClose={() => setShowOnboarding(false)}
+      onCreateServer={() => {
+        setShowOnboarding(false)
+        navigate({ to: '/settings' })
+        // Trigger server creation via UI store
+      }}
+    />
   )
 }


### PR DESCRIPTION
## 变更内容

### 新增功能
1. **新手引导流程 (OnboardingModal)**
   - 4 步引导：欢迎 → Buddy 介绍 → 创建服务器 → 探索发现
   - 支持跳过和分步导航
   - 首次登录自动显示

2. **Buddy 推荐配置 (BuddyPresetSelector)**
   - 5 种预设模板：代码助手、写作助手、设计助手、研究助手、自定义
   - 水平滑动选择，视觉区分
   - 选择后自动填充表单

3. **设置页面集成**
   - 首次访问自动显示引导
   - Buddy 创建对话框集成预设选择

### 解决的问题
- ✅ 新用户不知道核心玩法
- ✅ 缺少功能引导
- ✅ 提供官方推荐配置

### 文件变更
-  - 新增
-  - 新增
-  - 集成引导
-  - 集成预设选择

### 截图
（请在浏览器测试后补充）

### 测试
- [ ] 首次登录显示引导
- [ ] 引导流程完整走通
- [ ] Buddy 预设选择正常
- [ ] 预设自动填充表单