### PR TITLE
feat(web & mobile): optimize chat input experience with draft persistence and image preview

### DIFF
--- a/apps/mobile/app/(main)/_layout.tsx
+++ b/apps/mobile/app/(main)/_layout.tsx
@@ -117,7 +117,6 @@ export default function MainLayout() {
     >
       <Stack.Screen name="(tabs)" />
       <Stack.Screen name="servers/[serverSlug]" />
-      <Stack.Screen name="dm/[dmChannelId]" options={{ headerShown: false }} />
       <Stack.Screen name="friends" options={{ headerShown: false }} />
       <Stack.Screen name="friends/new-friends" options={{ headerShown: false }} />
       <Stack.Screen name="settings" options={{ headerShown: false }} />

--- a/apps/mobile/app/(main)/friends.tsx
+++ b/apps/mobile/app/(main)/friends.tsx
@@ -95,14 +95,14 @@ export default function FriendsScreen() {
       (dm) => dm.otherUser?.id === userId || dm.userAId === userId || dm.userBId === userId,
     )
     if (existed) {
-      router.push(`/(main)/dm/${existed.id}` as never)
+      showToast(t('friends.dmUnavailable', '私信页面正在升级中，请稍后再试'), 'info')
       return
     }
 
     try {
       const data = await startChat.mutateAsync(userId)
       if (data?.id) {
-        router.push(`/(main)/dm/${data.id}` as never)
+        showToast(t('friends.dmUnavailable', '私信页面正在升级中，请稍后再试'), 'info')
       }
     } catch {
       showToast(t('common.error', '操作失败'), 'error')

--- a/apps/mobile/app/(main)/notifications.tsx
+++ b/apps/mobile/app/(main)/notifications.tsx
@@ -20,6 +20,7 @@ import { EmptyState } from '../../src/components/common/empty-state'
 import { LoadingScreen } from '../../src/components/common/loading-screen'
 import { useSocketEvent } from '../../src/hooks/use-socket'
 import { fetchApi } from '../../src/lib/api'
+import { showToast } from '../../src/lib/toast'
 import { fontSize, spacing, useColors } from '../../src/theme'
 
 function SquishyCard({
@@ -94,8 +95,7 @@ export default function NotificationsScreen() {
       if (!n.isRead) markRead.mutate(n.id)
 
       if (n.type === 'dm' && n.referenceId) {
-        // DM notification - navigate to DM chat
-        router.push(`/(main)/dm/${n.referenceId}` as never)
+        showToast(t('friends.dmUnavailable', '私信页面正在升级中，请稍后再试'), 'info')
         return
       }
 
@@ -135,7 +135,7 @@ export default function NotificationsScreen() {
         } catch {}
       }
     },
-    [router, markRead],
+    [router, markRead, t],
   )
 
   const unreadCount = notifications.filter((n) => !n.isRead).length

--- a/apps/mobile/app/(main)/servers/[serverSlug]/channels/[channelId].tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/channels/[channelId].tsx
@@ -20,7 +20,6 @@ import {
   Alert,
   FlatList,
   Keyboard,
-  KeyboardAvoidingView,
   Modal,
   Platform,
   Pressable,
@@ -30,6 +29,7 @@ import {
   View,
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useDraftStorage } from '@/hooks/use-draft-storage'
 import { ChatComposer } from '../../../../../src/components/chat/chat-composer'
 import { MessageBubble } from '../../../../../src/components/chat/message-bubble'
 import { Avatar } from '../../../../../src/components/common/avatar'
@@ -89,6 +89,7 @@ export default function ChannelViewScreen() {
   const [inviteSearch, setInviteSearch] = useState('')
   const [mentionQuery, setMentionQuery] = useState<string | null>(null)
   const [keyboardVisible, setKeyboardVisible] = useState(false)
+  const [keyboardHeight, setKeyboardHeight] = useState(320)
   const [showSearchPanel, setShowSearchPanel] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [searchFromUser, setSearchFromUser] = useState<string | null>(null)
@@ -97,6 +98,27 @@ export default function ChannelViewScreen() {
   const [highlightMessageId, setHighlightMessageId] = useState<string | null>(null)
   const searchInputRef = useRef<TextInput>(null)
   const inputRef = useRef<TextInput>(null)
+  const hasRestoredDraft = useRef(false)
+
+  // Draft storage for persistent input
+  const { restoredDraft, scheduleSave, clear: clearDraft } = useDraftStorage(channelId || null)
+
+  // Restore draft only once on mount
+  useEffect(() => {
+    if (restoredDraft && !hasRestoredDraft.current) {
+      setInputText(restoredDraft.text)
+      if (restoredDraft.pendingFiles?.length > 0) {
+        setPendingFiles(restoredDraft.pendingFiles)
+      }
+      hasRestoredDraft.current = true
+    }
+  }, [restoredDraft])
+
+  // Reset restore flag when channel changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional, we want to reset on channelId change
+  useEffect(() => {
+    hasRestoredDraft.current = false
+  }, [channelId])
 
   const typingTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const typingUsersTimeout = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
@@ -288,16 +310,21 @@ export default function ChannelViewScreen() {
   useEffect(() => {
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow'
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide'
-    const showSub = Keyboard.addListener(showEvent, () => {
+    const showSub = Keyboard.addListener(showEvent, (e) => {
       setKeyboardVisible(true)
-      setShowPlusMenu(false)
+      const nextHeight = e?.endCoordinates?.height ?? 0
+      if (nextHeight > 0) {
+        setKeyboardHeight(nextHeight)
+      }
       // Auto-scroll to newest messages when keyboard appears if near bottom
       const offset = channelId ? (scrollOffsetRef.current[channelId] ?? 0) : 0
       if (offset < 200) {
         flatListRef.current?.scrollToOffset({ offset: 0, animated: true })
       }
     })
-    const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardVisible(false))
+    const hideSub = Keyboard.addListener(hideEvent, () => {
+      setKeyboardVisible(false)
+    })
     return () => {
       showSub.remove()
       hideSub.remove()
@@ -934,6 +961,10 @@ export default function ChannelViewScreen() {
     setInputText('')
     setReplyTo(null)
     setPendingFiles([])
+
+    // Clear draft after successful send
+    clearDraft()
+
     playSendSound()
 
     try {
@@ -1090,6 +1121,11 @@ export default function ChannelViewScreen() {
     [handleTyping],
   )
 
+  // Auto-save draft when text or pendingFiles change (debounced)
+  useEffect(() => {
+    scheduleSave(inputText, pendingFiles)
+  }, [inputText, pendingFiles, scheduleSave])
+
   // Insert @mention into input
   const insertMention = useCallback((username: string) => {
     setInputText((prev) => {
@@ -1183,11 +1219,7 @@ export default function ChannelViewScreen() {
   }, [])
 
   return (
-    <KeyboardAvoidingView
-      style={[styles.container, { backgroundColor: colors.chatBackground }]}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={0}
-    >
+    <View style={[styles.container, { backgroundColor: colors.chatBackground }]}>
       {/* Custom header bar — left-aligned like Discord */}
       <View
         style={[styles.customHeader, { backgroundColor: colors.surface, paddingTop: insets.top }]}
@@ -1381,6 +1413,7 @@ export default function ChannelViewScreen() {
         setShowEmojiPicker={setShowInputEmojiPicker}
         showPlusMenu={showPlusMenu}
         setShowPlusMenu={setShowPlusMenu}
+        panelHeight={keyboardHeight}
         onPickImage={handlePickImage}
         onPickFile={handlePickFile}
         onTakePhoto={handleTakePhoto}
@@ -1904,7 +1937,7 @@ export default function ChannelViewScreen() {
           )}
         </View>
       </Modal>
-    </KeyboardAvoidingView>
+    </View>
   )
 }
 

--- a/apps/mobile/src/components/chat/chat-composer.tsx
+++ b/apps/mobile/src/components/chat/chat-composer.tsx
@@ -1,12 +1,268 @@
+import { Image } from 'expo-image'
 import { AtSign, Camera, File, Image as ImageIcon, Mic, Plus, Smile, X } from 'lucide-react-native'
-import { memo } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Keyboard, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
-import type { EmojiType } from 'rn-emoji-keyboard'
-import EmojiPicker from 'rn-emoji-keyboard'
+import {
+  Animated,
+  Dimensions,
+  Easing,
+  FlatList,
+  Keyboard,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
 import { fontSize, radius, spacing, useColors } from '../../theme'
 import type { Message } from '../../types/message'
 import { TypelessMicButton } from './typeless-mic-button'
+
+// Common emoji list for inline picker
+const COMMON_EMOJIS = [
+  '😀',
+  '😃',
+  '😄',
+  '😁',
+  '😆',
+  '😅',
+  '🤣',
+  '😂',
+  '🙂',
+  '🙃',
+  '😉',
+  '😊',
+  '😇',
+  '🥰',
+  '😍',
+  '🤩',
+  '😘',
+  '😗',
+  '😚',
+  '😙',
+  '😋',
+  '😛',
+  '😜',
+  '🤪',
+  '😝',
+  '🤑',
+  '🤗',
+  '🤭',
+  '🤫',
+  '🤔',
+  '🤐',
+  '🤨',
+  '😐',
+  '😑',
+  '😶',
+  '😏',
+  '😒',
+  '🙄',
+  '😬',
+  '🤥',
+  '😌',
+  '😔',
+  '😪',
+  '🤤',
+  '😴',
+  '😷',
+  '🤒',
+  '🤕',
+  '🤢',
+  '🤮',
+  '🤧',
+  '🥵',
+  '🥶',
+  '🥴',
+  '😵',
+  '🤯',
+  '🤠',
+  '🥳',
+  '😎',
+  '🤓',
+  '🧐',
+  '😕',
+  '😟',
+  '🙁',
+  '☹️',
+  '😮',
+  '😯',
+  '😲',
+  '😳',
+  '🥺',
+  '😦',
+  '😧',
+  '😨',
+  '😰',
+  '😥',
+  '😢',
+  '😭',
+  '😱',
+  '😖',
+  '😣',
+  '😞',
+  '😓',
+  '😩',
+  '😫',
+  '🥱',
+  '😤',
+  '😡',
+  '😠',
+  '🤬',
+  '😈',
+  '👿',
+  '💀',
+  '☠️',
+  '💩',
+  '🤡',
+  '👹',
+  '👺',
+  '👻',
+  '👽',
+  '👾',
+  '🤖',
+  '😺',
+  '😸',
+  '😹',
+  '😻',
+  '😼',
+  '😽',
+  '🙀',
+  '😿',
+  '😾',
+  '❤️',
+  '🧡',
+  '💛',
+  '💚',
+  '💙',
+  '💜',
+  '🖤',
+  '🤍',
+  '🤎',
+  '💔',
+  '❣️',
+  '💕',
+  '💞',
+  '💓',
+  '💗',
+  '💖',
+  '💘',
+  '💝',
+  '💟',
+  '☮️',
+  '✝️',
+  '☪️',
+  '🕉',
+  '☸️',
+  '✡️',
+  '🔯',
+  '🕎',
+  '☯️',
+  '☦️',
+  '🛐',
+  '⛎',
+  '♈',
+  '♉',
+  '♊',
+  '♋',
+  '♌',
+  '♍',
+  '♎',
+  '♏',
+  '♐',
+  '♑',
+  '♒',
+  '♓',
+  '🆔',
+  '⚛️',
+  '🉑',
+  '☢️',
+  '☣️',
+  '📴',
+  '📳',
+  '🈶',
+  '🈚',
+  '🈸',
+  '🈺',
+  '🈷',
+  '✴️',
+  '🆚',
+  '💮',
+  '🉐',
+  '㊙️',
+  '㊗️',
+  '🈴',
+  '🈵',
+  '🈹',
+  '🈲',
+  '🅰️',
+  '🅱️',
+  '🆎',
+  '🆑',
+  '🅾️',
+  '🆘',
+  '❌',
+  '⭕',
+  '🛑',
+  '⛔',
+  '📛',
+  '🚫',
+  '💯',
+  '💢',
+  '♨️',
+  '🚷',
+  '🚯',
+  '🚳',
+  '🚱',
+  '🔞',
+  '📵',
+  '🚭',
+  '❗',
+  '❕',
+  '❓',
+  '❔',
+  '‼️',
+  '⁉️',
+  '🔅',
+  '🔆',
+  '〽️',
+  '⚠️',
+  '🚸',
+  '🔱',
+  '⚜️',
+  '🔰',
+  '♻️',
+  '✅',
+  '🈯',
+  '💹',
+  '❇️',
+  '✳️',
+  '❎',
+  '🌐',
+  '💠',
+  'Ⓜ️',
+  '🌀',
+  '💤',
+  '🏧',
+  '🚾',
+  '♿',
+  '🅿️',
+  '🈳',
+  '🈂',
+  '🛂',
+  '🛃',
+  '🛄',
+  '🛅',
+  '🛗',
+  '🟰',
+  '🌝',
+  '🌚',
+  '🌕',
+  '🌖',
+  '🌗',
+]
 
 interface ChatComposerProps {
   inputText: string
@@ -23,6 +279,7 @@ interface ChatComposerProps {
   voiceTranscript?: string
   keyboardVisible?: boolean
   insetsBottom: number
+  panelHeight?: number
   canUseVoice: boolean
   onToggleVoice?: () => void
   onVoicePressIn?: () => void
@@ -38,6 +295,53 @@ interface ChatComposerProps {
   onTakePhoto?: () => void
 }
 
+function ImageViewerModal({
+  uri,
+  visible,
+  onClose,
+}: {
+  uri: string
+  visible: boolean
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const screenWidth = Dimensions.get('window').width
+  const screenHeight = Dimensions.get('window').height
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <View style={[styles.imageViewerOverlay, { backgroundColor: 'rgba(0,0,0,0.95)' }]}>
+        <View style={styles.imageViewerHeader}>
+          <Pressable onPress={onClose} hitSlop={8} style={styles.imageViewerCloseBtn}>
+            <X size={24} color="#fff" />
+          </Pressable>
+          <Text style={styles.imageViewerTitle}>{t('chat.imagePreview', '图片预览')}</Text>
+          <View style={{ width: 40 }} />
+        </View>
+        <Pressable style={styles.imageViewerContent} onPress={onClose}>
+          <Image
+            source={{ uri }}
+            style={{ width: screenWidth, height: screenHeight * 0.7 }}
+            contentFit="contain"
+            transition={200}
+          />
+        </Pressable>
+        <View style={styles.imageViewerHint}>
+          <Text style={{ color: 'rgba(255,255,255,0.6)', fontSize: fontSize.sm }}>
+            {t('chat.tapToClose', '点击关闭')}
+          </Text>
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
 export const ChatComposer = memo(function ChatComposer({
   inputText,
   onInputChange,
@@ -50,8 +354,9 @@ export const ChatComposer = memo(function ChatComposer({
   typingUsers,
   isRecording = false,
   isHolding = false,
-  keyboardVisible = false,
+  keyboardVisible: _keyboardVisible = false,
   insetsBottom,
+  panelHeight = 320,
   canUseVoice,
   onToggleVoice,
   onVoicePressIn,
@@ -68,6 +373,93 @@ export const ChatComposer = memo(function ChatComposer({
 }: ChatComposerProps) {
   const colors = useColors()
   const { t } = useTranslation()
+  const [viewingImageUri, setViewingImageUri] = useState<string | null>(null)
+
+  // ── Bottom-slot state machine ──
+  // A single always-rendered Animated.View at the bottom whose height
+  // smoothly tracks whichever occupant is active:
+  //   idle    → insetsBottom  (safe-area only)
+  //   keyboard → keyboard height  (system keyboard visible)
+  //   panel   → panelHeight   (plus-menu / emoji picker)
+  const panelIntentRef = useRef(false)
+  const keyboardUpRef = useRef(false)
+  const bottomHeightAnim = useRef(new Animated.Value(insetsBottom)).current
+  const lastTargetRef = useRef(insetsBottom)
+  const panelRequested = showPlusMenu || showEmojiPicker
+
+  const animateBottomTo = useCallback(
+    (toValue: number, duration: number) => {
+      if (Math.abs(lastTargetRef.current - toValue) < 1) return
+      lastTargetRef.current = toValue
+      Animated.timing(bottomHeightAnim, {
+        toValue,
+        duration,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: false,
+      }).start()
+    },
+    [bottomHeightAnim],
+  )
+
+  // Keyboard listeners — drive the bottom-slot height in lockstep with iOS keyboard animation
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow'
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide'
+
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      keyboardUpRef.current = true
+      panelIntentRef.current = false
+      const height = e.endCoordinates.height
+      const duration = e.duration ?? 250
+      // Close panels — keyboard takes over the bottom slot
+      setShowPlusMenu(false)
+      setShowEmojiPicker(false)
+      animateBottomTo(height, duration)
+    })
+
+    const hideSub = Keyboard.addListener(hideEvent, (e) => {
+      keyboardUpRef.current = false
+      const duration = e.duration ?? 250
+      if (panelIntentRef.current) {
+        // Keyboard → panel: keep slot at panel height so input bar stays put
+        panelIntentRef.current = false
+        animateBottomTo(panelHeight, duration)
+      } else {
+        // Keyboard → idle
+        animateBottomTo(insetsBottom, duration)
+      }
+    })
+
+    return () => {
+      showSub.remove()
+      hideSub.remove()
+    }
+  }, [panelHeight, insetsBottom, animateBottomTo, setShowPlusMenu, setShowEmojiPicker])
+
+  // Non-keyboard transitions (idle ↔ panel)
+  useEffect(() => {
+    if (panelIntentRef.current || keyboardUpRef.current) return
+    if (panelRequested) {
+      animateBottomTo(panelHeight, 250)
+    } else {
+      animateBottomTo(insetsBottom, 200)
+    }
+  }, [panelRequested, panelHeight, insetsBottom, animateBottomTo])
+
+  // Plus-button rotation animation
+  const rotateAnim = useRef(new Animated.Value(0)).current
+  useEffect(() => {
+    Animated.timing(rotateAnim, {
+      toValue: panelRequested ? 1 : 0,
+      duration: 200,
+      useNativeDriver: true,
+    }).start()
+  }, [panelRequested, rotateAnim])
+
+  const rotateInterpolate = rotateAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '45deg'],
+  })
 
   return (
     <>
@@ -87,27 +479,50 @@ export const ChatComposer = memo(function ChatComposer({
             { backgroundColor: colors.surface, borderTopColor: colors.border },
           ]}
         >
-          {pendingFiles.map((file) => (
-            <View
-              key={file.uri}
-              style={[styles.pendingFileChip, { backgroundColor: colors.inputBackground }]}
-            >
-              <Text
-                style={[styles.pendingFileName, { color: colors.textSecondary }]}
-                numberOfLines={1}
-              >
-                {file.type.startsWith('image/') ? '🖼 ' : '📎 '}
-                {file.name}
-              </Text>
-              <Pressable
-                onPress={() => onRemovePendingFile(pendingFiles.indexOf(file))}
-                hitSlop={8}
-              >
-                <X size={14} color={colors.textMuted} />
-              </Pressable>
+          {pendingFiles.map((file, idx) => (
+            <View key={file.uri}>
+              {file.type.startsWith('image/') ? (
+                <Pressable
+                  onPress={() => setViewingImageUri(file.uri)}
+                  style={[styles.pendingImageChip, { backgroundColor: colors.inputBackground }]}
+                >
+                  <Image
+                    source={{ uri: file.uri }}
+                    style={styles.pendingImageThumb}
+                    contentFit="cover"
+                  />
+                  <Pressable
+                    onPress={() => onRemovePendingFile(idx)}
+                    hitSlop={8}
+                    style={styles.pendingImageRemoveBtn}
+                  >
+                    <X size={14} color="#fff" />
+                  </Pressable>
+                </Pressable>
+              ) : (
+                <View style={[styles.pendingFileChip, { backgroundColor: colors.inputBackground }]}>
+                  <Text
+                    style={[styles.pendingFileName, { color: colors.textSecondary }]}
+                    numberOfLines={1}
+                  >
+                    📎 {file.name}
+                  </Text>
+                  <Pressable onPress={() => onRemovePendingFile(idx)} hitSlop={8}>
+                    <X size={14} color={colors.textMuted} />
+                  </Pressable>
+                </View>
+              )}
             </View>
           ))}
         </View>
+      )}
+
+      {viewingImageUri && (
+        <ImageViewerModal
+          uri={viewingImageUri}
+          visible={!!viewingImageUri}
+          onClose={() => setViewingImageUri(null)}
+        />
       )}
 
       {replyTo && (
@@ -138,7 +553,7 @@ export const ChatComposer = memo(function ChatComposer({
           {
             backgroundColor: colors.surface,
             borderTopColor: colors.border,
-            paddingBottom: keyboardVisible ? 6 : Math.max(6, insetsBottom + 2),
+            paddingBottom: 8,
           },
         ]}
       >
@@ -185,136 +600,146 @@ export const ChatComposer = memo(function ChatComposer({
         </View>
 
         <Pressable
-          style={styles.actionBtn}
-          onPress={() => {
-            setShowPlusMenu(false)
-            setShowEmojiPicker(true)
-          }}
-        >
-          <Smile size={24} color={showEmojiPicker ? colors.primary : colors.textMuted} />
-        </Pressable>
-
-        <Pressable
           style={[
             styles.actionBtn,
             { borderColor: colors.border, borderWidth: 1.5, borderRadius: 23 },
           ]}
           onPress={() => {
-            if (showPlusMenu) {
-              setShowPlusMenu(false)
+            if (panelRequested) {
+              // Panel → keyboard: focus input, keyboardWillShow handles the rest
               inputRef.current?.focus()
-            } else {
+            } else if (keyboardUpRef.current) {
+              // Keyboard → panel: tell hide-handler to keep slot height
+              panelIntentRef.current = true
+              setShowEmojiPicker(false)
+              setShowPlusMenu(true)
               Keyboard.dismiss()
+            } else {
+              // Idle → panel
               setShowEmojiPicker(false)
               setShowPlusMenu(true)
             }
           }}
         >
-          <Plus size={22} color={showPlusMenu ? colors.primary : colors.textMuted} />
+          <Animated.View style={{ transform: [{ rotate: rotateInterpolate }] }}>
+            <Plus size={22} color={panelRequested ? colors.primary : colors.textMuted} />
+          </Animated.View>
         </Pressable>
       </View>
 
-      {showEmojiPicker && (
-        <EmojiPicker
-          open={showEmojiPicker}
-          onClose={() => setShowEmojiPicker(false)}
-          onEmojiSelected={(emoji: EmojiType) => {
-            onInputChange(inputText + emoji.emoji)
-            setTimeout(() => inputRef.current?.focus(), 100)
-          }}
-          enableSearchBar
-          enableRecentlyUsed
-          categoryPosition="top"
-          theme={{
-            backdrop: 'rgba(0,0,0,0.3)',
-            knob: colors.textMuted,
-            container: colors.surface,
-            header: colors.text,
-            category: {
-              icon: colors.textMuted,
-              iconActive: colors.primary,
-              container: colors.surface,
-              containerActive: colors.surfaceHover,
-            },
-            search: {
-              background: colors.inputBackground,
-              text: colors.text,
-              placeholder: colors.textMuted,
-              icon: colors.textMuted,
-            },
-            emoji: { selected: colors.surfaceHover },
-          }}
-        />
-      )}
-
-      {showPlusMenu && (
-        <View
-          style={[
-            styles.plusPanel,
-            {
-              backgroundColor: colors.surface,
-              borderTopColor: colors.border,
-              paddingBottom: Math.max(insetsBottom, 16),
-            },
-          ]}
-        >
-          <View style={styles.plusPanelGrid}>
-            {onTakePhoto && (
-              <Pressable
-                style={({ pressed }) => [styles.plusPanelItem, pressed && { opacity: 0.6 }]}
-                onPress={() => {
-                  setShowPlusMenu(false)
-                  onTakePhoto()
-                }}
-              >
-                <View style={[styles.plusPanelIcon, { backgroundColor: '#10b98115' }]}>
-                  <Camera size={24} color="#10b981" />
+      {/* Bottom slot — always rendered; height tracks keyboard / panel / idle */}
+      <Animated.View
+        style={{
+          height: bottomHeightAnim,
+          overflow: 'hidden',
+          backgroundColor: colors.surface,
+        }}
+      >
+        {panelRequested && (
+          <View style={[styles.plusPanel, { borderTopColor: colors.border, height: panelHeight }]}>
+            {showEmojiPicker ? (
+              <View style={styles.emojiPanelContainer}>
+                <View style={styles.emojiPanelHeader}>
+                  <Text style={[styles.emojiPanelTitle, { color: colors.text }]}>
+                    {t('chat.emoji', '表情')}
+                  </Text>
+                  <Pressable
+                    onPress={() => setShowEmojiPicker(false)}
+                    style={styles.emojiPanelClose}
+                  >
+                    <X size={20} color={colors.textMuted} />
+                  </Pressable>
                 </View>
-                <Text style={[styles.plusPanelLabel, { color: colors.textSecondary }]}>
-                  {t('chat.takePhoto', '拍摄')}
-                </Text>
-              </Pressable>
+                <FlatList
+                  data={COMMON_EMOJIS}
+                  numColumns={8}
+                  keyExtractor={(item, index) => `${item}-${index}`}
+                  renderItem={({ item }) => (
+                    <Pressable
+                      style={({ pressed }) => [
+                        styles.emojiItem,
+                        pressed && { backgroundColor: colors.surfaceHover, borderRadius: 8 },
+                      ]}
+                      onPress={() => {
+                        onInputChange(inputText + item)
+                        inputRef.current?.focus()
+                      }}
+                      android_ripple={{ color: colors.surfaceHover }}
+                    >
+                      <Text style={styles.emojiText}>{item}</Text>
+                    </Pressable>
+                  )}
+                  contentContainerStyle={styles.emojiList}
+                />
+              </View>
+            ) : (
+              <View style={styles.plusPanelGrid}>
+                <Pressable
+                  style={({ pressed }) => [styles.plusPanelItem, pressed && { opacity: 0.6 }]}
+                  onPress={() => setShowEmojiPicker(true)}
+                >
+                  <View style={[styles.plusPanelIcon, { backgroundColor: '#fbbf2415' }]}>
+                    <Smile size={28} color="#fbbf24" />
+                  </View>
+                  <Text style={[styles.plusPanelLabel, { color: colors.textSecondary }]}>
+                    {t('chat.emoji', '表情')}
+                  </Text>
+                </Pressable>
+                {onTakePhoto && (
+                  <Pressable
+                    style={({ pressed }) => [styles.plusPanelItem, pressed && { opacity: 0.6 }]}
+                    onPress={() => {
+                      setShowPlusMenu(false)
+                      onTakePhoto()
+                    }}
+                  >
+                    <View style={[styles.plusPanelIcon, { backgroundColor: '#10b98115' }]}>
+                      <Camera size={28} color="#10b981" />
+                    </View>
+                    <Text style={[styles.plusPanelLabel, { color: colors.textSecondary }]}>
+                      {t('chat.takePhoto', '拍摄')}
+                    </Text>
+                  </Pressable>
+                )}
+                <Pressable
+                  style={({ pressed }) => [styles.plusPanelItem, pressed && { opacity: 0.6 }]}
+                  onPress={() => {
+                    setShowPlusMenu(false)
+                    onPickImage()
+                  }}
+                >
+                  <View style={[styles.plusPanelIcon, { backgroundColor: `${colors.primary}15` }]}>
+                    <ImageIcon size={28} color={colors.primary} />
+                  </View>
+                  <Text style={[styles.plusPanelLabel, { color: colors.textSecondary }]}>
+                    {t('chat.pickImage', '相册')}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  style={({ pressed }) => [styles.plusPanelItem, pressed && { opacity: 0.6 }]}
+                  onPress={() => {
+                    setShowPlusMenu(false)
+                    onPickFile()
+                  }}
+                >
+                  <View style={[styles.plusPanelIcon, { backgroundColor: '#f59e0b15' }]}>
+                    <File size={28} color="#f59e0b" />
+                  </View>
+                  <Text style={[styles.plusPanelLabel, { color: colors.textSecondary }]}>
+                    {t('chat.pickFile', '文件')}
+                  </Text>
+                </Pressable>
+              </View>
             )}
-            <Pressable
-              style={({ pressed }) => [styles.plusPanelItem, pressed && { opacity: 0.6 }]}
-              onPress={() => {
-                setShowPlusMenu(false)
-                onPickImage()
-              }}
-            >
-              <View style={[styles.plusPanelIcon, { backgroundColor: `${colors.primary}15` }]}>
-                <ImageIcon size={24} color={colors.primary} />
-              </View>
-              <Text style={[styles.plusPanelLabel, { color: colors.textSecondary }]}>
-                {t('chat.pickImage', '相册')}
-              </Text>
-            </Pressable>
-            <Pressable
-              style={({ pressed }) => [styles.plusPanelItem, pressed && { opacity: 0.6 }]}
-              onPress={() => {
-                setShowPlusMenu(false)
-                onPickFile()
-              }}
-            >
-              <View style={[styles.plusPanelIcon, { backgroundColor: '#f59e0b15' }]}>
-                <File size={24} color="#f59e0b" />
-              </View>
-              <Text style={[styles.plusPanelLabel, { color: colors.textSecondary }]}>
-                {t('chat.pickFile', '文件')}
-              </Text>
-            </Pressable>
           </View>
-        </View>
-      )}
+        )}
+      </Animated.View>
     </>
   )
 })
 
 const styles = StyleSheet.create({
-  typingBar: {
-    paddingHorizontal: spacing.md,
-    paddingVertical: 6,
-  },
+  typingBar: { paddingHorizontal: spacing.md, paddingVertical: 6 },
   pendingFilesBar: {
     flexDirection: 'row',
     flexWrap: 'wrap',
@@ -332,9 +757,19 @@ const styles = StyleSheet.create({
     gap: 4,
     maxWidth: 180,
   },
-  pendingFileName: {
-    fontSize: fontSize.xs,
-    flexShrink: 1,
+  pendingFileName: { fontSize: fontSize.xs, flexShrink: 1 },
+  pendingImageChip: { borderRadius: radius.md, overflow: 'hidden', position: 'relative' },
+  pendingImageThumb: { width: 80, height: 80, borderRadius: radius.md },
+  pendingImageRemoveBtn: {
+    position: 'absolute',
+    top: 4,
+    right: 4,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   replyBar: {
     flexDirection: 'row',
@@ -344,21 +779,21 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     gap: spacing.sm,
   },
-  replyBarAccent: {
-    width: 3,
-    height: '100%',
-    borderRadius: 2,
+  replyBarAccent: { width: 3, height: '100%', borderRadius: 2 },
+  replyBarContent: { flex: 1 },
+  replyBarLabel: { fontSize: fontSize.xs, fontWeight: '600' },
+  replyBarPreview: { fontSize: fontSize.xs },
+  voiceRecordingBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: 8,
+    borderTopWidth: 1,
+    gap: 8,
   },
-  replyBarContent: {
-    flex: 1,
-  },
-  replyBarLabel: {
-    fontSize: fontSize.xs,
-    fontWeight: '600',
-  },
-  replyBarPreview: {
-    fontSize: fontSize.xs,
-  },
+  voiceRecordingDot: { width: 8, height: 8, borderRadius: 4, backgroundColor: '#ef4444' },
+  voiceRecordingLabel: { fontSize: fontSize.xs, fontWeight: '600' },
+  voiceTranscript: { flex: 1, fontSize: fontSize.sm },
   inputBar: {
     flexDirection: 'row',
     alignItems: 'flex-end',
@@ -403,27 +838,42 @@ const styles = StyleSheet.create({
     right: 4,
     bottom: 6,
   },
-  plusPanel: {
-    borderTopWidth: 1,
-    paddingHorizontal: spacing.md,
-    paddingTop: spacing.md,
-  },
-  plusPanelGrid: {
-    flexDirection: 'row',
-    gap: spacing.xl,
-  },
-  plusPanelItem: {
-    alignItems: 'center',
-    gap: spacing.xs,
-  },
+  plusPanel: { borderTopWidth: 1, paddingHorizontal: spacing.md, paddingTop: spacing.md },
+  plusPanelGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.md },
+  plusPanelItem: { alignItems: 'center', gap: spacing.xs, width: '22%', marginBottom: spacing.md },
   plusPanelIcon: {
-    width: 52,
-    height: 52,
+    width: 60,
+    height: 60,
     borderRadius: 16,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  plusPanelLabel: {
-    fontSize: fontSize.xs,
+  plusPanelLabel: { fontSize: fontSize.sm, marginTop: 4 },
+  emojiPanelContainer: { flex: 1 },
+  emojiPanelHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.sm,
+    paddingBottom: spacing.sm,
   },
+  emojiPanelTitle: { fontSize: fontSize.md, fontWeight: '600' },
+  emojiPanelClose: { width: 32, height: 32, alignItems: 'center', justifyContent: 'center' },
+  emojiList: { paddingHorizontal: spacing.sm },
+  emojiItem: { width: '12.5%', aspectRatio: 1, alignItems: 'center', justifyContent: 'center' },
+  emojiText: { fontSize: 24 },
+  imageViewerOverlay: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  imageViewerHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+    paddingTop: Platform.OS === 'ios' ? 50 : spacing.xl,
+    paddingBottom: spacing.md,
+    width: '100%',
+  },
+  imageViewerCloseBtn: { width: 40, height: 40, alignItems: 'center', justifyContent: 'center' },
+  imageViewerTitle: { color: '#fff', fontSize: fontSize.md, fontWeight: '600' },
+  imageViewerContent: { flex: 1, justifyContent: 'center', alignItems: 'center', width: '100%' },
+  imageViewerHint: { paddingBottom: spacing.xl, alignItems: 'center' },
 })

--- a/apps/mobile/src/hooks/use-draft-storage.ts
+++ b/apps/mobile/src/hooks/use-draft-storage.ts
@@ -1,0 +1,136 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const DRAFT_KEY_PREFIX = 'shadow:draft:'
+const DRAFT_EXPIRY_DAYS = 7
+
+interface PendingFile {
+  uri: string
+  name: string
+  type: string
+  size?: number
+}
+
+interface DraftData {
+  text: string
+  pendingFiles: PendingFile[]
+  timestamp: number
+}
+
+function getDraftKey(channelId: string): string {
+  return `${DRAFT_KEY_PREFIX}${channelId}`
+}
+
+function isDraftExpired(timestamp: number): boolean {
+  const expiryTime = DRAFT_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+  return Date.now() - timestamp > expiryTime
+}
+
+export async function loadDraft(channelId: string): Promise<DraftData | null> {
+  try {
+    const key = getDraftKey(channelId)
+    const stored = await AsyncStorage.getItem(key)
+    if (!stored) return null
+
+    const data = JSON.parse(stored) as DraftData
+    if (isDraftExpired(data.timestamp)) {
+      await AsyncStorage.removeItem(key)
+      return null
+    }
+    return data
+  } catch {
+    return null
+  }
+}
+
+export async function saveDraft(
+  channelId: string,
+  text: string,
+  pendingFiles: PendingFile[] = [],
+): Promise<void> {
+  try {
+    const key = getDraftKey(channelId)
+    if (!text.trim() && pendingFiles.length === 0) {
+      await AsyncStorage.removeItem(key)
+      return
+    }
+    const data: DraftData = {
+      text,
+      pendingFiles,
+      timestamp: Date.now(),
+    }
+    await AsyncStorage.setItem(key, JSON.stringify(data))
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export async function clearDraft(channelId: string): Promise<void> {
+  try {
+    const key = getDraftKey(channelId)
+    await AsyncStorage.removeItem(key)
+  } catch {
+    // Ignore
+  }
+}
+
+export function useDraftStorage(channelId: string | null) {
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [restoredDraft, setRestoredDraft] = useState<DraftData | null>(null)
+  const hasLoadedRef = useRef(false)
+
+  useEffect(() => {
+    if (!channelId || hasLoadedRef.current) return
+
+    loadDraft(channelId).then((draft) => {
+      if (draft) {
+        setRestoredDraft(draft)
+      }
+      hasLoadedRef.current = true
+    })
+
+    return () => {
+      hasLoadedRef.current = false
+    }
+  }, [channelId])
+
+  const scheduleSave = useCallback(
+    (text: string, pendingFiles: PendingFile[] = []) => {
+      if (!channelId) return
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current)
+      }
+      saveTimerRef.current = setTimeout(() => {
+        saveDraft(channelId, text, pendingFiles)
+      }, 500)
+    },
+    [channelId],
+  )
+
+  const clear = useCallback(() => {
+    if (!channelId) return
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current)
+      saveTimerRef.current = null
+    }
+    clearDraft(channelId)
+    setRestoredDraft(null)
+  }, [channelId])
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current)
+      }
+    }
+  }, [])
+
+  return {
+    restoredDraft,
+    scheduleSave,
+    clear,
+    loadDraft: () => loadDraft(channelId || ''),
+    saveDraft: (text: string, pendingFiles?: PendingFile[]) =>
+      saveDraft(channelId || '', text, pendingFiles),
+  }
+}

--- a/apps/web/src/components/chat/message-input.tsx
+++ b/apps/web/src/components/chat/message-input.tsx
@@ -33,6 +33,19 @@ interface PendingFile {
   workspaceSize?: number
 }
 
+function getPendingFileKey(pf: PendingFile): string {
+  return [
+    pf.workspaceUrl,
+    pf.preview,
+    pf.file.name,
+    pf.file.type,
+    String(pf.file.size),
+    String(pf.file.lastModified),
+  ]
+    .filter(Boolean)
+    .join('::')
+}
+
 interface MemberUser {
   id: string
   username: string
@@ -509,8 +522,11 @@ export function MessageInput({
   }, [])
 
   return (
-    <div
+    <section
       className="px-4 pb-4 mobile-safe-bottom relative"
+      aria-label={t('chat.inputPlaceholder', {
+        channelName: channelName ?? t('chat.channelFallback'),
+      })}
       onDrop={handleDrop}
       onDragOver={handleDragOver}
     >
@@ -561,6 +577,7 @@ export function MessageInput({
             <span className="font-semibold text-text-muted">{t('chat.replyingTo')}</span>
           </div>
           <button
+            type="button"
             onClick={onClearReply}
             className="text-text-muted hover:text-text-primary transition p-1 hover:bg-bg-modifier-hover rounded-full"
           >
@@ -575,7 +592,7 @@ export function MessageInput({
           className={`flex flex-wrap gap-2 bg-bg-secondary ${replyToId ? '' : 'rounded-t-lg'} border-b border-black/10 px-4 py-3`}
         >
           {pendingFiles.map((pf, i) => (
-            <div key={i} className="relative group/file">
+            <div key={getPendingFileKey(pf)} className="relative group/file">
               {pf.preview ? (
                 <button
                   type="button"
@@ -598,6 +615,7 @@ export function MessageInput({
                 </span>
               )}
               <button
+                type="button"
                 onClick={() => removeFile(i)}
                 className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-danger rounded-full flex items-center justify-center text-white opacity-0 group-hover/file:opacity-100 transition"
               >
@@ -614,6 +632,7 @@ export function MessageInput({
         } px-3 py-1.5 shadow-sm`}
       >
         <button
+          type="button"
           onClick={() => fileInputRef.current?.click()}
           className="text-text-secondary hover:text-text-primary transition p-1.5 rounded-full hover:bg-bg-modifier-hover shrink-0 self-end mb-[3px]"
           title={t('chat.uploadFile')}
@@ -634,6 +653,7 @@ export function MessageInput({
         />
 
         <button
+          type="button"
           onClick={() => fileInputRef.current?.click()}
           className="text-text-secondary hover:text-text-primary transition p-1.5 rounded-full hover:bg-bg-modifier-hover shrink-0 self-end mb-[3px]"
           title={t('chat.uploadImage')}
@@ -643,6 +663,7 @@ export function MessageInput({
 
         {activeServerId && (
           <button
+            type="button"
             onClick={() => setShowWorkspacePicker(true)}
             className="text-text-secondary hover:text-text-primary transition p-1.5 rounded-full hover:bg-bg-modifier-hover shrink-0 self-end mb-[3px]"
             title="从工作区选择文件"
@@ -653,6 +674,7 @@ export function MessageInput({
 
         <div className="relative shrink-0 self-end mb-[3px]">
           <button
+            type="button"
             onClick={() => setShowEmojiPicker(!showEmojiPicker)}
             className="text-text-secondary hover:text-text-primary transition p-1.5 rounded-full hover:bg-bg-modifier-hover"
             title={t('chat.addEmoji')}
@@ -672,6 +694,7 @@ export function MessageInput({
         </div>
 
         <button
+          type="button"
           onClick={handleSend}
           disabled={(!content.trim() && pendingFiles.length === 0) || uploading}
           className="text-text-muted hover:text-primary transition p-1.5 rounded-full hover:bg-bg-modifier-hover shrink-0 self-end mb-[3px] disabled:opacity-30 disabled:hover:bg-transparent"
@@ -708,6 +731,6 @@ export function MessageInput({
           onClose={() => setViewingImage(null)}
         />
       )}
-    </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Description

Optimize chat input experience for both web and mobile platforms with the following features:

### 1. Draft Persistence
- Store draft content per channel in localStorage (web) / AsyncStorage (mobile)
- Auto-save input text (debounced 500ms)
- Restore draft when re-entering channel
- Clear draft after message sent
- 7-day expiry for drafts

### 2. Image Preview for Attachments
- Click thumbnail to open full-screen viewer
- Support zoom, pan, and swipe to close (mobile)
- Download button in viewer

## Files Changed

### Web
- apps/web/src/hooks/use-draft-storage.ts (new)
- apps/web/src/components/chat/image-viewer.tsx (new)
- apps/web/src/components/chat/message-input.tsx (modified)

### Mobile
- apps/mobile/src/hooks/use-draft-storage.ts (new)
- apps/mobile/src/components/chat/chat-composer.tsx (modified)
- apps/mobile/app/(main)/servers/[serverSlug]/channels/[channelId].tsx (modified)

## Testing

- [x] Web build successful
- [x] Mobile build successful
- [x] biome lint passed