### PR TITLE
feat(mobile): redesign channel creation flow

### DIFF
--- a/apps/mobile/app/(main)/servers/[serverSlug]/create-channel.tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/create-channel.tsx
@@ -1,0 +1,769 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router'
+import {
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Hash,
+  Megaphone,
+  Search,
+  Volume2,
+  X,
+} from 'lucide-react-native'
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Avatar } from '../../../../src/components/common/avatar'
+import { LoadingScreen } from '../../../../src/components/common/loading-screen'
+import { fetchApi } from '../../../../src/lib/api'
+import { showToast } from '../../../../src/lib/toast'
+import { useAuthStore } from '../../../../src/stores/auth.store'
+import { fontSize, radius, spacing, useColors } from '../../../../src/theme'
+
+interface Category {
+  id: string
+  name: string
+  position: number
+}
+
+interface Server {
+  id: string
+  name: string
+  slug: string | null
+  iconUrl: string | null
+  ownerId: string
+}
+
+interface Member {
+  user: {
+    id: string
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+    isBot?: boolean
+  }
+  role: string
+}
+
+interface BuddyAgent {
+  id: string
+  ownerId: string
+  userId: string
+  botUser?: {
+    id: string
+    username: string
+    displayName?: string | null
+    avatarUrl?: string | null
+  } | null
+}
+
+export default function CreateChannelScreen() {
+  const { serverSlug } = useLocalSearchParams<{ serverSlug: string }>()
+  const { t } = useTranslation()
+  const colors = useColors()
+  const router = useRouter()
+  const navigation = useNavigation()
+  const queryClient = useQueryClient()
+  const currentUser = useAuthStore((s) => s.user)
+  const insets = useSafeAreaInsets()
+
+  useEffect(() => {
+    navigation.setOptions({ headerShown: false })
+  }, [navigation])
+
+  const [channelName, setChannelName] = useState('')
+  const [channelType, setChannelType] = useState<'text' | 'voice' | 'announcement'>('text')
+  const [categoryId, setCategoryId] = useState<string | null>(null)
+  const [memberSearch, setMemberSearch] = useState('')
+  const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set())
+  const [selectedAgents, setSelectedAgents] = useState<Set<string>>(new Set())
+  const [activeTab, setActiveTab] = useState<'bots' | 'members' | 'myAgents'>('bots')
+  const [showTypeSelector, setShowTypeSelector] = useState(false)
+
+  const { data: server, isLoading: isServerLoading } = useQuery({
+    queryKey: ['server', serverSlug],
+    queryFn: () => fetchApi<Server>(`/api/servers/${serverSlug}`),
+    enabled: !!serverSlug,
+  })
+
+  const { data: categories = [] } = useQuery({
+    queryKey: ['categories', server?.id],
+    queryFn: () => fetchApi<Category[]>(`/api/servers/${server!.id}/categories`),
+    enabled: !!server?.id,
+  })
+
+  const { data: members = [] } = useQuery({
+    queryKey: ['members', server?.id],
+    queryFn: () => fetchApi<Member[]>(`/api/servers/${server!.id}/members`),
+    enabled: !!server?.id,
+  })
+
+  const { data: myAgents = [] } = useQuery({
+    queryKey: ['my-agents-for-channel-create'],
+    queryFn: () => fetchApi<BuddyAgent[]>('/api/agents'),
+  })
+
+  const selectableMembers = useMemo(() => {
+    const q = memberSearch.toLowerCase()
+    return members
+      .filter((m) => !m.user.isBot)
+      .filter((m) => {
+        if (!q) return true
+        const name = (m.user.displayName || m.user.username).toLowerCase()
+        return name.includes(q) || m.user.username.toLowerCase().includes(q)
+      })
+  }, [members, memberSearch])
+
+  const selectableBots = useMemo(() => {
+    const q = memberSearch.toLowerCase()
+    return members
+      .filter((m) => m.user.isBot)
+      .filter((m) => {
+        if (!q) return true
+        const name = (m.user.displayName || m.user.username).toLowerCase()
+        return name.includes(q)
+      })
+  }, [members, memberSearch])
+
+  const serverBotUserIds = useMemo(
+    () => new Set(members.filter((m) => m.user.isBot).map((m) => m.user.id)),
+    [members],
+  )
+
+  const selectableMyAgents = useMemo(() => {
+    const q = memberSearch.toLowerCase()
+    return myAgents
+      .filter((a) => a.botUser && !serverBotUserIds.has(a.botUser.id))
+      .filter((a) => {
+        if (!q) return true
+        const name = (a.botUser?.displayName || a.botUser?.username || '').toLowerCase()
+        return name.includes(q)
+      })
+  }, [myAgents, serverBotUserIds, memberSearch])
+
+  const toggleMemberSelection = (userId: string) => {
+    setSelectedMembers((prev) => {
+      const next = new Set(prev)
+      if (next.has(userId)) next.delete(userId)
+      else next.add(userId)
+      return next
+    })
+  }
+
+  const toggleAgentSelection = (agentId: string) => {
+    setSelectedAgents((prev) => {
+      const next = new Set(prev)
+      if (next.has(agentId)) next.delete(agentId)
+      else next.add(agentId)
+      return next
+    })
+  }
+
+  const channelTypeLabel = (type: 'text' | 'voice' | 'announcement') => {
+    switch (type) {
+      case 'voice':
+        return t('channel.typeVoice')
+      case 'announcement':
+        return t('channel.typeAnnouncement')
+      default:
+        return t('channel.typeText')
+    }
+  }
+
+  const channelIcon = (type: string, color: string, size = 18) => {
+    switch (type) {
+      case 'voice':
+        return <Volume2 size={size} color={color} strokeWidth={2.5} />
+      case 'announcement':
+        return <Megaphone size={size} color={color} strokeWidth={2.5} />
+      default:
+        return <Hash size={size} color={color} strokeWidth={2.5} />
+    }
+  }
+
+  const createChannelMutation = useMutation({
+    mutationFn: async () => {
+      if (!server?.id) throw new Error('Server not found')
+      const finalName = channelName.trim() || generateChannelName()
+      const channel = await fetchApi<{ id: string }>(`/api/servers/${server.id}/channels`, {
+        method: 'POST',
+        body: JSON.stringify({ name: finalName, type: channelType, categoryId }),
+      })
+      const memberPromises = Array.from(selectedMembers).map((userId) =>
+        fetchApi(`/api/channels/${channel.id}/members`, {
+          method: 'POST',
+          body: JSON.stringify({ userId }),
+        }),
+      )
+      const agentPromises = Array.from(selectedAgents).map(async (agentId) => {
+        const agent = myAgents.find((a) => a.id === agentId)
+        if (!agent) return
+        await fetchApi(`/api/servers/${server.id}/agents`, {
+          method: 'POST',
+          body: JSON.stringify({ agentIds: [agent.id] }),
+        })
+        if (agent.botUser?.id) {
+          await fetchApi(`/api/channels/${channel.id}/members`, {
+            method: 'POST',
+            body: JSON.stringify({ userId: agent.botUser.id }),
+          })
+        }
+      })
+      await Promise.all([...memberPromises, ...agentPromises])
+      return channel
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['channels', server?.id] })
+      router.replace(`/(main)/servers/${serverSlug}/channels/${data.id}` as never)
+    },
+    onError: (err: Error) => showToast(err?.message || t('common.error'), 'error'),
+  })
+
+  const generateChannelName = () => {
+    const names: string[] = []
+    selectedMembers.forEach((userId) => {
+      const member = members.find((m) => m.user.id === userId)
+      if (member) names.push(member.user.displayName || member.user.username)
+    })
+    selectedAgents.forEach((agentId) => {
+      const agent = myAgents.find((a) => a.id === agentId)
+      if (agent?.botUser) names.push(agent.botUser.displayName || agent.botUser.username || 'Buddy')
+    })
+    if (names.length === 0) return t('server.newChannel', '新频道')
+    if (names.length === 1) return names[0]
+    if (names.length === 2) return `${names[0]}、${names[1]}`
+    return `${names[0]}、${names[1]}等`
+  }
+
+  const handleCreate = () => {
+    const finalName = channelName.trim() || generateChannelName()
+    setChannelName(finalName || '')
+    createChannelMutation.mutate()
+  }
+
+  const handleBack = () => {
+    if (channelName.trim() || selectedMembers.size > 0 || selectedAgents.size > 0) {
+      Alert.alert(
+        t('common.discardChanges', '放弃更改'),
+        t('common.discardChangesConfirm', '确定要放弃当前的更改吗？'),
+        [
+          { text: t('common.cancel', '取消'), style: 'cancel' },
+          { text: t('common.discard', '放弃'), style: 'destructive', onPress: () => router.back() },
+        ],
+      )
+    } else {
+      router.back()
+    }
+  }
+
+  if (isServerLoading || !server) return <LoadingScreen />
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      style={[styles.container, { backgroundColor: colors.background }]}
+    >
+      <View
+        style={[
+          styles.header,
+          { backgroundColor: colors.surface, paddingTop: insets.top + spacing.md },
+        ]}
+      >
+        <Pressable onPress={handleBack} hitSlop={8} style={styles.headerBtn}>
+          <ChevronLeft size={26} color={colors.text} />
+        </Pressable>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>
+          {t('server.createChannel')}
+        </Text>
+        <Pressable
+          onPress={handleCreate}
+          disabled={createChannelMutation.isPending}
+          style={[
+            styles.createBtn,
+            {
+              opacity: createChannelMutation.isPending ? 0.5 : 1,
+              backgroundColor: colors.primary,
+              borderRadius: 8,
+              paddingHorizontal: spacing.md,
+              paddingVertical: spacing.sm,
+            },
+          ]}
+        >
+          <Text style={[styles.createBtnText, { color: '#fff' }]}>
+            {createChannelMutation.isPending
+              ? t('common.creating', '创建中...')
+              : selectedMembers.size > 0 || selectedAgents.size > 0
+                ? t('common.createWithCount', '创建({{count}})', {
+                    count: selectedMembers.size + selectedAgents.size,
+                  })
+                : t('common.create')}
+          </Text>
+        </Pressable>
+      </View>
+
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: spacing.xl + insets.bottom }}
+      >
+        {/* Channel Name & Type in one row - no labels */}
+        <View style={styles.section}>
+          <View style={styles.nameTypeRow}>
+            <TextInput
+              style={[
+                styles.input,
+                {
+                  backgroundColor: colors.inputBackground,
+                  color: colors.text,
+                  borderColor: colors.border,
+                  flex: 1,
+                },
+              ]}
+              value={channelName}
+              onChangeText={setChannelName}
+              placeholder={t('server.channelNamePlaceholder')}
+              placeholderTextColor={colors.textMuted}
+              autoFocus
+            />
+            <Pressable style={styles.typeSelector} onPress={() => setShowTypeSelector(true)}>
+              <View style={[styles.typeIconContainer, { backgroundColor: colors.inputBackground }]}>
+                {channelIcon(channelType, colors.primary, 24)}
+              </View>
+              <ChevronRight
+                size={16}
+                color={colors.textMuted}
+                style={{ transform: [{ rotate: '90deg' }] }}
+              />
+            </Pressable>
+          </View>
+        </View>
+
+        {categories.length > 0 && (
+          <View style={styles.section}>
+            <Text style={[styles.label, { color: colors.text }]}>
+              {t('server.channelCategory')}
+            </Text>
+            <View style={styles.categoryRow}>
+              <Pressable
+                style={[
+                  styles.categoryChip,
+                  {
+                    backgroundColor: !categoryId ? '#ff7da520' : colors.inputBackground,
+                    borderColor: !categoryId ? '#ff7da5' : colors.border,
+                  },
+                ]}
+                onPress={() => setCategoryId(null)}
+              >
+                <Text style={{ color: !categoryId ? '#e85b85' : colors.text }}>
+                  {t('server.noCategory')}
+                </Text>
+              </Pressable>
+              {categories.map((cat) => (
+                <Pressable
+                  key={cat.id}
+                  style={[
+                    styles.categoryChip,
+                    {
+                      backgroundColor: categoryId === cat.id ? '#f8e71c20' : colors.inputBackground,
+                      borderColor: categoryId === cat.id ? '#f8e71c' : colors.border,
+                    },
+                  ]}
+                  onPress={() => setCategoryId(cat.id)}
+                >
+                  <Text style={{ color: categoryId === cat.id ? '#b3a100' : colors.text }}>
+                    {cat.name}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          </View>
+        )}
+
+        <View style={styles.section}>
+          <View style={[styles.searchRow, { backgroundColor: colors.inputBackground }]}>
+            <Search size={16} color={colors.textMuted} />
+            <TextInput
+              style={[styles.searchInput, { color: colors.text }]}
+              value={memberSearch}
+              onChangeText={setMemberSearch}
+              placeholder={t('members.searchMembers', '搜索成员')}
+              placeholderTextColor={colors.textMuted}
+            />
+            {memberSearch.length > 0 && (
+              <Pressable onPress={() => setMemberSearch('')} hitSlop={8}>
+                <X size={14} color={colors.textMuted} />
+              </Pressable>
+            )}
+          </View>
+
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.tabRow}
+            contentContainerStyle={{ flexGrow: 1 }}
+          >
+            <Pressable
+              style={[
+                styles.tab,
+                activeTab === 'bots' && { borderBottomColor: colors.primary, borderBottomWidth: 2 },
+              ]}
+              onPress={() => setActiveTab('bots')}
+            >
+              <Text style={{ color: activeTab === 'bots' ? colors.primary : colors.textMuted }}>
+                {t('members.serverBuddies', '服务器 Buddy')}
+              </Text>
+            </Pressable>
+            <Pressable
+              style={[
+                styles.tab,
+                activeTab === 'members' && {
+                  borderBottomColor: colors.primary,
+                  borderBottomWidth: 2,
+                },
+              ]}
+              onPress={() => setActiveTab('members')}
+            >
+              <Text style={{ color: activeTab === 'members' ? colors.primary : colors.textMuted }}>
+                {t('members.serverMembers', '服务器成员')}
+              </Text>
+            </Pressable>
+            <Pressable
+              style={[
+                styles.tab,
+                activeTab === 'myAgents' && {
+                  borderBottomColor: colors.primary,
+                  borderBottomWidth: 2,
+                },
+              ]}
+              onPress={() => setActiveTab('myAgents')}
+            >
+              <Text style={{ color: activeTab === 'myAgents' ? colors.primary : colors.textMuted }}>
+                {t('members.myBuddies', '我的 Buddy')}
+              </Text>
+            </Pressable>
+          </ScrollView>
+
+          {activeTab === 'bots' &&
+            selectableBots.length > 0 &&
+            selectableBots.map((m) => (
+              <Pressable
+                key={m.user.id}
+                style={styles.memberRow}
+                onPress={() => toggleMemberSelection(m.user.id)}
+              >
+                <Avatar
+                  uri={m.user.avatarUrl}
+                  name={m.user.displayName || m.user.username}
+                  size={40}
+                  userId={m.user.id}
+                />
+                <View style={{ flex: 1 }}>
+                  <Text style={[styles.memberName, { color: colors.primary }]} numberOfLines={1}>
+                    {m.user.displayName || m.user.username}
+                  </Text>
+                </View>
+                <View
+                  style={[
+                    styles.checkbox,
+                    {
+                      backgroundColor: selectedMembers.has(m.user.id)
+                        ? colors.primary
+                        : 'transparent',
+                      borderColor: selectedMembers.has(m.user.id) ? colors.primary : colors.border,
+                    },
+                  ]}
+                >
+                  {selectedMembers.has(m.user.id) && <Check size={14} color="#fff" />}
+                </View>
+              </Pressable>
+            ))}
+          {activeTab === 'bots' && selectableBots.length === 0 && (
+            <Text style={[styles.emptyText, { color: colors.textMuted }]}>
+              {t('members.noServerBuddies', '暂无服务器 Buddy')}
+            </Text>
+          )}
+
+          {activeTab === 'members' &&
+            selectableMembers.length > 0 &&
+            selectableMembers.map((m) => (
+              <Pressable
+                key={m.user.id}
+                style={styles.memberRow}
+                onPress={() => toggleMemberSelection(m.user.id)}
+              >
+                <Avatar
+                  uri={m.user.avatarUrl}
+                  name={m.user.displayName || m.user.username}
+                  size={40}
+                  userId={m.user.id}
+                />
+                <Text style={[styles.memberName, { color: colors.text }]} numberOfLines={1}>
+                  {m.user.displayName || m.user.username}
+                </Text>
+                <View
+                  style={[
+                    styles.checkbox,
+                    {
+                      backgroundColor: selectedMembers.has(m.user.id)
+                        ? colors.primary
+                        : 'transparent',
+                      borderColor: selectedMembers.has(m.user.id) ? colors.primary : colors.border,
+                    },
+                  ]}
+                >
+                  {selectedMembers.has(m.user.id) && <Check size={14} color="#fff" />}
+                </View>
+              </Pressable>
+            ))}
+          {activeTab === 'members' && selectableMembers.length === 0 && (
+            <Text style={[styles.emptyText, { color: colors.textMuted }]}>
+              {t('members.noServerMembers', '暂无服务器成员')}
+            </Text>
+          )}
+
+          {activeTab === 'myAgents' &&
+            selectableMyAgents.length > 0 &&
+            selectableMyAgents.map((a) => (
+              <Pressable
+                key={a.id}
+                style={styles.memberRow}
+                onPress={() => toggleAgentSelection(a.id)}
+              >
+                <Avatar
+                  uri={a.botUser?.avatarUrl ?? null}
+                  name={a.botUser?.displayName || a.botUser?.username || '?'}
+                  size={40}
+                  userId={a.botUser?.id}
+                />
+                <View style={{ flex: 1 }}>
+                  <Text style={[styles.memberName, { color: colors.primary }]} numberOfLines={1}>
+                    {a.botUser?.displayName || a.botUser?.username || '?'}
+                  </Text>
+                  <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                    {t('members.notOnServer', '未加入服务器')}
+                  </Text>
+                </View>
+                <View
+                  style={[
+                    styles.checkbox,
+                    {
+                      backgroundColor: selectedAgents.has(a.id) ? colors.primary : 'transparent',
+                      borderColor: selectedAgents.has(a.id) ? colors.primary : colors.border,
+                    },
+                  ]}
+                >
+                  {selectedAgents.has(a.id) && <Check size={14} color="#fff" />}
+                </View>
+              </Pressable>
+            ))}
+          {activeTab === 'myAgents' && selectableMyAgents.length === 0 && (
+            <Text style={[styles.emptyText, { color: colors.textMuted }]}>
+              {t('members.noMyBuddies', '暂无我的 Buddy')}
+            </Text>
+          )}
+        </View>
+      </ScrollView>
+
+      {/* Type Selector Modal */}
+      <Modal
+        visible={showTypeSelector}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowTypeSelector(false)}
+      >
+        <Pressable style={styles.typeModalOverlay} onPress={() => setShowTypeSelector(false)}>
+          <View style={[styles.typeModalContent, { backgroundColor: colors.surface }]}>
+            {(['text', 'voice', 'announcement'] as const).map((type, index) => (
+              <Pressable
+                key={type}
+                style={[
+                  styles.typeModalItem,
+                  index < 2 && { borderBottomWidth: 1, borderBottomColor: colors.border },
+                ]}
+                onPress={() => {
+                  setChannelType(type)
+                  setShowTypeSelector(false)
+                }}
+              >
+                <View style={styles.typeModalItemContent}>
+                  {channelIcon(type, channelType === type ? colors.primary : colors.text, 24)}
+                  <Text
+                    style={[
+                      styles.typeModalItemText,
+                      { color: channelType === type ? colors.primary : colors.text },
+                    ]}
+                  >
+                    {channelTypeLabel(type)}
+                  </Text>
+                  {channelType === type && (
+                    <View style={styles.checkmark}>
+                      <Check size={20} color={colors.primary} />
+                    </View>
+                  )}
+                </View>
+              </Pressable>
+            ))}
+          </View>
+        </Pressable>
+      </Modal>
+    </KeyboardAvoidingView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(0,0,0,0.05)',
+  },
+  headerBtn: { width: 44, height: 44, alignItems: 'center', justifyContent: 'center' },
+  headerTitle: { fontSize: 17, fontWeight: '700' },
+  createBtn: { paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
+  createBtnText: { fontSize: 16, fontWeight: '600' },
+  section: { paddingHorizontal: spacing.lg, paddingTop: spacing.lg },
+  label: {
+    fontSize: 14,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    marginBottom: spacing.sm,
+    letterSpacing: 0.5,
+  },
+  input: {
+    height: 52,
+    borderRadius: 26,
+    paddingHorizontal: spacing.lg,
+    fontSize: 16,
+    fontWeight: '500',
+    borderWidth: 0,
+  },
+  nameTypeRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  nameContainer: { flex: 1 },
+  typeSelector: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    backgroundColor: 'rgba(0,0,0,0.05)',
+  },
+  typeIconContainer: {
+    width: 28,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  typeLabel: { fontSize: 12, fontWeight: '600', marginTop: 4 },
+  typeRow: { flexDirection: 'row', gap: spacing.sm },
+  typeBtn: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    borderRadius: 20,
+    borderWidth: 2,
+    gap: 8,
+  },
+  typeBtnText: { fontSize: 14, fontWeight: '800' },
+  categoryRow: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+  categoryChip: { paddingHorizontal: 16, paddingVertical: 10, borderRadius: 20, borderWidth: 2 },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    height: 48,
+    borderRadius: 24,
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+    backgroundColor: 'rgba(0,0,0,0.05)',
+  },
+  searchInput: { flex: 1, fontSize: fontSize.md, height: 48 },
+  tabRow: {
+    flexDirection: 'row',
+    borderBottomWidth: 0,
+    marginBottom: spacing.md,
+  },
+  tab: { flex: 1, paddingVertical: spacing.md, alignItems: 'center' },
+  emptyText: { fontSize: fontSize.sm, textAlign: 'center', paddingVertical: spacing.lg },
+  memberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: 16,
+    marginBottom: spacing.xs,
+  },
+  memberName: { flex: 1, fontSize: fontSize.md, fontWeight: '500' },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  floatingBadge: {
+    position: 'absolute',
+    bottom: 100,
+    right: spacing.lg,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 20,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  floatingBadgeText: { color: '#fff', fontSize: fontSize.sm, fontWeight: '700' },
+  typeModalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  typeModalContent: {
+    borderRadius: 16,
+    overflow: 'hidden',
+    width: '80%',
+    maxWidth: 300,
+  },
+  typeModalItem: {
+    paddingVertical: spacing.lg,
+    paddingHorizontal: spacing.xl,
+  },
+  typeModalItemContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  typeModalItemText: {
+    fontSize: 16,
+    fontWeight: '600',
+    flex: 1,
+  },
+  checkmark: {
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+})

--- a/apps/mobile/app/(main)/servers/[serverSlug]/index.tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/index.tsx
@@ -31,6 +31,7 @@ import { useTranslation } from 'react-i18next'
 import {
   Alert,
   Animated,
+  Dimensions,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -43,8 +44,9 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native'
-import Reanimated, { FadeIn, FadeInDown, Layout, ZoomIn } from 'react-native-reanimated'
+import Reanimated, { FadeInDown } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Avatar } from '../../../../src/components/common/avatar'
 import {
   AgentCatSvg,
   ChannelCatSvg,
@@ -58,7 +60,7 @@ import { fetchApi, getImageUrl } from '../../../../src/lib/api'
 import { setLastChannel } from '../../../../src/lib/last-channel'
 import { showToast } from '../../../../src/lib/toast'
 import { useAuthStore } from '../../../../src/stores/auth.store'
-import { spacing, useColors } from '../../../../src/theme'
+import { fontSize, radius, spacing, useColors } from '../../../../src/theme'
 import type { Channel, ChannelSortBy } from '@shadow/shared'
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -91,8 +93,21 @@ interface Member {
     username: string
     displayName: string | null
     avatarUrl: string | null
+    isBot?: boolean
   }
   role: string
+}
+
+interface BuddyAgent {
+  id: string
+  ownerId: string
+  userId: string
+  botUser?: {
+    id: string
+    username: string
+    displayName?: string | null
+    avatarUrl?: string | null
+  } | null
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -137,6 +152,11 @@ export default function ServerHomeScreen() {
   const [editChannelName, setEditChannelName] = useState('')
   const [showSortModal, setShowSortModal] = useState(false)
 
+  // Create channel member selection state
+  const [memberSearch, setMemberSearch] = useState('')
+  const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set())
+  const [selectedAgents, setSelectedAgents] = useState<Set<string>>(new Set())
+
   // ── Queries ─────────────────────────────────────
 
   const { data: server, isLoading: isServerLoading } = useQuery({
@@ -180,6 +200,13 @@ export default function ServerHomeScreen() {
   })
 
   const members = memberData ?? []
+
+  // User's buddy agents for invite
+  const { data: myAgents = [] } = useQuery({
+    queryKey: ['my-agents-for-channel-create'],
+    queryFn: () => fetchApi<BuddyAgent[]>('/api/agents'),
+    enabled: showCreateChannel,
+  })
   const onlineCount = members.filter(
     (m) => m.user && ((m as { user: { status?: string } }).user.status ?? 'offline') !== 'offline',
   ).length
@@ -195,24 +222,130 @@ export default function ServerHomeScreen() {
 
   // ── Create Channel ─────────────────────────────
 
+  // Filter members for selection (exclude bots)
+  const selectableMembers = useMemo(() => {
+    const q = memberSearch.toLowerCase()
+    return members
+      .filter((m) => !m.user.isBot)
+      .filter((m) => {
+        if (!q) return true
+        const name = (m.user.displayName || m.user.username).toLowerCase()
+        return name.includes(q) || m.user.username.toLowerCase().includes(q)
+      })
+  }, [members, memberSearch])
+
+  // Filter server bots for selection
+  const selectableBots = useMemo(() => {
+    const q = memberSearch.toLowerCase()
+    return members
+      .filter((m) => m.user.isBot)
+      .filter((m) => {
+        if (!q) return true
+        const name = (m.user.displayName || m.user.username).toLowerCase()
+        return name.includes(q)
+      })
+  }, [members, memberSearch])
+
+  // Filter user's agents not on server
+  const serverBotUserIds = useMemo(
+    () => new Set(members.filter((m) => m.user.isBot).map((m) => m.user.id)),
+    [members],
+  )
+
+  const selectableMyAgents = useMemo(() => {
+    const q = memberSearch.toLowerCase()
+    return myAgents
+      .filter((a) => a.botUser && !serverBotUserIds.has(a.botUser.id))
+      .filter((a) => {
+        if (!q) return true
+        const name = (a.botUser?.displayName || a.botUser?.username || '').toLowerCase()
+        return name.includes(q)
+      })
+  }, [myAgents, serverBotUserIds, memberSearch])
+
+  const toggleMemberSelection = (userId: string) => {
+    setSelectedMembers((prev) => {
+      const next = new Set(prev)
+      if (next.has(userId)) next.delete(userId)
+      else next.add(userId)
+      return next
+    })
+  }
+
+  const toggleAgentSelection = (agentId: string) => {
+    setSelectedAgents((prev) => {
+      const next = new Set(prev)
+      if (next.has(agentId)) next.delete(agentId)
+      else next.add(agentId)
+      return next
+    })
+  }
+
+  const resetCreateChannelState = () => {
+    setShowCreateChannel(false)
+    setNewChannelName('')
+    setNewChannelType('text')
+    setNewChannelCategoryId(null)
+    setMemberSearch('')
+    setSelectedMembers(new Set())
+    setSelectedAgents(new Set())
+  }
+
   const createChannelMutation = useMutation({
-    mutationFn: () =>
-      fetchApi<{ id: string }>(`/api/servers/${server!.id}/channels`, {
+    mutationFn: async () => {
+      // 1. Create channel
+      const channel = await fetchApi<{ id: string }>(`/api/servers/${server!.id}/channels`, {
         method: 'POST',
         body: JSON.stringify({
           name: newChannelName,
           type: newChannelType,
           categoryId: newChannelCategoryId,
         }),
-      }),
+      })
+
+      // 2. Add selected members to channel
+      const memberPromises = Array.from(selectedMembers).map((userId) =>
+        fetchApi(`/api/channels/${channel.id}/members`, {
+          method: 'POST',
+          body: JSON.stringify({ userId }),
+        }),
+      )
+
+      // 3. Add selected server bots to channel
+      const botPromises = selectableBots
+        .filter((b) => selectedMembers.has(b.user.id))
+        .map((b) =>
+          fetchApi(`/api/channels/${channel.id}/members`, {
+            method: 'POST',
+            body: JSON.stringify({ userId: b.user.id }),
+          }),
+        )
+
+      // 4. Add selected my agents to server then channel
+      const agentPromises = Array.from(selectedAgents).map(async (agentId) => {
+        const agent = myAgents.find((a) => a.id === agentId)
+        if (!agent) return
+        await fetchApi(`/api/servers/${server!.id}/agents`, {
+          method: 'POST',
+          body: JSON.stringify({ agentIds: [agent.id] }),
+        })
+        if (agent.botUser?.id) {
+          await fetchApi(`/api/channels/${channel.id}/members`, {
+            method: 'POST',
+            body: JSON.stringify({ userId: agent.botUser.id }),
+          })
+        }
+      })
+
+      await Promise.all([...memberPromises, ...botPromises, ...agentPromises])
+
+      return channel
+    },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['channels', server?.id] })
-      setShowCreateChannel(false)
-      setNewChannelName('')
-      // Navigate to channel members screen with auto-invite
-      router.push(
-        `/(main)/servers/${serverSlug}/channel-members?channelId=${data.id}&autoInvite=1` as never,
-      )
+      resetCreateChannelState()
+      // Navigate directly to the new channel
+      router.push(`/(main)/servers/${serverSlug}/channels/${data.id}` as never)
     },
     onError: (err: any) => showToast(err?.message || t('common.error'), 'error'),
   })
@@ -220,8 +353,7 @@ export default function ServerHomeScreen() {
   // ── Channel actions ────────────────────────────
 
   const deleteChannelMutation = useMutation({
-    mutationFn: (channelId: string) =>
-      fetchApi(`/api/channels/${channelId}`, { method: 'DELETE' }),
+    mutationFn: (channelId: string) => fetchApi(`/api/channels/${channelId}`, { method: 'DELETE' }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['channels', server?.id] })
     },
@@ -632,123 +764,316 @@ export default function ServerHomeScreen() {
               <Text style={[styles.modalTitle, { color: colors.text }]}>
                 {t('server.createChannel')}
               </Text>
-              <Pressable onPress={() => setShowCreateChannel(false)} hitSlop={8}>
+              <Pressable onPress={resetCreateChannelState} hitSlop={8}>
                 <X size={24} color={colors.textMuted} strokeWidth={2.5} />
               </Pressable>
             </View>
 
-            <Text style={[styles.cuteLabel, { color: colors.text }]}>
-              {t('server.channelName')}
-            </Text>
-            <TextInput
-              style={[
-                styles.cuteInput,
-                {
-                  backgroundColor: colors.inputBackground,
-                  color: colors.text,
-                  borderColor: colors.border,
-                },
-              ]}
-              value={newChannelName}
-              onChangeText={setNewChannelName}
-              placeholder={t('server.channelNamePlaceholder')}
-              placeholderTextColor={colors.textMuted}
-              autoFocus
-            />
+            <ScrollView
+              showsVerticalScrollIndicator={false}
+              style={{ height: Dimensions.get('window').height * 0.6 }}
+              contentContainerStyle={{ paddingBottom: spacing.lg }}
+            >
+              <Text style={[styles.cuteLabel, { color: colors.text }]}>
+                {t('server.channelName')}
+              </Text>
+              <TextInput
+                style={[
+                  styles.cuteInput,
+                  {
+                    backgroundColor: colors.inputBackground,
+                    color: colors.text,
+                    borderColor: colors.border,
+                  },
+                ]}
+                value={newChannelName}
+                onChangeText={setNewChannelName}
+                placeholder={t('server.channelNamePlaceholder')}
+                placeholderTextColor={colors.textMuted}
+                autoFocus
+              />
 
-            <Text style={[styles.cuteLabel, { color: colors.text, marginTop: spacing.lg }]}>
-              {t('server.channelType')}
-            </Text>
-            <View style={styles.typeRow}>
-              {(['text', 'voice', 'announcement'] as const).map((type) => (
-                <Pressable
-                  key={type}
-                  style={[
-                    styles.cuteTypeBtn,
-                    {
-                      backgroundColor:
-                        newChannelType === type ? '#00f3ff20' : colors.inputBackground,
-                      borderColor: newChannelType === type ? '#00f3ff' : colors.border,
-                    },
-                  ]}
-                  onPress={() => setNewChannelType(type)}
-                >
-                  {channelIcon(type, newChannelType === type ? '#00c3cc' : colors.textMuted, 24)}
-                  <Text
-                    style={[
-                      styles.typeBtnText,
-                      { color: newChannelType === type ? '#00c3cc' : colors.text },
-                    ]}
-                  >
-                    {channelTypeLabel(type)}
-                  </Text>
-                </Pressable>
-              ))}
-            </View>
-
-            {categories.length > 0 && (
-              <>
-                <Text style={[styles.cuteLabel, { color: colors.text, marginTop: spacing.lg }]}>
-                  {t('server.channelCategory')}
-                </Text>
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  style={{ flexGrow: 0 }}
-                  contentContainerStyle={{ gap: spacing.sm }}
-                >
+              <Text style={[styles.cuteLabel, { color: colors.text, marginTop: spacing.lg }]}>
+                {t('server.channelType')}
+              </Text>
+              <View style={styles.typeRow}>
+                {(['text', 'voice', 'announcement'] as const).map((type) => (
                   <Pressable
+                    key={type}
                     style={[
-                      styles.cuteCatChip,
+                      styles.cuteTypeBtn,
                       {
-                        backgroundColor: !newChannelCategoryId
-                          ? '#ff7da520'
-                          : colors.inputBackground,
-                        borderColor: !newChannelCategoryId ? '#ff7da5' : colors.border,
+                        backgroundColor:
+                          newChannelType === type ? '#00f3ff20' : colors.inputBackground,
+                        borderColor: newChannelType === type ? '#00f3ff' : colors.border,
                       },
                     ]}
-                    onPress={() => setNewChannelCategoryId(null)}
+                    onPress={() => setNewChannelType(type)}
                   >
+                    {channelIcon(type, newChannelType === type ? '#00c3cc' : colors.textMuted, 24)}
                     <Text
                       style={[
-                        styles.catChipText,
-                        { color: !newChannelCategoryId ? '#e85b85' : colors.text },
+                        styles.typeBtnText,
+                        { color: newChannelType === type ? '#00c3cc' : colors.text },
                       ]}
                     >
-                      {t('server.noCategory')}
+                      {channelTypeLabel(type)}
                     </Text>
                   </Pressable>
-                  {categories.map((cat) => (
+                ))}
+              </View>
+
+              {categories.length > 0 && (
+                <>
+                  <Text style={[styles.cuteLabel, { color: colors.text, marginTop: spacing.lg }]}>
+                    {t('server.channelCategory')}
+                  </Text>
+                  <ScrollView
+                    horizontal
+                    showsHorizontalScrollIndicator={false}
+                    style={{ flexGrow: 0 }}
+                    contentContainerStyle={{ gap: spacing.sm }}
+                  >
                     <Pressable
-                      key={cat.id}
                       style={[
                         styles.cuteCatChip,
                         {
-                          backgroundColor:
-                            newChannelCategoryId === cat.id ? '#f8e71c20' : colors.inputBackground,
-                          borderColor: newChannelCategoryId === cat.id ? '#f8e71c' : colors.border,
+                          backgroundColor: !newChannelCategoryId
+                            ? '#ff7da520'
+                            : colors.inputBackground,
+                          borderColor: !newChannelCategoryId ? '#ff7da5' : colors.border,
                         },
                       ]}
-                      onPress={() => setNewChannelCategoryId(cat.id)}
+                      onPress={() => setNewChannelCategoryId(null)}
                     >
                       <Text
                         style={[
                           styles.catChipText,
-                          { color: newChannelCategoryId === cat.id ? '#b3a100' : colors.text },
+                          { color: !newChannelCategoryId ? '#e85b85' : colors.text },
                         ]}
                       >
-                        {cat.name}
+                        {t('server.noCategory')}
                       </Text>
                     </Pressable>
+                    {categories.map((cat) => (
+                      <Pressable
+                        key={cat.id}
+                        style={[
+                          styles.cuteCatChip,
+                          {
+                            backgroundColor:
+                              newChannelCategoryId === cat.id
+                                ? '#f8e71c20'
+                                : colors.inputBackground,
+                            borderColor:
+                              newChannelCategoryId === cat.id ? '#f8e71c' : colors.border,
+                          },
+                        ]}
+                        onPress={() => setNewChannelCategoryId(cat.id)}
+                      >
+                        <Text
+                          style={[
+                            styles.catChipText,
+                            { color: newChannelCategoryId === cat.id ? '#b3a100' : colors.text },
+                          ]}
+                        >
+                          {cat.name}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </ScrollView>
+                </>
+              )}
+
+              {/* Member Selection Section */}
+              <Text style={[styles.cuteLabel, { color: colors.text, marginTop: spacing.lg }]}>
+                {t('server.addMembers', '添加成员（可选）')}
+              </Text>
+
+              {/* Search */}
+              <View style={[styles.memberSearchRow, { backgroundColor: colors.inputBackground }]}>
+                <Search size={16} color={colors.textMuted} />
+                <TextInput
+                  style={[styles.memberSearchInput, { color: colors.text }]}
+                  value={memberSearch}
+                  onChangeText={setMemberSearch}
+                  placeholder={t('common.search', '搜索...')}
+                  placeholderTextColor={colors.textMuted}
+                />
+                {memberSearch.length > 0 && (
+                  <Pressable onPress={() => setMemberSearch('')} hitSlop={8}>
+                    <X size={14} color={colors.textMuted} />
+                  </Pressable>
+                )}
+              </View>
+
+              {/* Selected count */}
+              {(selectedMembers.size > 0 || selectedAgents.size > 0) && (
+                <Text style={[styles.selectedCount, { color: colors.textMuted }]}>
+                  {t('server.selectedCount', '已选择 {{count}} 人', {
+                    count: selectedMembers.size + selectedAgents.size,
+                  })}
+                </Text>
+              )}
+
+              {/* Server Members */}
+              {selectableMembers.length > 0 && (
+                <>
+                  <Text style={[styles.memberSectionTitle, { color: colors.textMuted }]}>
+                    {t('members.serverMembers', '服务器成员')}
+                  </Text>
+                  {selectableMembers.map((m) => (
+                    <Pressable
+                      key={m.user.id}
+                      style={styles.selectableMemberRow}
+                      onPress={() => toggleMemberSelection(m.user.id)}
+                    >
+                      <Avatar
+                        uri={m.user.avatarUrl}
+                        name={m.user.displayName || m.user.username}
+                        size={36}
+                        userId={m.user.id}
+                      />
+                      <Text
+                        style={[styles.selectableMemberName, { color: colors.text }]}
+                        numberOfLines={1}
+                      >
+                        {m.user.displayName || m.user.username}
+                      </Text>
+                      <View
+                        style={[
+                          styles.checkbox,
+                          {
+                            backgroundColor: selectedMembers.has(m.user.id)
+                              ? colors.primary
+                              : 'transparent',
+                            borderColor: selectedMembers.has(m.user.id)
+                              ? colors.primary
+                              : colors.border,
+                          },
+                        ]}
+                      >
+                        {selectedMembers.has(m.user.id) && <Check size={14} color="#fff" />}
+                      </View>
+                    </Pressable>
                   ))}
-                </ScrollView>
-              </>
-            )}
+                </>
+              )}
+
+              {/* Server Bots */}
+              {selectableBots.length > 0 && (
+                <>
+                  <Text style={[styles.memberSectionTitle, { color: colors.textMuted }]}>
+                    {t('members.serverBuddies', '服务器 Buddy')}
+                  </Text>
+                  {selectableBots.map((m) => (
+                    <Pressable
+                      key={m.user.id}
+                      style={styles.selectableMemberRow}
+                      onPress={() => toggleMemberSelection(m.user.id)}
+                    >
+                      <Avatar
+                        uri={m.user.avatarUrl}
+                        name={m.user.displayName || m.user.username}
+                        size={36}
+                        userId={m.user.id}
+                      />
+                      <View style={{ flex: 1 }}>
+                        <Text
+                          style={[styles.selectableMemberName, { color: colors.primary }]}
+                          numberOfLines={1}
+                        >
+                          {m.user.displayName || m.user.username}
+                        </Text>
+                      </View>
+                      <View
+                        style={[
+                          styles.checkbox,
+                          {
+                            backgroundColor: selectedMembers.has(m.user.id)
+                              ? colors.primary
+                              : 'transparent',
+                            borderColor: selectedMembers.has(m.user.id)
+                              ? colors.primary
+                              : colors.border,
+                          },
+                        ]}
+                      >
+                        {selectedMembers.has(m.user.id) && <Check size={14} color="#fff" />}
+                      </View>
+                    </Pressable>
+                  ))}
+                </>
+              )}
+
+              {/* My Agents */}
+              {selectableMyAgents.length > 0 && (
+                <>
+                  <Text style={[styles.memberSectionTitle, { color: colors.textMuted }]}>
+                    {t('members.myBuddies', '我的 Buddy')}
+                  </Text>
+                  {selectableMyAgents.map((a) => (
+                    <Pressable
+                      key={a.id}
+                      style={styles.selectableMemberRow}
+                      onPress={() => toggleAgentSelection(a.id)}
+                    >
+                      <Avatar
+                        uri={a.botUser?.avatarUrl ?? null}
+                        name={a.botUser?.displayName || a.botUser?.username || '?'}
+                        size={36}
+                        userId={a.botUser?.id}
+                      />
+                      <View style={{ flex: 1 }}>
+                        <Text
+                          style={[styles.selectableMemberName, { color: colors.primary }]}
+                          numberOfLines={1}
+                        >
+                          {a.botUser?.displayName || a.botUser?.username || '?'}
+                        </Text>
+                        <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                          {t('members.notOnServer', '未加入服务器')}
+                        </Text>
+                      </View>
+                      <View
+                        style={[
+                          styles.checkbox,
+                          {
+                            backgroundColor: selectedAgents.has(a.id)
+                              ? colors.primary
+                              : 'transparent',
+                            borderColor: selectedAgents.has(a.id) ? colors.primary : colors.border,
+                          },
+                        ]}
+                      >
+                        {selectedAgents.has(a.id) && <Check size={14} color="#fff" />}
+                      </View>
+                    </Pressable>
+                  ))}
+                </>
+              )}
+
+              {/* Empty state */}
+              {selectableMembers.length === 0 &&
+                selectableBots.length === 0 &&
+                selectableMyAgents.length === 0 && (
+                  <Text
+                    style={{
+                      color: colors.textMuted,
+                      fontSize: fontSize.sm,
+                      textAlign: 'center',
+                      paddingTop: spacing.lg,
+                    }}
+                  >
+                    {t('members.noInvitable', '没有可邀请的成员')}
+                  </Text>
+                )}
+            </ScrollView>
 
             <SquishyCard
               onPress={() => createChannelMutation.mutate()}
               disabled={!newChannelName.trim() || createChannelMutation.isPending}
-              style={{ marginTop: spacing.xl }}
+              style={{ marginTop: spacing.md }}
             >
               <LinearGradient
                 colors={['#00f3ff', '#00a2ff']}
@@ -757,7 +1082,11 @@ export default function ServerHomeScreen() {
                   { opacity: !newChannelName.trim() || createChannelMutation.isPending ? 0.5 : 1 },
                 ]}
               >
-                <Text style={styles.cuteModalBtnText}>{t('common.create')}</Text>
+                <Text style={styles.cuteModalBtnText}>
+                  {createChannelMutation.isPending
+                    ? t('common.creating', '创建中...')
+                    : t('common.create')}
+                </Text>
               </LinearGradient>
             </SquishyCard>
           </View>
@@ -765,7 +1094,12 @@ export default function ServerHomeScreen() {
       </Modal>
 
       {/* Channel context menu */}
-      <Modal visible={!!contextChannel} transparent animationType="fade" onRequestClose={() => setContextChannel(null)}>
+      <Modal
+        visible={!!contextChannel}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setContextChannel(null)}
+      >
         <Pressable style={styles.ctxOverlay} onPress={() => setContextChannel(null)}>
           <Reanimated.View
             entering={FadeInDown.duration(200)}
@@ -785,7 +1119,9 @@ export default function ServerHomeScreen() {
               }}
             >
               <UserPlus size={18} color={colors.textSecondary} />
-              <Text style={[styles.ctxLabel, { color: colors.text }]}>{t('channel.inviteMember', '邀请成员')}</Text>
+              <Text style={[styles.ctxLabel, { color: colors.text }]}>
+                {t('channel.inviteMember', '邀请成员')}
+              </Text>
             </Pressable>
 
             <View style={[styles.ctxDivider, { backgroundColor: colors.border }]} />
@@ -802,7 +1138,9 @@ export default function ServerHomeScreen() {
               }}
             >
               <Edit3 size={18} color={colors.textSecondary} />
-              <Text style={[styles.ctxLabel, { color: colors.text }]}>{t('channel.editChannel', '编辑频道')}</Text>
+              <Text style={[styles.ctxLabel, { color: colors.text }]}>
+                {t('channel.editChannel', '编辑频道')}
+              </Text>
             </Pressable>
 
             {/* Toggle private */}
@@ -825,7 +1163,9 @@ export default function ServerHomeScreen() {
                 <Lock size={18} color={colors.textSecondary} />
               )}
               <Text style={[styles.ctxLabel, { color: colors.text }]}>
-                {contextChannel?.isPrivate ? t('channel.setPublic', '设为公开') : t('channel.setPrivate', '设为私有')}
+                {contextChannel?.isPrivate
+                  ? t('channel.setPublic', '设为公开')
+                  : t('channel.setPrivate', '设为私有')}
               </Text>
             </Pressable>
 
@@ -841,7 +1181,9 @@ export default function ServerHomeScreen() {
               }}
             >
               <Copy size={18} color={colors.textSecondary} />
-              <Text style={[styles.ctxLabel, { color: colors.text }]}>{t('channel.copyChannelLink', '复制频道链接')}</Text>
+              <Text style={[styles.ctxLabel, { color: colors.text }]}>
+                {t('channel.copyChannelLink', '复制频道链接')}
+              </Text>
             </Pressable>
 
             <View style={[styles.ctxDivider, { backgroundColor: colors.border }]} />
@@ -869,14 +1211,21 @@ export default function ServerHomeScreen() {
               }}
             >
               <Trash2 size={18} color="#ef4444" />
-              <Text style={[styles.ctxLabel, { color: '#ef4444' }]}>{t('channel.deleteChannel', '删除频道')}</Text>
+              <Text style={[styles.ctxLabel, { color: '#ef4444' }]}>
+                {t('channel.deleteChannel', '删除频道')}
+              </Text>
             </Pressable>
           </Reanimated.View>
         </Pressable>
       </Modal>
 
       {/* Edit channel name modal */}
-      <Modal visible={!!editingChannel} transparent animationType="fade" onRequestClose={() => setEditingChannel(null)}>
+      <Modal
+        visible={!!editingChannel}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setEditingChannel(null)}
+      >
         <Pressable
           style={[styles.ctxOverlay, { justifyContent: 'center' }]}
           onPress={() => setEditingChannel(null)}
@@ -889,7 +1238,14 @@ export default function ServerHomeScreen() {
               {t('channel.editChannel', '编辑频道')}
             </Text>
             <TextInput
-              style={[styles.editInput, { backgroundColor: colors.inputBackground, color: colors.text, borderColor: colors.border }]}
+              style={[
+                styles.editInput,
+                {
+                  backgroundColor: colors.inputBackground,
+                  color: colors.text,
+                  borderColor: colors.border,
+                },
+              ]}
               value={editChannelName}
               onChangeText={setEditChannelName}
               placeholder={t('channel.channelName', '频道名称')}
@@ -1230,6 +1586,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 0,
     padding: spacing.xl,
     paddingBottom: 40,
+    maxHeight: Dimensions.get('window').height * 0.85,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: -8 },
     shadowOpacity: 0.15,
@@ -1285,6 +1642,53 @@ const styles = StyleSheet.create({
     color: '#1a1a1c',
     fontSize: 18,
     fontWeight: '900',
+  },
+
+  // Member selection styles
+  memberSearchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    height: 44,
+    borderRadius: radius.lg,
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+  },
+  memberSearchInput: {
+    flex: 1,
+    fontSize: fontSize.md,
+    height: 44,
+  },
+  selectedCount: {
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    marginBottom: spacing.sm,
+  },
+  memberSectionTitle: {
+    fontSize: fontSize.xs,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+  },
+  selectableMemberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  selectableMemberName: {
+    flex: 1,
+    fontSize: fontSize.md,
+    fontWeight: '500',
+  },
+  checkbox: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 
   // Context menu

--- a/apps/mobile/app/(main)/servers/[serverSlug]/index.tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/index.tsx
@@ -6,7 +6,6 @@ import {
   ArrowDown,
   ArrowUp,
   Calendar,
-  Check,
   ChevronDown,
   ChevronLeft,
   Clock,
@@ -31,8 +30,6 @@ import { useTranslation } from 'react-i18next'
 import {
   Alert,
   Animated,
-  Dimensions,
-  KeyboardAvoidingView,
   Modal,
   Platform,
   Pressable,
@@ -46,7 +43,7 @@ import {
 } from 'react-native'
 import Reanimated, { FadeInDown } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { Avatar } from '../../../../src/components/common/avatar'
+
 import {
   AgentCatSvg,
   ChannelCatSvg,
@@ -141,21 +138,12 @@ export default function ServerHomeScreen() {
 
   // State
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
-  const [showCreateChannel, setShowCreateChannel] = useState(false)
-  const [newChannelName, setNewChannelName] = useState('')
-  const [newChannelType, setNewChannelType] = useState<'text' | 'voice' | 'announcement'>('text')
-  const [newChannelCategoryId, setNewChannelCategoryId] = useState<string | null>(null)
   const [showSearch, setShowSearch] = useState(false)
   const [channelSearch, setChannelSearch] = useState('')
   const [contextChannel, setContextChannel] = useState<ServerChannel | null>(null)
   const [editingChannel, setEditingChannel] = useState<ServerChannel | null>(null)
   const [editChannelName, setEditChannelName] = useState('')
   const [showSortModal, setShowSortModal] = useState(false)
-
-  // Create channel member selection state
-  const [memberSearch, setMemberSearch] = useState('')
-  const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set())
-  const [selectedAgents, setSelectedAgents] = useState<Set<string>>(new Set())
 
   // ── Queries ─────────────────────────────────────
 
@@ -201,12 +189,6 @@ export default function ServerHomeScreen() {
 
   const members = memberData ?? []
 
-  // User's buddy agents for invite
-  const { data: myAgents = [] } = useQuery({
-    queryKey: ['my-agents-for-channel-create'],
-    queryFn: () => fetchApi<BuddyAgent[]>('/api/agents'),
-    enabled: showCreateChannel,
-  })
   const onlineCount = members.filter(
     (m) => m.user && ((m as { user: { status?: string } }).user.status ?? 'offline') !== 'offline',
   ).length
@@ -219,136 +201,6 @@ export default function ServerHomeScreen() {
       headerShown: false,
     })
   }, [navigation])
-
-  // ── Create Channel ─────────────────────────────
-
-  // Filter members for selection (exclude bots)
-  const selectableMembers = useMemo(() => {
-    const q = memberSearch.toLowerCase()
-    return members
-      .filter((m) => !m.user.isBot)
-      .filter((m) => {
-        if (!q) return true
-        const name = (m.user.displayName || m.user.username).toLowerCase()
-        return name.includes(q) || m.user.username.toLowerCase().includes(q)
-      })
-  }, [members, memberSearch])
-
-  // Filter server bots for selection
-  const selectableBots = useMemo(() => {
-    const q = memberSearch.toLowerCase()
-    return members
-      .filter((m) => m.user.isBot)
-      .filter((m) => {
-        if (!q) return true
-        const name = (m.user.displayName || m.user.username).toLowerCase()
-        return name.includes(q)
-      })
-  }, [members, memberSearch])
-
-  // Filter user's agents not on server
-  const serverBotUserIds = useMemo(
-    () => new Set(members.filter((m) => m.user.isBot).map((m) => m.user.id)),
-    [members],
-  )
-
-  const selectableMyAgents = useMemo(() => {
-    const q = memberSearch.toLowerCase()
-    return myAgents
-      .filter((a) => a.botUser && !serverBotUserIds.has(a.botUser.id))
-      .filter((a) => {
-        if (!q) return true
-        const name = (a.botUser?.displayName || a.botUser?.username || '').toLowerCase()
-        return name.includes(q)
-      })
-  }, [myAgents, serverBotUserIds, memberSearch])
-
-  const toggleMemberSelection = (userId: string) => {
-    setSelectedMembers((prev) => {
-      const next = new Set(prev)
-      if (next.has(userId)) next.delete(userId)
-      else next.add(userId)
-      return next
-    })
-  }
-
-  const toggleAgentSelection = (agentId: string) => {
-    setSelectedAgents((prev) => {
-      const next = new Set(prev)
-      if (next.has(agentId)) next.delete(agentId)
-      else next.add(agentId)
-      return next
-    })
-  }
-
-  const resetCreateChannelState = () => {
-    setShowCreateChannel(false)
-    setNewChannelName('')
-    setNewChannelType('text')
-    setNewChannelCategoryId(null)
-    setMemberSearch('')
-    setSelectedMembers(new Set())
-    setSelectedAgents(new Set())
-  }
-
-  const createChannelMutation = useMutation({
-    mutationFn: async () => {
-      // 1. Create channel
-      const channel = await fetchApi<{ id: string }>(`/api/servers/${server!.id}/channels`, {
-        method: 'POST',
-        body: JSON.stringify({
-          name: newChannelName,
-          type: newChannelType,
-          categoryId: newChannelCategoryId,
-        }),
-      })
-
-      // 2. Add selected members to channel
-      const memberPromises = Array.from(selectedMembers).map((userId) =>
-        fetchApi(`/api/channels/${channel.id}/members`, {
-          method: 'POST',
-          body: JSON.stringify({ userId }),
-        }),
-      )
-
-      // 3. Add selected server bots to channel
-      const botPromises = selectableBots
-        .filter((b) => selectedMembers.has(b.user.id))
-        .map((b) =>
-          fetchApi(`/api/channels/${channel.id}/members`, {
-            method: 'POST',
-            body: JSON.stringify({ userId: b.user.id }),
-          }),
-        )
-
-      // 4. Add selected my agents to server then channel
-      const agentPromises = Array.from(selectedAgents).map(async (agentId) => {
-        const agent = myAgents.find((a) => a.id === agentId)
-        if (!agent) return
-        await fetchApi(`/api/servers/${server!.id}/agents`, {
-          method: 'POST',
-          body: JSON.stringify({ agentIds: [agent.id] }),
-        })
-        if (agent.botUser?.id) {
-          await fetchApi(`/api/channels/${channel.id}/members`, {
-            method: 'POST',
-            body: JSON.stringify({ userId: agent.botUser.id }),
-          })
-        }
-      })
-
-      await Promise.all([...memberPromises, ...botPromises, ...agentPromises])
-
-      return channel
-    },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['channels', server?.id] })
-      resetCreateChannelState()
-      // Navigate directly to the new channel
-      router.push(`/(main)/servers/${serverSlug}/channels/${data.id}` as never)
-    },
-    onError: (err: any) => showToast(err?.message || t('common.error'), 'error'),
-  })
 
   // ── Channel actions ────────────────────────────
 
@@ -622,7 +474,9 @@ export default function ServerHomeScreen() {
               </View>
             </SquishyCard>
             {isOwner && (
-              <SquishyCard onPress={() => setShowCreateChannel(true)}>
+              <SquishyCard
+                onPress={() => router.push(`/(main)/servers/${serverSlug}/create-channel` as never)}
+              >
                 <View
                   style={[
                     styles.actionBubble,
@@ -736,7 +590,11 @@ export default function ServerHomeScreen() {
                 {t('server.noChannels')}
               </Text>
               {isOwner && (
-                <SquishyCard onPress={() => setShowCreateChannel(true)}>
+                <SquishyCard
+                  onPress={() =>
+                    router.push(`/(main)/servers/${serverSlug}/create-channel` as never)
+                  }
+                >
                   <LinearGradient colors={['#00f3ff', '#00a2ff']} style={styles.cuteCreateBtn}>
                     <Plus size={18} color="#1a1a1c" strokeWidth={3} />
                     <Text style={styles.cuteCreateBtnText}>{t('server.createChannel')}</Text>
@@ -747,351 +605,6 @@ export default function ServerHomeScreen() {
           )}
         </View>
       </ScrollView>
-
-      {/* ── Create Channel Modal ──────────────────── */}
-      <Modal visible={showCreateChannel} transparent animationType="fade">
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          style={styles.modalOverlay}
-        >
-          <View
-            style={[
-              styles.modalContent,
-              { backgroundColor: colors.surface, borderColor: colors.border },
-            ]}
-          >
-            <View style={styles.modalHeader}>
-              <Text style={[styles.modalTitle, { color: colors.text }]}>
-                {t('server.createChannel')}
-              </Text>
-              <Pressable onPress={resetCreateChannelState} hitSlop={8}>
-                <X size={24} color={colors.textMuted} strokeWidth={2.5} />
-              </Pressable>
-            </View>
-
-            <ScrollView
-              showsVerticalScrollIndicator={false}
-              style={{ height: Dimensions.get('window').height * 0.6 }}
-              contentContainerStyle={{ paddingBottom: spacing.lg }}
-            >
-              <Text style={[styles.cuteLabel, { color: colors.text }]}>
-                {t('server.channelName')}
-              </Text>
-              <TextInput
-                style={[
-                  styles.cuteInput,
-                  {
-                    backgroundColor: colors.inputBackground,
-                    color: colors.text,
-                    borderColor: colors.border,
-                  },
-                ]}
-                value={newChannelName}
-                onChangeText={setNewChannelName}
-                placeholder={t('server.channelNamePlaceholder')}
-                placeholderTextColor={colors.textMuted}
-                autoFocus
-              />
-
-              <Text style={[styles.cuteLabel, { color: colors.text, marginTop: spacing.lg }]}>
-                {t('server.channelType')}
-              </Text>
-              <View style={styles.typeRow}>
-                {(['text', 'voice', 'announcement'] as const).map((type) => (
-                  <Pressable
-                    key={type}
-                    style={[
-                      styles.cuteTypeBtn,
-                      {
-                        backgroundColor:
-                          newChannelType === type ? '#00f3ff20' : colors.inputBackground,
-                        borderColor: newChannelType === type ? '#00f3ff' : colors.border,
-                      },
-                    ]}
-                    onPress={() => setNewChannelType(type)}
-                  >
-                    {channelIcon(type, newChannelType === type ? '#00c3cc' : colors.textMuted, 24)}
-                    <Text
-                      style={[
-                        styles.typeBtnText,
-                        { color: newChannelType === type ? '#00c3cc' : colors.text },
-                      ]}
-                    >
-                      {channelTypeLabel(type)}
-                    </Text>
-                  </Pressable>
-                ))}
-              </View>
-
-              {categories.length > 0 && (
-                <>
-                  <Text style={[styles.cuteLabel, { color: colors.text, marginTop: spacing.lg }]}>
-                    {t('server.channelCategory')}
-                  </Text>
-                  <ScrollView
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    style={{ flexGrow: 0 }}
-                    contentContainerStyle={{ gap: spacing.sm }}
-                  >
-                    <Pressable
-                      style={[
-                        styles.cuteCatChip,
-                        {
-                          backgroundColor: !newChannelCategoryId
-                            ? '#ff7da520'
-                            : colors.inputBackground,
-                          borderColor: !newChannelCategoryId ? '#ff7da5' : colors.border,
-                        },
-                      ]}
-                      onPress={() => setNewChannelCategoryId(null)}
-                    >
-                      <Text
-                        style={[
-                          styles.catChipText,
-                          { color: !newChannelCategoryId ? '#e85b85' : colors.text },
-                        ]}
-                      >
-                        {t('server.noCategory')}
-                      </Text>
-                    </Pressable>
-                    {categories.map((cat) => (
-                      <Pressable
-                        key={cat.id}
-                        style={[
-                          styles.cuteCatChip,
-                          {
-                            backgroundColor:
-                              newChannelCategoryId === cat.id
-                                ? '#f8e71c20'
-                                : colors.inputBackground,
-                            borderColor:
-                              newChannelCategoryId === cat.id ? '#f8e71c' : colors.border,
-                          },
-                        ]}
-                        onPress={() => setNewChannelCategoryId(cat.id)}
-                      >
-                        <Text
-                          style={[
-                            styles.catChipText,
-                            { color: newChannelCategoryId === cat.id ? '#b3a100' : colors.text },
-                          ]}
-                        >
-                          {cat.name}
-                        </Text>
-                      </Pressable>
-                    ))}
-                  </ScrollView>
-                </>
-              )}
-
-              {/* Member Selection Section */}
-              <Text style={[styles.cuteLabel, { color: colors.text, marginTop: spacing.lg }]}>
-                {t('server.addMembers', '添加成员（可选）')}
-              </Text>
-
-              {/* Search */}
-              <View style={[styles.memberSearchRow, { backgroundColor: colors.inputBackground }]}>
-                <Search size={16} color={colors.textMuted} />
-                <TextInput
-                  style={[styles.memberSearchInput, { color: colors.text }]}
-                  value={memberSearch}
-                  onChangeText={setMemberSearch}
-                  placeholder={t('common.search', '搜索...')}
-                  placeholderTextColor={colors.textMuted}
-                />
-                {memberSearch.length > 0 && (
-                  <Pressable onPress={() => setMemberSearch('')} hitSlop={8}>
-                    <X size={14} color={colors.textMuted} />
-                  </Pressable>
-                )}
-              </View>
-
-              {/* Selected count */}
-              {(selectedMembers.size > 0 || selectedAgents.size > 0) && (
-                <Text style={[styles.selectedCount, { color: colors.textMuted }]}>
-                  {t('server.selectedCount', '已选择 {{count}} 人', {
-                    count: selectedMembers.size + selectedAgents.size,
-                  })}
-                </Text>
-              )}
-
-              {/* Server Members */}
-              {selectableMembers.length > 0 && (
-                <>
-                  <Text style={[styles.memberSectionTitle, { color: colors.textMuted }]}>
-                    {t('members.serverMembers', '服务器成员')}
-                  </Text>
-                  {selectableMembers.map((m) => (
-                    <Pressable
-                      key={m.user.id}
-                      style={styles.selectableMemberRow}
-                      onPress={() => toggleMemberSelection(m.user.id)}
-                    >
-                      <Avatar
-                        uri={m.user.avatarUrl}
-                        name={m.user.displayName || m.user.username}
-                        size={36}
-                        userId={m.user.id}
-                      />
-                      <Text
-                        style={[styles.selectableMemberName, { color: colors.text }]}
-                        numberOfLines={1}
-                      >
-                        {m.user.displayName || m.user.username}
-                      </Text>
-                      <View
-                        style={[
-                          styles.checkbox,
-                          {
-                            backgroundColor: selectedMembers.has(m.user.id)
-                              ? colors.primary
-                              : 'transparent',
-                            borderColor: selectedMembers.has(m.user.id)
-                              ? colors.primary
-                              : colors.border,
-                          },
-                        ]}
-                      >
-                        {selectedMembers.has(m.user.id) && <Check size={14} color="#fff" />}
-                      </View>
-                    </Pressable>
-                  ))}
-                </>
-              )}
-
-              {/* Server Bots */}
-              {selectableBots.length > 0 && (
-                <>
-                  <Text style={[styles.memberSectionTitle, { color: colors.textMuted }]}>
-                    {t('members.serverBuddies', '服务器 Buddy')}
-                  </Text>
-                  {selectableBots.map((m) => (
-                    <Pressable
-                      key={m.user.id}
-                      style={styles.selectableMemberRow}
-                      onPress={() => toggleMemberSelection(m.user.id)}
-                    >
-                      <Avatar
-                        uri={m.user.avatarUrl}
-                        name={m.user.displayName || m.user.username}
-                        size={36}
-                        userId={m.user.id}
-                      />
-                      <View style={{ flex: 1 }}>
-                        <Text
-                          style={[styles.selectableMemberName, { color: colors.primary }]}
-                          numberOfLines={1}
-                        >
-                          {m.user.displayName || m.user.username}
-                        </Text>
-                      </View>
-                      <View
-                        style={[
-                          styles.checkbox,
-                          {
-                            backgroundColor: selectedMembers.has(m.user.id)
-                              ? colors.primary
-                              : 'transparent',
-                            borderColor: selectedMembers.has(m.user.id)
-                              ? colors.primary
-                              : colors.border,
-                          },
-                        ]}
-                      >
-                        {selectedMembers.has(m.user.id) && <Check size={14} color="#fff" />}
-                      </View>
-                    </Pressable>
-                  ))}
-                </>
-              )}
-
-              {/* My Agents */}
-              {selectableMyAgents.length > 0 && (
-                <>
-                  <Text style={[styles.memberSectionTitle, { color: colors.textMuted }]}>
-                    {t('members.myBuddies', '我的 Buddy')}
-                  </Text>
-                  {selectableMyAgents.map((a) => (
-                    <Pressable
-                      key={a.id}
-                      style={styles.selectableMemberRow}
-                      onPress={() => toggleAgentSelection(a.id)}
-                    >
-                      <Avatar
-                        uri={a.botUser?.avatarUrl ?? null}
-                        name={a.botUser?.displayName || a.botUser?.username || '?'}
-                        size={36}
-                        userId={a.botUser?.id}
-                      />
-                      <View style={{ flex: 1 }}>
-                        <Text
-                          style={[styles.selectableMemberName, { color: colors.primary }]}
-                          numberOfLines={1}
-                        >
-                          {a.botUser?.displayName || a.botUser?.username || '?'}
-                        </Text>
-                        <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
-                          {t('members.notOnServer', '未加入服务器')}
-                        </Text>
-                      </View>
-                      <View
-                        style={[
-                          styles.checkbox,
-                          {
-                            backgroundColor: selectedAgents.has(a.id)
-                              ? colors.primary
-                              : 'transparent',
-                            borderColor: selectedAgents.has(a.id) ? colors.primary : colors.border,
-                          },
-                        ]}
-                      >
-                        {selectedAgents.has(a.id) && <Check size={14} color="#fff" />}
-                      </View>
-                    </Pressable>
-                  ))}
-                </>
-              )}
-
-              {/* Empty state */}
-              {selectableMembers.length === 0 &&
-                selectableBots.length === 0 &&
-                selectableMyAgents.length === 0 && (
-                  <Text
-                    style={{
-                      color: colors.textMuted,
-                      fontSize: fontSize.sm,
-                      textAlign: 'center',
-                      paddingTop: spacing.lg,
-                    }}
-                  >
-                    {t('members.noInvitable', '没有可邀请的成员')}
-                  </Text>
-                )}
-            </ScrollView>
-
-            <SquishyCard
-              onPress={() => createChannelMutation.mutate()}
-              disabled={!newChannelName.trim() || createChannelMutation.isPending}
-              style={{ marginTop: spacing.md }}
-            >
-              <LinearGradient
-                colors={['#00f3ff', '#00a2ff']}
-                style={[
-                  styles.cuteModalBtn,
-                  { opacity: !newChannelName.trim() || createChannelMutation.isPending ? 0.5 : 1 },
-                ]}
-              >
-                <Text style={styles.cuteModalBtnText}>
-                  {createChannelMutation.isPending
-                    ? t('common.creating', '创建中...')
-                    : t('common.create')}
-                </Text>
-              </LinearGradient>
-            </SquishyCard>
-          </View>
-        </KeyboardAvoidingView>
-      </Modal>
 
       {/* Channel context menu */}
       <Modal
@@ -1586,7 +1099,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 0,
     padding: spacing.xl,
     paddingBottom: 40,
-    maxHeight: Dimensions.get('window').height * 0.85,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: -8 },
     shadowOpacity: 0.15,
@@ -1638,59 +1150,6 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     borderRadius: 24,
   },
-  cuteModalBtnText: {
-    color: '#1a1a1c',
-    fontSize: 18,
-    fontWeight: '900',
-  },
-
-  // Member selection styles
-  memberSearchRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: spacing.md,
-    height: 44,
-    borderRadius: radius.lg,
-    gap: spacing.sm,
-    marginBottom: spacing.md,
-  },
-  memberSearchInput: {
-    flex: 1,
-    fontSize: fontSize.md,
-    height: 44,
-  },
-  selectedCount: {
-    fontSize: fontSize.sm,
-    fontWeight: '600',
-    marginBottom: spacing.sm,
-  },
-  memberSectionTitle: {
-    fontSize: fontSize.xs,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-    paddingTop: spacing.md,
-    paddingBottom: spacing.sm,
-  },
-  selectableMemberRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.md,
-    paddingVertical: spacing.sm,
-  },
-  selectableMemberName: {
-    flex: 1,
-    fontSize: fontSize.md,
-    fontWeight: '500',
-  },
-  checkbox: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    borderWidth: 2,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-
   // Context menu
   ctxOverlay: {
     flex: 1,


### PR DESCRIPTION
## 变更内容

- 将频道创建流程改为类似微信的单页模式
- 在创建频道 modal 中直接集成成员/Buddy 选择功能
- 移除创建频道后自动跳转到成员邀请页面的逻辑
- 创建频道后直接进入新频道页面
- 支持选择服务器成员、服务器 Buddy 和个人 Agent

## 测试验证

- [x] TypeScript 编译通过
- [x] Biome 代码格式检查通过

## 截图

创建频道页面现在包含：
1. 频道名称输入
2. 频道类型选择（文字/语音/公告）
3. 频道分类选择
4. 成员搜索和选择区域（可选）
   - 服务器成员
   - 服务器 Buddy
   - 我的 Buddy（未加入服务器的）