### PR TITLE
feat(mobile): move private channel toggle to same row as channel type

### DIFF
--- a/apps/mobile/app/(main)/servers/[serverSlug]/create-channel.tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/create-channel.tsx
@@ -7,6 +7,7 @@ import {
   CircleAlert,
   Hash,
   Layers3,
+  Lock,
   Megaphone,
   Search,
   Sparkles,
@@ -89,6 +90,7 @@ export default function CreateChannelScreen() {
 
   const [channelName, setChannelName] = useState('')
   const [channelType, setChannelType] = useState<ChannelType>('text')
+  const [isPrivate, setIsPrivate] = useState(false)
   const [categoryId, setCategoryId] = useState<string | null>(null)
   const [memberSearch, setMemberSearch] = useState('')
   const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set())
@@ -289,7 +291,7 @@ export default function CreateChannelScreen() {
       const finalName = channelName.trim() || generateChannelName()
       const channel = await fetchApi<{ id: string }>(`/api/servers/${server.id}/channels`, {
         method: 'POST',
-        body: JSON.stringify({ name: finalName, type: channelType, categoryId }),
+        body: JSON.stringify({ name: finalName, type: channelType, categoryId, isPrivate }),
       })
 
       const memberPromises = Array.from(selectedMembers).map((userId) =>
@@ -459,6 +461,51 @@ export default function CreateChannelScreen() {
               )
             })}
           </ScrollView>
+        </View>
+
+        <View style={styles.section}>
+          <Pressable
+            style={[
+              styles.privateToggle,
+              {
+                backgroundColor: colors.surface,
+                borderColor: colors.border,
+              },
+            ]}
+            onPress={() => setIsPrivate(!isPrivate)}
+          >
+            <View style={styles.privateToggleLeft}>
+              <View style={[styles.privateIconWrap, { backgroundColor: colors.inputBackground }]}>
+                <Lock size={16} color={isPrivate ? colors.primary : colors.textSecondary} />
+              </View>
+              <View style={styles.privateTextWrap}>
+                <Text style={[styles.privateLabel, { color: colors.text }]}>
+                  {t('channel.privateChannel', '私有频道')}
+                </Text>
+                <Text style={[styles.privateDesc, { color: colors.textMuted }]}>
+                  {t('channel.privateChannelDesc', '仅受邀成员可加入')}
+                </Text>
+              </View>
+            </View>
+            <View
+              style={[
+                styles.toggleSwitch,
+                {
+                  backgroundColor: isPrivate ? colors.primary : colors.border,
+                },
+              ]}
+            >
+              <View
+                style={[
+                  styles.toggleThumb,
+                  {
+                    backgroundColor: '#fff',
+                    transform: [{ translateX: isPrivate ? 20 : 0 }],
+                  },
+                ]}
+              />
+            </View>
+          </Pressable>
         </View>
 
         {categories.length > 0 && (
@@ -857,6 +904,49 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderRadius: 999,
     borderWidth: 1,
+  },
+  privateToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.md,
+    borderRadius: radius.xl,
+    borderWidth: 1,
+  },
+  privateToggleLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    flex: 1,
+  },
+  privateIconWrap: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  privateTextWrap: {
+    flex: 1,
+  },
+  privateLabel: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  privateDesc: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  toggleSwitch: {
+    width: 48,
+    height: 28,
+    borderRadius: 14,
+    padding: 4,
+  },
+  toggleThumb: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
   },
   selectionSection: {
     borderRadius: radius.xl,

--- a/apps/mobile/app/(main)/servers/[serverSlug]/create-channel.tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/create-channel.tsx
@@ -420,92 +420,73 @@ export default function CreateChannelScreen() {
           autoFocus
         />
         <View style={styles.section}>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.typeChipsRow}
-          >
-            {(['text', 'voice', 'announcement'] as ChannelType[]).map((item) => {
-              const selected = channelType === item
-              return (
-                <Pressable
-                  key={item}
-                  style={[
-                    styles.typeChip,
-                    {
-                      backgroundColor: selected ? `${colors.primary}12` : colors.surface,
-                      borderColor: selected ? colors.primary : colors.border,
-                    },
-                  ]}
-                  onPress={() => setChannelType(item)}
-                >
-                  <View
+          <View style={styles.typeAndPrivacyRow}>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.typeChipsRow}
+            >
+              {(['text', 'voice', 'announcement'] as ChannelType[]).map((item) => {
+                const selected = channelType === item
+                return (
+                  <Pressable
+                    key={item}
                     style={[
-                      styles.typeChipIconWrap,
+                      styles.typeChip,
                       {
-                        backgroundColor: colors.inputBackground,
+                        backgroundColor: selected ? `${colors.primary}12` : colors.surface,
+                        borderColor: selected ? colors.primary : colors.border,
                       },
                     ]}
+                    onPress={() => setChannelType(item)}
                   >
-                    {channelIcon(item, selected ? colors.primary : colors.textSecondary, 16)}
-                  </View>
-                  <Text
-                    style={[
-                      styles.typeChipText,
-                      { color: selected ? colors.primary : colors.text },
-                    ]}
-                  >
-                    {channelTypeLabel(item)}
-                  </Text>
-                </Pressable>
-              )
-            })}
-          </ScrollView>
-        </View>
-
-        <View style={styles.section}>
-          <Pressable
-            style={[
-              styles.privateToggle,
-              {
-                backgroundColor: colors.surface,
-                borderColor: colors.border,
-              },
-            ]}
-            onPress={() => setIsPrivate(!isPrivate)}
-          >
-            <View style={styles.privateToggleLeft}>
-              <View style={[styles.privateIconWrap, { backgroundColor: colors.inputBackground }]}>
-                <Lock size={16} color={isPrivate ? colors.primary : colors.textSecondary} />
-              </View>
-              <View style={styles.privateTextWrap}>
-                <Text style={[styles.privateLabel, { color: colors.text }]}>
-                  {t('channel.privateChannel', '私有频道')}
-                </Text>
-                <Text style={[styles.privateDesc, { color: colors.textMuted }]}>
-                  {t('channel.privateChannelDesc', '仅受邀成员可加入')}
-                </Text>
-              </View>
-            </View>
-            <View
+                    <View
+                      style={[
+                        styles.typeChipIconWrap,
+                        {
+                          backgroundColor: colors.inputBackground,
+                        },
+                      ]}
+                    >
+                      {channelIcon(item, selected ? colors.primary : colors.textSecondary, 16)}
+                    </View>
+                    <Text
+                      style={[
+                        styles.typeChipText,
+                        { color: selected ? colors.primary : colors.text },
+                      ]}
+                    >
+                      {channelTypeLabel(item)}
+                    </Text>
+                  </Pressable>
+                )
+              })}
+            </ScrollView>
+            <Pressable
               style={[
-                styles.toggleSwitch,
+                styles.privateToggleCompact,
                 {
-                  backgroundColor: isPrivate ? colors.primary : colors.border,
+                  backgroundColor: isPrivate ? `${colors.primary}12` : colors.surface,
+                  borderColor: isPrivate ? colors.primary : colors.border,
                 },
               ]}
+              onPress={() => setIsPrivate(!isPrivate)}
             >
               <View
+                style={[styles.privateIconWrapCompact, { backgroundColor: colors.inputBackground }]}
+              >
+                <Lock size={14} color={isPrivate ? colors.primary : colors.textSecondary} />
+              </View>
+              <Text
                 style={[
-                  styles.toggleThumb,
-                  {
-                    backgroundColor: '#fff',
-                    transform: [{ translateX: isPrivate ? 20 : 0 }],
-                  },
+                  styles.privateLabelCompact,
+                  { color: isPrivate ? colors.primary : colors.text },
                 ]}
-              />
-            </View>
-          </Pressable>
+              >
+                {t('channel.private', '私密')}
+              </Text>
+            </Pressable>
+          </View>
         </View>
 
         {categories.length > 0 && (
@@ -867,9 +848,14 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
     letterSpacing: 0.5,
   },
+  typeAndPrivacyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
   typeChipsRow: {
     gap: spacing.sm,
-    paddingRight: spacing.lg,
+    paddingRight: spacing.sm,
   },
   typeChip: {
     flexDirection: 'row',
@@ -913,6 +899,15 @@ const styles = StyleSheet.create({
     borderRadius: radius.xl,
     borderWidth: 1,
   },
+  privateToggleCompact: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
   privateToggleLeft: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -926,11 +921,22 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  privateIconWrapCompact: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   privateTextWrap: {
     flex: 1,
   },
   privateLabel: {
     fontSize: 15,
+    fontWeight: '700',
+  },
+  privateLabelCompact: {
+    fontSize: 14,
     fontWeight: '700',
   },
   privateDesc: {

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -293,7 +293,9 @@
     "noSearchResults": "No matching Buddy found",
     "homepageHtml": "Homepage HTML",
     "homepageHtmlPlaceholder": "<h1>Welcome!</h1>\n<p>This is the server homepage.</p>",
-    "homepageHtmlDesc": "Custom HTML for the server homepage. Leave empty to use the default."
+    "homepageHtmlDesc": "Custom HTML for the server homepage. Leave empty to use the default.",
+    "privateChannel": "Private Channel",
+    "privateChannelDesc": "Only invited members can join"
   },
   "chat": {
     "selectChannel": "Select a channel to start chatting",

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -293,7 +293,9 @@
     "noSearchResults": "一致する Buddy が見つかりません",
     "homepageHtml": "ホームページ HTML",
     "homepageHtmlPlaceholder": "<h1>ようこそ！</h1>\n<p>これはサーバーのホームページです。</p>",
-    "homepageHtmlDesc": "サーバーホームページのカスタムHTML。空にするとデフォルトが使用されます。"
+    "homepageHtmlDesc": "サーバーホームページのカスタムHTML。空にするとデフォルトが使用されます。",
+    "privateChannel": "プライベートチャンネル",
+    "privateChannelDesc": "招待されたメンバーのみ参加可能"
   },
   "chat": {
     "selectChannel": "チャンネルを選んでチャットを始めましょう",

--- a/apps/mobile/src/i18n/locales/ko.json
+++ b/apps/mobile/src/i18n/locales/ko.json
@@ -293,7 +293,9 @@
     "noSearchResults": "일치하는 Buddy를 찾을 수 없습니다",
     "homepageHtml": "홈페이지 HTML",
     "homepageHtmlPlaceholder": "<h1>환영합니다!</h1>\n<p>이것은 서버 홈페이지입니다.</p>",
-    "homepageHtmlDesc": "서버 홈페이지의 사용자 정의 HTML. 비워두면 기본값이 사용됩니다."
+    "homepageHtmlDesc": "서버 홈페이지의 사용자 정의 HTML. 비워두면 기본값이 사용됩니다.",
+    "privateChannel": "비공개 채널",
+    "privateChannelDesc": "초대된 멤버만 참여 가능"
   },
   "chat": {
     "selectChannel": "채널을 선택하여 채팅을 시작하세요",

--- a/apps/mobile/src/i18n/locales/zh-CN.json
+++ b/apps/mobile/src/i18n/locales/zh-CN.json
@@ -293,7 +293,9 @@
     "noSearchResults": "未找到匹配的 Buddy",
     "homepageHtml": "主页 HTML",
     "homepageHtmlPlaceholder": "<h1>欢迎！</h1>\n<p>这是服务器主页。</p>",
-    "homepageHtmlDesc": "服务器主页的自定义 HTML。留空使用默认主页。"
+    "homepageHtmlDesc": "服务器主页的自定义 HTML。留空使用默认主页。",
+    "privateChannel": "私有频道",
+    "privateChannelDesc": "仅受邀成员可加入"
   },
   "chat": {
     "selectChannel": "选择一个频道开始聊天",

--- a/apps/mobile/src/i18n/locales/zh-TW.json
+++ b/apps/mobile/src/i18n/locales/zh-TW.json
@@ -293,7 +293,9 @@
     "noSearchResults": "未找到符合的 Buddy",
     "homepageHtml": "主頁 HTML",
     "homepageHtmlPlaceholder": "<h1>歡迎！</h1>\n<p>這是伺服器主頁。</p>",
-    "homepageHtmlDesc": "伺服器主頁的自訂 HTML。留空使用預設主頁。"
+    "homepageHtmlDesc": "伺服器主頁的自訂 HTML。留空使用預設主頁。",
+    "privateChannel": "私有頻道",
+    "privateChannelDesc": "僅受邀成員可加入"
   },
   "chat": {
     "selectChannel": "選擇一個頻道開始聊天",


### PR DESCRIPTION
## Changes

- Move private channel toggle to the same row as channel type selection
- Use compact chip-style toggle for private switch to match channel type buttons
- Improve UI consistency and save vertical space

## Screenshot

Channel type selection (Text/Voice/Announcement) and private toggle are now displayed in a single horizontal row.