### PR TITLE
fix(admin): reset channel state when switching servers

### DIFF
--- a/apps/admin/src/pages/dashboard.tsx
+++ b/apps/admin/src/pages/dashboard.tsx
@@ -803,6 +803,8 @@ function DashboardContent() {
                           className="border-b border-zinc-800/50 hover:bg-zinc-800/30 cursor-pointer"
                           onClick={() => {
                             setSelectedServer(s)
+                            setSelectedChannel(null)
+                            setChannelMessages([])
                             loadServerChannels(s.id)
                           }}
                         >


### PR DESCRIPTION
## Bug Description
When switching servers in the admin dashboard, the right panel was still displaying the previous server's channel content instead of showing the new server's channel list.

## Root Cause
When clicking on a server in the server list, only setSelectedServer() was called, but selectedChannel and channelMessages states were not reset. This caused the UI to still render the old channel's messages.

## Fix
Reset selectedChannel to null and clear channelMessages array when a new server is selected.

## Changes
- Added setSelectedChannel(null) and setChannelMessages([]) in the server click handler

## Testing
- [ ] Switch from Server A (with Channel X selected) to Server B
- [ ] Verify right panel shows Server B's channel list instead of Channel X's messages