### PR TITLE
feat(cli): add @shadowob/cli for Shadow server management

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@shadowob/cli",
+  "version": "0.1.0",
+  "description": "Shadow CLI — command-line interface for Shadow servers",
+  "type": "module",
+  "bin": {
+    "shadowob": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --out-dir dist --clean",
+    "dev": "tsup src/index.ts --format esm --out-dir dist --clean --watch",
+    "lint": "biome lint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@shadowob/sdk": "workspace:*",
+    "commander": "^13.1.0",
+    "chalk": "^5.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.21",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -1,0 +1,200 @@
+import { Command } from 'commander'
+import { getClient } from '../utils/client.js'
+import { output, outputSuccess, outputError, type OutputOptions } from '../utils/output.js'
+
+export function createAgentsCommand(): Command {
+  const agents = new Command('agents').description('Agent management commands')
+
+  agents
+    .command('list')
+    .description('List your agents')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const agents = await client.listAgents()
+        output(agents, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  agents
+    .command('get')
+    .description('Get agent details')
+    .argument('<agent-id>', 'Agent ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const agent = await client.getAgent(agentId)
+        output(agent, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  agents
+    .command('create')
+    .description('Create a new agent')
+    .requiredOption('--name <name>', 'Agent name')
+    .option('--display-name <name>', 'Display name')
+    .option('--avatar-url <url>', 'Avatar URL')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (options: {
+        name: string
+        displayName?: string
+        avatarUrl?: string
+        profile?: string
+        json?: boolean
+      }) => {
+        try {
+          const client = await getClient(options.profile)
+          const agent = await client.createAgent({
+            name: options.name,
+            displayName: options.displayName,
+            avatarUrl: options.avatarUrl,
+          })
+          output(agent, { json: options.json })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  agents
+    .command('update')
+    .description('Update an agent')
+    .argument('<agent-id>', 'Agent ID')
+    .option('--name <name>', 'New name')
+    .option('--display-name <name>', 'New display name')
+    .option('--avatar-url <url>', 'New avatar URL')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        agentId: string,
+        options: {
+          name?: string
+          displayName?: string
+          avatarUrl?: string
+          profile?: string
+          json?: boolean
+        }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          const agent = await client.updateAgent(agentId, {
+            name: options.name,
+            displayName: options.displayName,
+            avatarUrl: options.avatarUrl,
+          })
+          output(agent, { json: options.json })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  agents
+    .command('delete')
+    .description('Delete an agent')
+    .argument('<agent-id>', 'Agent ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        await client.deleteAgent(agentId)
+        const outputOpts: OutputOptions = { json: options.json }
+        outputSuccess('Agent deleted', outputOpts)
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  agents
+    .command('start')
+    .description('Start an agent')
+    .argument('<agent-id>', 'Agent ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        await client.startAgent(agentId)
+        const outputOpts: OutputOptions = { json: options.json }
+        outputSuccess('Agent started', outputOpts)
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  agents
+    .command('stop')
+    .description('Stop an agent')
+    .argument('<agent-id>', 'Agent ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        await client.stopAgent(agentId)
+        const outputOpts: OutputOptions = { json: options.json }
+        outputSuccess('Agent stopped', outputOpts)
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  agents
+    .command('token')
+    .description('Generate a new token for an agent')
+    .argument('<agent-id>', 'Agent ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const result = await client.generateAgentToken(agentId)
+        if (options.json) {
+          output(result, { json: true })
+        } else {
+          console.log(result.token)
+        }
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  agents
+    .command('config')
+    .description('Get agent remote config')
+    .argument('<agent-id>', 'Agent ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const config = await client.getAgentConfig(agentId)
+        output(config, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  return agents
+}

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -1,0 +1,156 @@
+import { Command } from 'commander'
+import { configManager } from '../config/manager.js'
+import { output, outputSuccess, outputError, type OutputOptions } from '../utils/output.js'
+import { ShadowClient } from '@shadowob/sdk'
+
+export function createAuthCommand(): Command {
+  const auth = new Command('auth').description('Authentication commands')
+
+  auth
+    .command('login')
+    .description('Authenticate with a Shadow server')
+    .requiredOption('--server-url <url>', 'Shadow server URL')
+    .requiredOption('--token <token>', 'JWT token')
+    .option('--profile <name>', 'Profile name', 'default')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { serverUrl: string; token: string; profile: string; json?: boolean }) => {
+      try {
+        const client = new ShadowClient(options.serverUrl, options.token)
+        const user = await client.getMe()
+
+        await configManager.setProfile(options.profile, {
+          serverUrl: options.serverUrl,
+          token: options.token,
+        })
+        await configManager.switchProfile(options.profile)
+
+        const outputOpts: OutputOptions = { json: options.json }
+        if (options.json) {
+          output({ success: true, profile: options.profile, user }, outputOpts)
+        } else {
+          outputSuccess(`Logged in as ${user.username} (${options.profile})`, outputOpts)
+        }
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  auth
+    .command('logout')
+    .description('Remove a profile')
+    .option('--profile <name>', 'Profile name (default: current)')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { profile?: string; json?: boolean }) => {
+      try {
+        const profileName = options.profile ?? (await configManager.getCurrentProfileName())
+        if (!profileName) {
+          outputError('No profile specified and no current profile', { json: options.json })
+          process.exit(1)
+        }
+
+        const deleted = await configManager.deleteProfile(profileName)
+        if (!deleted) {
+          outputError(`Profile "${profileName}" not found`, { json: options.json })
+          process.exit(1)
+        }
+
+        const outputOpts: OutputOptions = { json: options.json }
+        outputSuccess(`Logged out (${profileName})`, outputOpts)
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  auth
+    .command('whoami')
+    .description('Show current user and profile')
+    .option('--profile <name>', 'Profile name (default: current)')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { profile?: string; json?: boolean }) => {
+      try {
+        const profileName = options.profile ?? (await configManager.getCurrentProfileName())
+        const profile = await configManager.getProfile(options.profile)
+
+        if (!profile) {
+          outputError(
+            profileName
+              ? `Profile "${profileName}" not found`
+              : 'Not authenticated. Run: shadowob auth login',
+            { json: options.json }
+          )
+          process.exit(1)
+        }
+
+        const client = new ShadowClient(profile.serverUrl, profile.token)
+        const user = await client.getMe()
+
+        const outputOpts: OutputOptions = { json: options.json }
+        if (options.json) {
+          output({ profile: profileName, user, serverUrl: profile.serverUrl }, outputOpts)
+        } else {
+          console.log(`Profile: ${profileName}`)
+          console.log(`Server:  ${profile.serverUrl}`)
+          console.log(`User:    ${user.username}`)
+          if (user.displayName && user.displayName !== user.username) {
+            console.log(`Name:    ${user.displayName}`)
+          }
+        }
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  auth
+    .command('switch')
+    .description('Switch to a different profile')
+    .argument('<profile>', 'Profile name')
+    .option('--json', 'Output as JSON')
+    .action(async (profileName: string, options: { json?: boolean }) => {
+      try {
+        const switched = await configManager.switchProfile(profileName)
+        if (!switched) {
+          outputError(`Profile "${profileName}" not found`, { json: options.json })
+          process.exit(1)
+        }
+
+        const outputOpts: OutputOptions = { json: options.json }
+        outputSuccess(`Switched to profile: ${profileName}`, outputOpts)
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  auth
+    .command('list')
+    .description('List all profiles')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { json?: boolean }) => {
+      try {
+        const profiles = await configManager.listProfiles()
+        const current = await configManager.getCurrentProfileName()
+
+        const outputOpts: OutputOptions = { json: options.json }
+        if (options.json) {
+          output({ profiles, current }, outputOpts)
+        } else {
+          if (profiles.length === 0) {
+            console.log('No profiles. Run: shadowob auth login')
+            return
+          }
+          for (const name of profiles) {
+            const marker = name === current ? '* ' : '  '
+            console.log(`${marker}${name}`)
+          }
+        }
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  return auth
+}

--- a/apps/cli/src/commands/channels.ts
+++ b/apps/cli/src/commands/channels.ts
@@ -1,0 +1,322 @@
+import { Command } from 'commander'
+import { getClient } from '../utils/client.js'
+import { output, outputSuccess, outputError, type OutputOptions } from '../utils/output.js'
+
+export function createChannelsCommand(): Command {
+  const channels = new Command('channels').description('Channel commands')
+
+  channels
+    .command('list')
+    .description('List channels in a server')
+    .requiredOption('--server-id <id>', 'Server ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { serverId: string; profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const channels = await client.getServerChannels(options.serverId)
+        output(channels, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  channels
+    .command('get')
+    .description('Get channel details')
+    .argument('<channel-id>', 'Channel ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (channelId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const channel = await client.getChannel(channelId)
+        output(channel, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  channels
+    .command('create')
+    .description('Create a channel')
+    .requiredOption('--server-id <id>', 'Server ID')
+    .requiredOption('--name <name>', 'Channel name')
+    .option('--type <type>', 'Channel type', 'text')
+    .option('--description <desc>', 'Channel description')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (options: {
+        serverId: string
+        name: string
+        type?: string
+        description?: string
+        profile?: string
+        json?: boolean
+      }) => {
+        try {
+          const client = await getClient(options.profile)
+          const channel = await client.createChannel(options.serverId, {
+            name: options.name,
+            type: options.type,
+            description: options.description,
+          })
+          output(channel, { json: options.json })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  channels
+    .command('delete')
+    .description('Delete a channel')
+    .argument('<channel-id>', 'Channel ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (channelId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        await client.deleteChannel(channelId)
+        const outputOpts: OutputOptions = { json: options.json }
+        outputSuccess('Channel deleted', outputOpts)
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  // Messages subcommand
+  channels
+    .command('messages')
+    .description('List messages in a channel')
+    .argument('<channel-id>', 'Channel ID')
+    .option('--limit <n>', 'Number of messages', '50')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        channelId: string,
+        options: { limit?: string; cursor?: string; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          const result = await client.getMessages(
+            channelId,
+            parseInt(options.limit ?? '50'),
+            options.cursor
+          )
+          output(result.messages, { json: options.json })
+          if (!options.json && result.hasMore) {
+            console.log('(has more messages)')
+          }
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  // Send message
+  channels
+    .command('send')
+    .description('Send a message to a channel')
+    .argument('<channel-id>', 'Channel ID')
+    .requiredOption('--content <text>', 'Message content')
+    .option('--reply-to <id>', 'Reply to message ID')
+    .option('--thread-id <id>', 'Send to thread')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        channelId: string,
+        options: {
+          content: string
+          replyTo?: string
+          threadId?: string
+          profile?: string
+          json?: boolean
+        }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          const message = await client.sendMessage(channelId, options.content, {
+            replyToId: options.replyTo,
+            threadId: options.threadId,
+          })
+          output(message, { json: options.json })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  // Edit message
+  channels
+    .command('edit')
+    .description('Edit a message')
+    .argument('<message-id>', 'Message ID')
+    .requiredOption('--content <text>', 'New content')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        messageId: string,
+        options: { content: string; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          const message = await client.editMessage(messageId, options.content)
+          output(message, { json: options.json })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  // Delete message
+  channels
+    .command('delete-message')
+    .description('Delete a message')
+    .argument('<message-id>', 'Message ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (messageId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        await client.deleteMessage(messageId)
+        const outputOpts: OutputOptions = { json: options.json }
+        outputSuccess('Message deleted', outputOpts)
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  // React to message
+  channels
+    .command('react')
+    .description('Add a reaction to a message')
+    .argument('<message-id>', 'Message ID')
+    .requiredOption('--emoji <emoji>', 'Emoji to react with')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        messageId: string,
+        options: { emoji: string; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          await client.addReaction(messageId, options.emoji)
+          const outputOpts: OutputOptions = { json: options.json }
+          outputSuccess('Reaction added', outputOpts)
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  // Unreact to message
+  channels
+    .command('unreact')
+    .description('Remove a reaction from a message')
+    .argument('<message-id>', 'Message ID')
+    .requiredOption('--emoji <emoji>', 'Emoji to remove')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        messageId: string,
+        options: { emoji: string; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          await client.removeReaction(messageId, options.emoji)
+          const outputOpts: OutputOptions = { json: options.json }
+          outputSuccess('Reaction removed', outputOpts)
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  // Pin message
+  channels
+    .command('pin')
+    .description('Pin a message')
+    .argument('<message-id>', 'Message ID')
+    .option('--channel-id <id>', 'Channel ID (if not in channel context)')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        messageId: string,
+        options: { channelId?: string; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          await client.pinMessage(messageId, options.channelId)
+          const outputOpts: OutputOptions = { json: options.json }
+          outputSuccess('Message pinned', outputOpts)
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  // Unpin message
+  channels
+    .command('unpin')
+    .description('Unpin a message')
+    .argument('<message-id>', 'Message ID')
+    .option('--channel-id <id>', 'Channel ID (if not in channel context)')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        messageId: string,
+        options: { channelId?: string; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          await client.unpinMessage(messageId, options.channelId)
+          const outputOpts: OutputOptions = { json: options.json }
+          outputSuccess('Message unpinned', outputOpts)
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  // List pinned messages
+  channels
+    .command('pinned')
+    .description('List pinned messages in a channel')
+    .argument('<channel-id>', 'Channel ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (channelId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const messages = await client.getPinnedMessages(channelId)
+        output(messages, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  return channels
+}

--- a/apps/cli/src/commands/listen.ts
+++ b/apps/cli/src/commands/listen.ts
@@ -1,0 +1,246 @@
+import { Command } from 'commander'
+import { getSocket } from '../utils/client.js'
+import { output, outputError } from '../utils/output.js'
+import type { ServerEventMap } from '@shadowob/sdk'
+
+export function createListenCommand(): Command {
+  const listen = new Command('listen').description('Listen to real-time events')
+
+  listen
+    .command('channel')
+    .description('Listen to events in a channel')
+    .argument('<channel-id>', 'Channel ID')
+    .option('--mode <mode>', 'Listen mode: stream or poll', 'stream')
+    .option('--timeout <seconds>', 'Timeout in seconds (stream mode)', '60')
+    .option('--count <n>', 'Stop after N events (stream mode)')
+    .option('--since <duration>', 'Poll events since duration (e.g., 5m, 1h)', '5m')
+    .option('--last <n>', 'Poll last N messages', '50')
+    .option('--event-type <type>', 'Filter by event type (comma-separated)')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON (one per line)')
+    .action(
+      async (
+        channelId: string,
+        options: {
+          mode: string
+          timeout?: string
+          count?: string
+          since?: string
+          last?: string
+          eventType?: string
+          profile?: string
+          json?: boolean
+        }
+      ) => {
+        try {
+          const eventTypes = options.eventType?.split(',').map((t) => t.trim())
+
+          if (options.mode === 'poll') {
+            // Poll mode: fetch recent messages and exit
+            const { getClient } = await import('../utils/client.js')
+            const client = await getClient(options.profile)
+            const limit = parseInt(options.last ?? '50')
+            const result = await client.getMessages(channelId, limit)
+
+            if (options.json) {
+              for (const msg of result.messages) {
+                console.log(JSON.stringify({ type: 'message:new', data: msg }))
+              }
+            } else {
+              for (const msg of result.messages) {
+                console.log(`[${msg.createdAt}] ${msg.author?.username ?? 'unknown'}: ${msg.content}`)
+              }
+            }
+            return
+          }
+
+          // Stream mode: connect via WebSocket and listen
+          const socket = await getSocket(options.profile)
+          const timeoutMs = parseInt(options.timeout ?? '60') * 1000
+          const maxCount = options.count ? parseInt(options.count) : undefined
+
+          let count = 0
+          let timeoutId: NodeJS.Timeout | undefined
+
+          const cleanup = () => {
+            if (timeoutId) clearTimeout(timeoutId)
+            socket.disconnect()
+          }
+
+          // Set up timeout
+          timeoutId = setTimeout(() => {
+            if (!options.json) {
+              console.error('(timeout reached)')
+            }
+            cleanup()
+            process.exit(0)
+          }, timeoutMs)
+
+          // Handle events
+          const shouldOutput = (eventType: string) => {
+            if (!eventTypes) return true
+            return eventTypes.includes(eventType)
+          }
+
+          const outputEvent = (type: string, data: unknown) => {
+            if (!shouldOutput(type)) return
+
+            count++
+            if (options.json) {
+              console.log(JSON.stringify({ type, data, timestamp: new Date().toISOString() }))
+            } else {
+              const timestamp = new Date().toLocaleTimeString()
+              if (type === 'message:new') {
+                const msg = data as { author?: { username?: string }; content?: string }
+                console.log(`[${timestamp}] ${msg.author?.username ?? 'unknown'}: ${msg.content ?? ''}`)
+              } else {
+                console.log(`[${timestamp}] ${type}:`, JSON.stringify(data))
+              }
+            }
+
+            if (maxCount && count >= maxCount) {
+              cleanup()
+              process.exit(0)
+            }
+          }
+
+          // Register event handlers
+          socket.on('message:new', ((msg: ServerEventMap['message:new']) => {
+            if (msg.channelId === channelId) {
+              outputEvent('message:new', msg)
+            }
+          }) as ServerEventMap['message:new'])
+
+          socket.on('message:updated', ((msg: ServerEventMap['message:updated']) => {
+            if (msg.channelId === channelId) {
+              outputEvent('message:updated', msg)
+            }
+          }) as ServerEventMap['message:updated'])
+
+          socket.on('message:deleted', ((payload: ServerEventMap['message:deleted']) => {
+            if (payload.channelId === channelId) {
+              outputEvent('message:deleted', payload)
+            }
+          }) as ServerEventMap['message:deleted'])
+
+          socket.on('reaction:add', ((payload: ServerEventMap['reaction:add']) => {
+            outputEvent('reaction:add', payload)
+          }) as ServerEventMap['reaction:add'])
+
+          socket.on('reaction:remove', ((payload: ServerEventMap['reaction:remove']) => {
+            outputEvent('reaction:remove', payload)
+          }) as ServerEventMap['reaction:remove'])
+
+          socket.on('member:typing', ((payload: ServerEventMap['member:typing']) => {
+            if (payload.channelId === channelId) {
+              outputEvent('member:typing', payload)
+            }
+          }) as ServerEventMap['member:typing'])
+
+          socket.on('member:join', ((payload: ServerEventMap['member:join']) => {
+            if (payload.channelId === channelId) {
+              outputEvent('member:join', payload)
+            }
+          }) as ServerEventMap['member:join'])
+
+          socket.on('member:leave', ((payload: ServerEventMap['member:leave']) => {
+            if (payload.channelId === channelId) {
+              outputEvent('member:leave', payload)
+            }
+          }) as ServerEventMap['member:leave'])
+
+          // Connect and join channel
+          socket.connect()
+          await socket.waitForConnect(5000)
+          await socket.joinChannel(channelId)
+
+          if (!options.json) {
+            console.error(`(listening to channel ${channelId}, timeout: ${timeoutMs}ms)`)
+          }
+
+          // Keep process alive
+          await new Promise(() => {
+            // Never resolves, waits for timeout or signal
+          })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  listen
+    .command('dm')
+    .description('Listen to DM events')
+    .argument('<dm-channel-id>', 'DM Channel ID')
+    .option('--timeout <seconds>', 'Timeout in seconds', '60')
+    .option('--count <n>', 'Stop after N events')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON (one per line)')
+    .action(
+      async (
+        dmChannelId: string,
+        options: {
+          timeout?: string
+          count?: string
+          profile?: string
+          json?: boolean
+        }
+      ) => {
+        try {
+          const socket = await getSocket(options.profile)
+          const timeoutMs = parseInt(options.timeout ?? '60') * 1000
+          const maxCount = options.count ? parseInt(options.count) : undefined
+
+          let count = 0
+          let timeoutId: NodeJS.Timeout | undefined
+
+          const cleanup = () => {
+            if (timeoutId) clearTimeout(timeoutId)
+            socket.disconnect()
+          }
+
+          timeoutId = setTimeout(() => {
+            cleanup()
+            process.exit(0)
+          }, timeoutMs)
+
+          socket.on('dm:message:new', ((msg: ServerEventMap['dm:message:new']) => {
+            if (msg.dmChannelId !== dmChannelId) return
+
+            count++
+            if (options.json) {
+              console.log(JSON.stringify({ type: 'dm:message:new', data: msg }))
+            } else {
+              const timestamp = new Date(msg.createdAt).toLocaleTimeString()
+              console.log(`[${timestamp}] ${msg.author?.username ?? 'unknown'}: ${msg.content}`)
+            }
+
+            if (maxCount && count >= maxCount) {
+              cleanup()
+              process.exit(0)
+            }
+          }) as ServerEventMap['dm:message:new'])
+
+          // Connect and join DM channel
+          socket.connect()
+          await socket.waitForConnect(5000)
+          socket.joinDmChannel(dmChannelId)
+
+          if (!options.json) {
+            console.error(`(listening to DM channel ${dmChannelId}, timeout: ${timeoutMs}ms)`)
+          }
+
+          // Keep process alive
+          await new Promise(() => {
+            // Never resolves, waits for timeout or signal
+          })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  return listen
+}

--- a/apps/cli/src/commands/servers.ts
+++ b/apps/cli/src/commands/servers.ts
@@ -1,0 +1,209 @@
+import { Command } from 'commander'
+import { getClient } from '../utils/client.js'
+import { output, outputSuccess, outputError, type OutputOptions } from '../utils/output.js'
+
+export function createServersCommand(): Command {
+  const servers = new Command('servers').description('Server management commands')
+
+  servers
+    .command('list')
+    .description('List all servers you have joined')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const servers = await client.listServers()
+        output(servers, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  servers
+    .command('get')
+    .description('Get server details')
+    .argument('<server-id>', 'Server ID or slug')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (serverId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const server = await client.getServer(serverId)
+        output(server, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  servers
+    .command('create')
+    .description('Create a new server')
+    .requiredOption('--name <name>', 'Server name')
+    .option('--slug <slug>', 'Server slug')
+    .option('--description <desc>', 'Server description')
+    .option('--public', 'Make server public')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (options: {
+        name: string
+        slug?: string
+        description?: string
+        public?: boolean
+        profile?: string
+        json?: boolean
+      }) => {
+        try {
+          const client = await getClient(options.profile)
+          const server = await client.createServer({
+            name: options.name,
+            slug: options.slug,
+            description: options.description,
+            isPublic: options.public,
+          })
+          output(server, { json: options.json })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  servers
+    .command('join')
+    .description('Join a server')
+    .argument('<server-id>', 'Server ID or slug')
+    .option('--invite-code <code>', 'Invite code (if required)')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        serverId: string,
+        options: { inviteCode?: string; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          const result = await client.joinServer(serverId, options.inviteCode)
+          const outputOpts: OutputOptions = { json: options.json }
+          if (options.json) {
+            output(result, outputOpts)
+          } else {
+            outputSuccess('Joined server', outputOpts)
+          }
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  servers
+    .command('leave')
+    .description('Leave a server')
+    .argument('<server-id>', 'Server ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (serverId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        await client.leaveServer(serverId)
+        const outputOpts: OutputOptions = { json: options.json }
+        outputSuccess('Left server', outputOpts)
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  servers
+    .command('members')
+    .description('List server members')
+    .argument('<server-id>', 'Server ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (serverId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const members = await client.getMembers(serverId)
+        output(members, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  servers
+    .command('homepage')
+    .description('Get or set server homepage')
+    .argument('<server-id>', 'Server ID or slug')
+    .option('--set <file>', 'Set homepage from HTML file (use "-" for stdin)')
+    .option('--clear', 'Clear homepage (reset to default)')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        serverId: string,
+        options: { set?: string; clear?: boolean; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+
+          if (options.clear) {
+            const result = await client.updateServerHomepage(serverId, null)
+            output(result, { json: options.json })
+            return
+          }
+
+          if (options.set) {
+            let html: string
+            if (options.set === '-') {
+              // Read from stdin
+              const chunks: Buffer[] = []
+              for await (const chunk of process.stdin) {
+                chunks.push(Buffer.from(chunk))
+              }
+              html = Buffer.concat(chunks).toString('utf-8')
+            } else {
+              const { readFile } = await import('node:fs/promises')
+              html = await readFile(options.set, 'utf-8')
+            }
+            const result = await client.updateServerHomepage(serverId, html)
+            output(result, { json: options.json })
+            return
+          }
+
+          // Get homepage
+          const server = await client.getServer(serverId)
+          if (options.json) {
+            output({ homepageHtml: server.homepageHtml }, { json: true })
+          } else {
+            console.log(server.homepageHtml ?? '(default homepage)')
+          }
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  servers
+    .command('discover')
+    .description('Discover public servers')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const servers = await client.discoverServers()
+        output(servers, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  return servers
+}

--- a/apps/cli/src/commands/threads.ts
+++ b/apps/cli/src/commands/threads.ts
@@ -1,0 +1,141 @@
+import { Command } from 'commander'
+import { getClient } from '../utils/client.js'
+import { output, outputSuccess, outputError, type OutputOptions } from '../utils/output.js'
+
+export function createThreadsCommand(): Command {
+  const threads = new Command('threads').description('Thread commands')
+
+  threads
+    .command('list')
+    .description('List threads in a channel')
+    .argument('<channel-id>', 'Channel ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (channelId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const threads = await client.listThreads(channelId)
+        output(threads, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  threads
+    .command('get')
+    .description('Get thread details')
+    .argument('<thread-id>', 'Thread ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (threadId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        const thread = await client.getThread(threadId)
+        output(thread, { json: options.json })
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  threads
+    .command('create')
+    .description('Create a thread')
+    .argument('<channel-id>', 'Channel ID')
+    .requiredOption('--name <name>', 'Thread name')
+    .requiredOption('--parent-message <id>', 'Parent message ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        channelId: string,
+        options: {
+          name: string
+          parentMessage: string
+          profile?: string
+          json?: boolean
+        }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          const thread = await client.createThread(channelId, options.name, options.parentMessage)
+          output(thread, { json: options.json })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  threads
+    .command('delete')
+    .description('Delete a thread')
+    .argument('<thread-id>', 'Thread ID')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(async (threadId: string, options: { profile?: string; json?: boolean }) => {
+      try {
+        const client = await getClient(options.profile)
+        await client.deleteThread(threadId)
+        const outputOpts: OutputOptions = { json: options.json }
+        outputSuccess('Thread deleted', outputOpts)
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+        process.exit(1)
+      }
+    })
+
+  threads
+    .command('messages')
+    .description('List messages in a thread')
+    .argument('<thread-id>', 'Thread ID')
+    .option('--limit <n>', 'Number of messages', '50')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        threadId: string,
+        options: { limit?: string; cursor?: string; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          const messages = await client.getThreadMessages(
+            threadId,
+            parseInt(options.limit ?? '50'),
+            options.cursor
+          )
+          output(messages, { json: options.json })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  threads
+    .command('send')
+    .description('Send a message to a thread')
+    .argument('<thread-id>', 'Thread ID')
+    .requiredOption('--content <text>', 'Message content')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        threadId: string,
+        options: { content: string; profile?: string; json?: boolean }
+      ) => {
+        try {
+          const client = await getClient(options.profile)
+          const message = await client.sendToThread(threadId, options.content)
+          output(message, { json: options.json })
+        } catch (error) {
+          outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+          process.exit(1)
+        }
+      }
+    )
+
+  return threads
+}

--- a/apps/cli/src/config/manager.ts
+++ b/apps/cli/src/config/manager.ts
@@ -1,0 +1,93 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export interface Profile {
+  serverUrl: string
+  token: string
+}
+
+export interface Config {
+  profiles: Record<string, Profile>
+  currentProfile?: string
+}
+
+const CONFIG_DIR = join(homedir(), '.shadowob')
+const CONFIG_FILE = join(CONFIG_DIR, 'shadowob.config.json')
+
+export class ConfigManager {
+  private config: Config | null = null
+
+  private async load(): Promise<Config> {
+    if (this.config) return this.config
+
+    if (!existsSync(CONFIG_FILE)) {
+      this.config = { profiles: {} }
+      return this.config
+    }
+
+    try {
+      const content = await readFile(CONFIG_FILE, 'utf-8')
+      this.config = JSON.parse(content) as Config
+      return this.config
+    } catch {
+      this.config = { profiles: {} }
+      return this.config
+    }
+  }
+
+  private async save(): Promise<void> {
+    if (!this.config) return
+    await mkdir(CONFIG_DIR, { recursive: true })
+    await writeFile(CONFIG_FILE, JSON.stringify(this.config, null, 2))
+  }
+
+  async getProfile(name?: string): Promise<Profile | null> {
+    const config = await this.load()
+    const profileName = name ?? config.currentProfile
+    if (!profileName) return null
+    return config.profiles[profileName] ?? null
+  }
+
+  async getCurrentProfileName(): Promise<string | null> {
+    const config = await this.load()
+    return config.currentProfile ?? null
+  }
+
+  async setProfile(name: string, profile: Profile): Promise<void> {
+    const config = await this.load()
+    config.profiles[name] = profile
+    await this.save()
+  }
+
+  async deleteProfile(name: string): Promise<boolean> {
+    const config = await this.load()
+    if (!config.profiles[name]) return false
+    delete config.profiles[name]
+    if (config.currentProfile === name) {
+      delete config.currentProfile
+    }
+    await this.save()
+    return true
+  }
+
+  async switchProfile(name: string): Promise<boolean> {
+    const config = await this.load()
+    if (!config.profiles[name]) return false
+    config.currentProfile = name
+    await this.save()
+    return true
+  }
+
+  async listProfiles(): Promise<string[]> {
+    const config = await this.load()
+    return Object.keys(config.profiles)
+  }
+
+  getConfigPath(): string {
+    return CONFIG_FILE
+  }
+}
+
+export const configManager = new ConfigManager()

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { Command } from 'commander'
+import { createAuthCommand } from './commands/auth.js'
+import { createServersCommand } from './commands/servers.js'
+import { createChannelsCommand } from './commands/channels.js'
+import { createThreadsCommand } from './commands/threads.js'
+import { createAgentsCommand } from './commands/agents.js'
+import { createListenCommand } from './commands/listen.js'
+import { configManager } from './config/manager.js'
+
+const program = new Command()
+
+program
+  .name('shadowob')
+  .description('Shadow CLI — command-line interface for Shadow servers')
+  .version('0.1.0')
+  .configureHelp({
+    sortSubcommands: true,
+  })
+
+// Global options
+program.option('--profile <name>', 'Profile to use (default: current)')
+
+// Commands
+program.addCommand(createAuthCommand())
+program.addCommand(createServersCommand())
+program.addCommand(createChannelsCommand())
+program.addCommand(createThreadsCommand())
+program.addCommand(createAgentsCommand())
+program.addCommand(createListenCommand())
+
+// Config command
+program
+  .command('config')
+  .description('Show configuration file path')
+  .action(() => {
+    console.log(configManager.getConfigPath())
+  })
+
+program.parse()

--- a/apps/cli/src/utils/client.ts
+++ b/apps/cli/src/utils/client.ts
@@ -1,0 +1,33 @@
+import { ShadowClient, ShadowSocket } from '@shadowob/sdk'
+import { configManager } from '../config/manager.js'
+
+export async function getClient(profile?: string): Promise<ShadowClient> {
+  const config = await configManager.getProfile(profile)
+  if (!config) {
+    throw new Error(
+      profile
+        ? `Profile "${profile}" not found. Run: shadowob auth login --profile ${profile}`
+        : 'Not authenticated. Run: shadowob auth login'
+    )
+  }
+  return new ShadowClient(config.serverUrl, config.token)
+}
+
+export async function getSocket(profile?: string): Promise<ShadowSocket> {
+  const config = await configManager.getProfile(profile)
+  if (!config) {
+    throw new Error(
+      profile
+        ? `Profile "${profile}" not found. Run: shadowob auth login --profile ${profile}`
+        : 'Not authenticated. Run: shadowob auth login'
+    )
+  }
+  return new ShadowSocket({ serverUrl: config.serverUrl, token: config.token })
+}
+
+export function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}

--- a/apps/cli/src/utils/output.ts
+++ b/apps/cli/src/utils/output.ts
@@ -1,0 +1,102 @@
+import chalk from 'chalk'
+
+export interface OutputOptions {
+  json?: boolean
+}
+
+export function output(data: unknown, options: OutputOptions): void {
+  if (options.json) {
+    console.log(JSON.stringify(data, null, 2))
+    return
+  }
+
+  if (data === null || data === undefined) {
+    return
+  }
+
+  if (typeof data === 'string') {
+    console.log(data)
+    return
+  }
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      console.log(chalk.gray('No results'))
+      return
+    }
+    formatArray(data)
+    return
+  }
+
+  if (typeof data === 'object') {
+    formatObject(data as Record<string, unknown>)
+    return
+  }
+
+  console.log(String(data))
+}
+
+export function outputError(message: string, options: OutputOptions): void {
+  if (options.json) {
+    console.log(JSON.stringify({ error: message }, null, 2))
+    return
+  }
+  console.error(chalk.red(`Error: ${message}`))
+}
+
+export function outputSuccess(message: string, options: OutputOptions): void {
+  if (options.json) {
+    console.log(JSON.stringify({ success: true, message }, null, 2))
+    return
+  }
+  console.log(chalk.green(message))
+}
+
+function formatArray(items: unknown[]): void {
+  if (items.length === 0) return
+
+  const first = items[0]
+  if (typeof first !== 'object' || first === null) {
+    items.forEach((item) => console.log(String(item)))
+    return
+  }
+
+  // Format as table-like list
+  const keys = Object.keys(first as Record<string, unknown>)
+  const idKey = keys.find((k) => k === 'id') || keys[0]
+  const nameKey = keys.find((k) => k === 'name' || k === 'username' || k === 'slug') || keys[1] || idKey
+
+  for (const item of items) {
+    const obj = item as Record<string, unknown>
+    const id = String(obj[idKey] ?? '')
+    const name = String(obj[nameKey] ?? '')
+
+    if (name && name !== id) {
+      console.log(`${chalk.cyan(id)}  ${name}`)
+    } else {
+      console.log(chalk.cyan(id))
+    }
+  }
+}
+
+function formatObject(obj: Record<string, unknown>): void {
+  const entries = Object.entries(obj)
+  const maxKeyLength = Math.max(...entries.map(([k]) => k.length))
+
+  for (const [key, value] of entries) {
+    const formattedKey = key.padEnd(maxKeyLength)
+    let formattedValue: string
+
+    if (value === null || value === undefined) {
+      formattedValue = chalk.gray('null')
+    } else if (typeof value === 'boolean') {
+      formattedValue = value ? chalk.green('true') : chalk.red('false')
+    } else if (typeof value === 'object') {
+      formattedValue = JSON.stringify(value)
+    } else {
+      formattedValue = String(value)
+    }
+
+    console.log(`${chalk.gray(formattedKey)}  ${formattedValue}`)
+  }
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "ShadowOwnBuddy",
   "description": "Shadow server channel plugin — enables AI agents to chat in Shadow channels with threads, reactions, and media support",
   "channels": ["shadowob"],
-  "skills": ["skills/shadow-server"],
+  "skills": ["skills/shadowob"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/packages/openclaw/skills/shadowob/SKILL.md
+++ b/packages/openclaw/skills/shadowob/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: shadowob
+description: "Shadow server CLI — manage servers, channels, messages, agents, and listen to real-time events via shadowob CLI"
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🏠",
+        "requires": { "bins": ["shadowob"] },
+        "primaryEnv": "SHADOWOB_TOKEN",
+      },
+  }
+---
+allowed-tools: ["exec"]
+
+# Shadow CLI
+
+Use `shadowob` CLI to interact with Shadow servers.
+
+## Quickstart
+
+```bash
+# Login (one-time setup)
+shadowob auth login --server-url https://shadowob.com --token <jwt>
+
+# List servers
+shadowob servers list --json
+
+# Send a message
+shadowob channels send <channel-id> --content "Hello" --json
+```
+
+## Authentication
+
+Set token via:
+1. `shadowob auth login` (persistent, stored in `~/.shadowob/shadowob.config.json`)
+2. `--profile <name>` to use a specific profile
+3. `SHADOWOB_TOKEN` env var (used by SDK directly)
+
+### Profile Commands
+
+```bash
+shadowob auth login --server-url <url> --token <token> --profile <name>
+shadowob auth switch <profile>
+shadowob auth list
+shadowob auth whoami
+shadowob auth logout --profile <name>
+```
+
+## Servers
+
+```bash
+# List joined servers
+shadowob servers list --json
+
+# Get server details
+shadowob servers get <server-id> --json
+
+# Create server
+shadowob servers create --name "My Server" --slug myserver --json
+
+# Join/Leave
+shadowob servers join <server-id> [--invite-code <code>]
+shadowob servers leave <server-id>
+
+# Members
+shadowob servers members <server-id> --json
+
+# Homepage
+shadowob servers homepage <server-id>
+shadowob servers homepage <server-id> --set <file.html>
+shadowob servers homepage <server-id> --clear
+
+# Discover public servers
+shadowob servers discover --json
+```
+
+## Channels
+
+```bash
+# List channels
+shadowob channels list --server-id <server-id> --json
+
+# Get channel
+shadowob channels get <channel-id> --json
+
+# Create/Delete
+shadowob channels create --server-id <id> --name <name> [--type text] --json
+shadowob channels delete <channel-id>
+
+# Messages
+shadowob channels messages <channel-id> [--limit 50] [--cursor <cursor>] --json
+shadowob channels send <channel-id> --content "text" [--reply-to <id>] [--thread-id <id>] --json
+shadowob channels edit <message-id> --content "new text" --json
+shadowob channels delete-message <message-id>
+
+# Reactions
+shadowob channels react <message-id> --emoji 👍
+shadowob channels unreact <message-id> --emoji 👍
+
+# Pins
+shadowob channels pin <message-id> [--channel-id <id>]
+shadowob channels unpin <message-id> [--channel-id <id>]
+shadowob channels pinned <channel-id> --json
+```
+
+## Threads
+
+```bash
+# List threads
+shadowob threads list <channel-id> --json
+
+# Get thread
+shadowob threads get <thread-id> --json
+
+# Create/Delete
+shadowob threads create <channel-id> --name <name> --parent-message <id> --json
+shadowob threads delete <thread-id>
+
+# Messages
+shadowob threads messages <thread-id> [--limit 50] --json
+shadowob threads send <thread-id> --content "text" --json
+```
+
+## Agents
+
+```bash
+# List agents
+shadowob agents list --json
+
+# Get agent
+shadowob agents get <agent-id> --json
+
+# Create/Update/Delete
+shadowob agents create --name <name> [--display-name <name>] [--avatar-url <url>] --json
+shadowob agents update <agent-id> [--name <name>] [--display-name <name>] --json
+shadowob agents delete <agent-id>
+
+# Control
+shadowob agents start <agent-id>
+shadowob agents stop <agent-id>
+
+# Token
+shadowob agents token <agent-id> --json
+
+# Config
+shadowob agents config <agent-id> --json
+```
+
+## Listen (Real-time Events)
+
+```bash
+# Stream mode: listen until timeout or count
+shadowob listen channel <channel-id> --mode stream [--timeout 60] [--count 10] --json
+
+# Poll mode: fetch recent messages
+shadowob listen channel <channel-id> --mode poll [--last 50] --json
+
+# Filter events
+shadowob listen channel <id> --event-type message:new,reaction:add --json
+
+# DM events
+shadowob listen dm <dm-channel-id> [--timeout 60] --json
+```
+
+## Output Format
+
+- Default: human-readable list format
+- `--json`: JSON output for programmatic use
+
+## Error Handling
+
+Commands exit with code 1 on error. Use `--json` to get structured errors:
+
+```json
+{ "error": "message" }
+```

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,17 +3,27 @@
   "version": "0.2.3",
   "description": "Shadow SDK — typed REST client and real-time Socket.IO event listener for Shadow servers",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
+  "files": ["dist"],
   "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
     "@shadowob/shared": "workspace:*",
     "socket.io-client": "^4.8.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  outDir: 'dist',
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,19 +2,38 @@
   "name": "@shadowob/shared",
   "version": "0.1.2",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./types": "./src/types/index.ts",
-    "./constants": "./src/constants/index.ts",
-    "./utils": "./src/utils/index.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./types": {
+      "import": "./dist/types/index.js",
+      "types": "./dist/types/index.d.ts"
+    },
+    "./constants": {
+      "import": "./dist/constants/index.js",
+      "types": "./dist/constants/index.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts"
+    }
   },
+  "files": ["dist"],
   "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
     "nanoid": "^5.1.7"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/types/index.ts', 'src/constants/index.ts', 'src/utils/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  outDir: 'dist',
+})


### PR DESCRIPTION
## Summary

Add comprehensive CLI tool for Shadow server operations, replacing the limited shadow-server skill with a full-featured shadowob skill for OpenClaw.

## Changes

### New CLI Package (apps/cli)

Authentication, servers, channels, threads, agents, and real-time event listening commands.

### Build Configuration

Added tsup configs to packages/sdk and packages/shared for proper ESM distribution.

### OpenClaw Integration

New skill: packages/openclaw/skills/shadowob/SKILL.md

## Features

- Multi-profile support
- JSON output mode
- Real-time event listening via Socket.IO

## Testing


> shadow@ build /Users/maopeng/Projects/shadow/.research/shadow-cli
> pnpm -r build

Scope: 12 of 13 workspace projects
packages/shared build$ tsup
website build$ rspress build
website build: sh: rspress: command not found
packages/shared build: sh: tsup: command not found
/Users/maopeng/Projects/shadow/.research/shadow-cli/website:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @shadowob/website@0.1.0 build: `rspress build`
spawn ENOENT
 WARN   Local package.json exists, but node_modules missing, did you mean to install?
 WARN   Local package.json exists, but node_modules missing, did you mean to install?
 ELIFECYCLE  Command failed with exit code 1.
 WARN   Local package.json exists, but node_modules missing, did you mean to install?