### PR TITLE
fix(mobile): always show voice input icon in chat composer

### DIFF
--- a/apps/mobile/app/(main)/dm/[dmChannelId].tsx
+++ b/apps/mobile/app/(main)/dm/[dmChannelId].tsx
@@ -77,7 +77,7 @@ export default function DmChatScreen() {
   const typingTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const typingUsersTimeout = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
 
-  const { isRecording, voiceTranscript, toggleVoiceInput, speechSupported } = useChatVoiceInput({
+  const { isRecording, voiceTranscript, toggleVoiceInput } = useChatVoiceInput({
     speechLang: t('chat.speechLang'),
     onPermissionDenied: () => Alert.alert(t('chat.micPermission', '需要麦克风权限')),
     onUnavailable: () => Alert.alert(t('chat.voiceNotSupported', '语音输入不可用')),
@@ -681,7 +681,6 @@ export default function DmChatScreen() {
         voiceTranscript={voiceTranscript}
         keyboardVisible={keyboardVisible}
         insetsBottom={insets.bottom}
-        canUseVoice={speechSupported}
         onToggleVoice={toggleVoiceInput}
         showAtButton={false}
         showEmojiPicker={showInputEmojiPicker}

--- a/apps/mobile/app/(main)/servers/[serverSlug]/channels/[channelId].tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/channels/[channelId].tsx
@@ -100,7 +100,7 @@ export default function ChannelViewScreen() {
 
   const typingTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const typingUsersTimeout = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
-  const { isRecording, voiceTranscript, toggleVoiceInput, speechSupported } = useChatVoiceInput({
+  const { isRecording, voiceTranscript, toggleVoiceInput } = useChatVoiceInput({
     speechLang: t('chat.speechLang'),
     onPermissionDenied: () => Alert.alert(t('common.error'), t('chat.micPermissionDenied')),
     onUnavailable: () => Alert.alert(t('common.error'), t('chat.voiceInputUnavailable')),
@@ -1362,7 +1362,6 @@ export default function ChannelViewScreen() {
         voiceTranscript={voiceTranscript}
         keyboardVisible={keyboardVisible}
         insetsBottom={insets.bottom}
-        canUseVoice={speechSupported}
         onToggleVoice={toggleVoiceInput}
         showAtButton
         onPressAt={() => {

--- a/apps/mobile/src/components/chat/chat-composer.tsx
+++ b/apps/mobile/src/components/chat/chat-composer.tsx
@@ -21,7 +21,6 @@ interface ChatComposerProps {
   voiceTranscript: string
   keyboardVisible?: boolean
   insetsBottom: number
-  canUseVoice: boolean
   onToggleVoice: () => void
   showAtButton?: boolean
   onPressAt?: () => void
@@ -48,7 +47,6 @@ export const ChatComposer = memo(function ChatComposer({
   voiceTranscript,
   keyboardVisible = false,
   insetsBottom,
-  canUseVoice,
   onToggleVoice,
   showAtButton = false,
   onPressAt,
@@ -184,14 +182,12 @@ export const ChatComposer = memo(function ChatComposer({
             returnKeyType="send"
             keyboardAppearance="dark"
           />
-          {canUseVoice && (
-            <Pressable
-              style={[styles.inputMicBtn, isRecording && { backgroundColor: colors.primary }]}
-              onPress={onToggleVoice}
-            >
-              <Mic size={18} color={isRecording ? '#fff' : colors.textMuted} />
-            </Pressable>
-          )}
+          <Pressable
+            style={[styles.inputMicBtn, isRecording && { backgroundColor: colors.primary }]}
+            onPress={onToggleVoice}
+          >
+            <Mic size={18} color={isRecording ? '#fff' : colors.textMuted} />
+          </Pressable>
         </View>
 
         <Pressable


### PR DESCRIPTION
The refactor in fcb148e gated the mic icon behind canUseVoice (speechSupported), which depends on a dynamic require of expo-speech-recognition that can silently fail. The old code always rendered the mic icon and handled unavailability on press. Restore that behavior by removing the conditional wrapper.