### PR TITLE
feat(web): add channel sorting functionality

### DIFF
--- a/apps/web/src/components/channel/channel-sidebar.tsx
+++ b/apps/web/src/components/channel/channel-sidebar.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useChannelSort } from '../../hooks/use-channel-sort'
 import { useSocketEvent } from '../../hooks/use-socket'
 import { fetchApi } from '../../lib/api'
 import { joinChannel } from '../../lib/socket'
@@ -32,6 +33,7 @@ import { useAuthStore } from '../../stores/auth.store'
 import { useChatStore } from '../../stores/chat.store'
 import { useUIStore } from '../../stores/ui.store'
 import { useConfirmStore } from '../common/confirm-dialog'
+import { ChannelSortButton } from './channel-sort-button'
 
 interface Channel {
   id: string
@@ -41,6 +43,9 @@ interface Channel {
   position: number
   isPrivate: boolean
   isMember?: boolean
+  createdAt?: string
+  updatedAt?: string
+  lastMessageAt?: string | null
 }
 
 interface Server {
@@ -154,10 +159,14 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
     queryFn: () => fetchApi<Server>(`/api/servers/${serverSlug}`),
   })
 
-  const { data: channels = [] } = useQuery({
+  const { data: rawChannels = [] } = useQuery<Channel[]>({
     queryKey: ['channels', serverSlug],
     queryFn: () => fetchApi<Channel[]>(`/api/servers/${serverSlug}/channels`),
   })
+
+  // Channel sorting
+  const { sortChannels, updateLastAccessed } = useChannelSort(server?.id)
+  const channels = sortChannels(rawChannels)
 
   const { data: scopedUnread } = useQuery({
     queryKey: ['notification-scoped-unread'],
@@ -441,6 +450,7 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
   const handleSelectChannel = useCallback(
     (channelId: string) => {
       requestMarkScopeRead({ channelId })
+      updateLastAccessed(channelId)
       setMobileView('chat')
       // Navigate to channel URL using channel ID
       navigate({
@@ -448,7 +458,7 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
         params: { serverSlug: server?.slug ?? serverSlug, channelId },
       })
     },
-    [setMobileView, server?.slug, serverSlug, navigate, requestMarkScopeRead],
+    [setMobileView, server?.slug, serverSlug, navigate, requestMarkScopeRead, updateLastAccessed],
   )
 
   // Rejoin active channel room on socket reconnect
@@ -624,13 +634,16 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
             <span className="w-2 h-2 rounded-full bg-danger shrink-0" title="该服务器有未读通知" />
           )}
         </div>
-        <button
-          onClick={openServerEdit}
-          className="text-text-muted hover:text-text-primary transition"
-          title={t('channel.serverSettings')}
-        >
-          <Settings size={16} />
-        </button>
+        <div className="flex items-center gap-1">
+          {server?.id && <ChannelSortButton serverId={server.id} />}
+          <button
+            onClick={openServerEdit}
+            className="text-text-muted hover:text-text-primary transition"
+            title={t('channel.serverSettings')}
+          >
+            <Settings size={16} />
+          </button>
+        </div>
       </div>
 
       {/* Channel list */}

--- a/apps/web/src/components/channel/channel-sort-button.tsx
+++ b/apps/web/src/components/channel/channel-sort-button.tsx
@@ -1,0 +1,120 @@
+import type { ChannelSortBy } from '@shadowob/shared'
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Calendar,
+  Check,
+  Clock,
+  MessageSquare,
+} from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useChannelSort } from '../../hooks/use-channel-sort'
+
+interface SortOption {
+  value: ChannelSortBy
+  label: string
+  icon: typeof Calendar
+}
+
+interface ChannelSortButtonProps {
+  serverId: string
+}
+
+export function ChannelSortButton({ serverId }: ChannelSortButtonProps) {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const { sortBy, sortDirection, setSortBy, toggleSortDirection } = useChannelSort(serverId)
+
+  const sortOptions: SortOption[] = [
+    {
+      value: 'position',
+      label: t('sort.byPosition', { defaultValue: '默认顺序' }),
+      icon: ArrowUpDown,
+    },
+    {
+      value: 'lastMessageAt',
+      label: t('sort.byLastMessage', { defaultValue: '最新消息' }),
+      icon: MessageSquare,
+    },
+    {
+      value: 'lastAccessedAt',
+      label: t('sort.byLastAccessed', { defaultValue: '访问时间' }),
+      icon: Clock,
+    },
+    {
+      value: 'createdAt',
+      label: t('sort.byCreatedAt', { defaultValue: '创建时间' }),
+      icon: Calendar,
+    },
+    { value: 'updatedAt', label: t('sort.byUpdatedAt', { defaultValue: '更新时间' }), icon: Clock },
+  ]
+
+  const currentOption = sortOptions.find((opt) => opt.value === sortBy) || sortOptions[0]!
+  const DirectionIcon = sortDirection === 'asc' ? ArrowUp : ArrowDown
+
+  const handleSelectSort = (value: ChannelSortBy) => {
+    if (value === sortBy) {
+      toggleSortDirection()
+    } else {
+      setSortBy(value)
+    }
+    setIsOpen(false)
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium text-text-muted hover:text-text-secondary hover:bg-bg-modifier-hover transition"
+      >
+        <currentOption.icon size={14} />
+        <span className="hidden sm:inline">{currentOption.label}</span>
+        <DirectionIcon size={12} />
+      </button>
+
+      {isOpen && (
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-40"
+            onClick={() => setIsOpen(false)}
+            aria-label="Close"
+          />
+          <div className="absolute right-0 top-full mt-1 z-50 w-56 bg-bg-tertiary rounded-lg shadow-lg border border-border-subtle py-1">
+            <div className="px-3 py-2 text-xs font-bold uppercase text-text-muted border-b border-border-subtle">
+              {t('sort.title', { defaultValue: '排序方式' })}
+            </div>
+            {sortOptions.map((option) => {
+              const Icon = option.icon
+              const isSelected = sortBy === option.value
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => handleSelectSort(option.value)}
+                  className={`flex items-center gap-2 w-full px-3 py-2 text-sm transition ${
+                    isSelected
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-text-secondary hover:bg-bg-modifier-hover hover:text-text-primary'
+                  }`}
+                >
+                  <Icon size={16} className={isSelected ? 'text-primary' : 'text-text-muted'} />
+                  <span className="flex-1 text-left">{option.label}</span>
+                  {isSelected && (
+                    <>
+                      <DirectionIcon size={12} className="text-primary" />
+                      <Check size={14} className="text-primary" />
+                    </>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/hooks/use-channel-sort.ts
+++ b/apps/web/src/hooks/use-channel-sort.ts
@@ -1,0 +1,161 @@
+import type { ChannelSortBy, ChannelSortDirection } from '@shadowob/shared'
+import { useCallback, useMemo } from 'react'
+import { DEFAULT_SORT, useChannelSortStore } from '../stores/channel-sort.store'
+
+function getSafeTime(value?: string | null): number {
+  if (!value) return 0
+  const timestamp = new Date(value).getTime()
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+/** Minimal channel interface for sorting */
+interface SortableChannel {
+  id: string
+  position?: number
+  createdAt?: string
+  updatedAt?: string
+  lastMessageAt?: string | null
+}
+
+export interface UseChannelSortReturn {
+  /** Current sort criteria */
+  sortBy: ChannelSortBy
+  /** Current sort direction */
+  sortDirection: ChannelSortDirection
+  /** Set sort criteria */
+  setSortBy: (by: ChannelSortBy) => void
+  /** Set sort direction */
+  setSortDirection: (direction: ChannelSortDirection) => void
+  /** Toggle sort direction */
+  toggleSortDirection: () => void
+  /** Check if has custom sort */
+  hasCustomSort: boolean
+  /** Sort channels based on current settings */
+  sortChannels: <T extends SortableChannel>(channels: T[]) => (T & { lastAccessedAt?: string })[]
+  /** Update last accessed timestamp for a channel */
+  updateLastAccessed: (channelId: string) => void
+}
+
+/**
+ * Hook for channel sorting functionality
+ * @param serverId - Server ID to get/set sort config
+ */
+export function useChannelSort(serverId?: string): UseChannelSortReturn {
+  // Subscribe to store state directly - this will trigger re-render when config changes
+  const serverSortConfigs = useChannelSortStore((s) => s.serverSortConfigs)
+  const updateLastAccessed = useChannelSortStore((s) => s.updateLastAccessed)
+  const getLastAccessed = useChannelSortStore((s) => s.getLastAccessed)
+  const storeSetSortBy = useChannelSortStore((s) => s.setSortBy)
+  const storeSetSortDirection = useChannelSortStore((s) => s.setSortDirection)
+  const storeToggleSortDirection = useChannelSortStore((s) => s.toggleSortDirection)
+
+  // Get current sort config for this server
+  const currentConfig = useMemo(() => {
+    if (!serverId) return DEFAULT_SORT
+    return serverSortConfigs[serverId] ?? DEFAULT_SORT
+  }, [serverSortConfigs, serverId])
+
+  const { sortBy, sortDirection } = currentConfig
+
+  // Check if has custom sort
+  const hasCustomSort = useMemo(() => {
+    if (!serverId) return false
+    return sortBy !== 'position'
+  }, [sortBy, serverId])
+
+  // Wrapper functions that include serverId
+  const setSortBy = useCallback(
+    (by: ChannelSortBy) => {
+      if (!serverId) return
+      storeSetSortBy(serverId, by)
+    },
+    [serverId, storeSetSortBy],
+  )
+
+  const setSortDirection = useCallback(
+    (direction: ChannelSortDirection) => {
+      if (!serverId) return
+      storeSetSortDirection(serverId, direction)
+    },
+    [serverId, storeSetSortDirection],
+  )
+
+  const toggleSortDirection = useCallback(() => {
+    if (!serverId) return
+    storeToggleSortDirection(serverId)
+  }, [serverId, storeToggleSortDirection])
+
+  // Stable sort function that uses current sort config from closure
+  const sortChannels = useCallback(
+    <T extends SortableChannel>(channels: T[]): (T & { lastAccessedAt?: string })[] => {
+      const config = serverId ? (serverSortConfigs[serverId] ?? DEFAULT_SORT) : DEFAULT_SORT
+      const currentSortBy = config.sortBy ?? DEFAULT_SORT.sortBy
+      const currentSortDirection = config.sortDirection ?? DEFAULT_SORT.sortDirection
+
+      const sorted = [...channels].map((ch) => ({
+        ...ch,
+        lastAccessedAt: getLastAccessed(ch.id),
+      }))
+
+      sorted.sort((a, b) => {
+        let comparison = 0
+
+        switch (currentSortBy) {
+          case 'createdAt':
+            comparison = getSafeTime(a.createdAt) - getSafeTime(b.createdAt)
+            break
+          case 'updatedAt':
+            comparison = getSafeTime(a.updatedAt) - getSafeTime(b.updatedAt)
+            break
+          case 'lastMessageAt': {
+            comparison = getSafeTime(a.lastMessageAt) - getSafeTime(b.lastMessageAt)
+            break
+          }
+          case 'lastAccessedAt': {
+            comparison = getSafeTime(a.lastAccessedAt) - getSafeTime(b.lastAccessedAt)
+            break
+          }
+          default:
+            comparison = (a.position ?? 0) - (b.position ?? 0)
+            break
+        }
+
+        if (comparison === 0) {
+          comparison = (a.position ?? 0) - (b.position ?? 0)
+        }
+
+        if (comparison === 0) {
+          comparison = a.id.localeCompare(b.id)
+        }
+
+        return currentSortDirection === 'asc' ? comparison : -comparison
+      })
+
+      return sorted
+    },
+    [getLastAccessed, serverId, serverSortConfigs],
+  )
+
+  return useMemo(
+    () => ({
+      sortBy,
+      sortDirection,
+      setSortBy,
+      setSortDirection,
+      toggleSortDirection,
+      hasCustomSort,
+      sortChannels,
+      updateLastAccessed,
+    }),
+    [
+      sortBy,
+      sortDirection,
+      setSortBy,
+      setSortDirection,
+      toggleSortDirection,
+      hasCustomSort,
+      sortChannels,
+      updateLastAccessed,
+    ],
+  )
+}

--- a/apps/web/src/stores/channel-sort.store.ts
+++ b/apps/web/src/stores/channel-sort.store.ts
@@ -1,0 +1,126 @@
+import type { ChannelSortBy, ChannelSortDirection } from '@shadowob/shared'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export interface ServerSortConfig {
+  sortBy: ChannelSortBy
+  sortDirection: ChannelSortDirection
+}
+
+export interface ChannelSortState {
+  /** Sort config per server: serverId -> config */
+  serverSortConfigs: Record<string, ServerSortConfig>
+  /** Last accessed timestamps for channels: channelId -> timestamp */
+  lastAccessedAt: Record<string, string>
+  /** Set sort criteria for a server */
+  setSortBy: (serverId: string, by: ChannelSortBy) => void
+  /** Set sort direction for a server */
+  setSortDirection: (serverId: string, direction: ChannelSortDirection) => void
+  /** Toggle sort direction for a server */
+  toggleSortDirection: (serverId: string) => void
+  /** Get sort config for a server */
+  getSortConfig: (serverId: string) => ServerSortConfig
+  /** Check if server has custom sorting (not default position) */
+  hasCustomSort: (serverId: string) => boolean
+  /** Update last accessed timestamp for a channel */
+  updateLastAccessed: (channelId: string) => void
+  /** Get last accessed timestamp for a channel */
+  getLastAccessed: (channelId: string) => string | undefined
+}
+
+export const DEFAULT_SORT: ServerSortConfig = {
+  sortBy: 'position',
+  sortDirection: 'asc',
+}
+
+function isTimeSort(by: ChannelSortBy): boolean {
+  return by !== 'position'
+}
+
+export const useChannelSortStore = create<ChannelSortState>()(
+  persist(
+    (set, get) => ({
+      serverSortConfigs: {},
+      lastAccessedAt: {},
+
+      setSortBy: (serverId, by) => {
+        const currentConfig = get().serverSortConfigs[serverId] ?? DEFAULT_SORT
+        const nextDirection: ChannelSortDirection =
+          by === 'position'
+            ? 'asc'
+            : by !== currentConfig.sortBy && isTimeSort(by)
+              ? 'desc'
+              : currentConfig.sortDirection
+
+        set((state) => ({
+          serverSortConfigs: {
+            ...state.serverSortConfigs,
+            [serverId]: {
+              ...DEFAULT_SORT,
+              ...state.serverSortConfigs[serverId],
+              sortBy: by,
+              sortDirection: nextDirection,
+            },
+          },
+        }))
+      },
+
+      setSortDirection: (serverId, direction) => {
+        set((state) => ({
+          serverSortConfigs: {
+            ...state.serverSortConfigs,
+            [serverId]: {
+              ...DEFAULT_SORT,
+              ...state.serverSortConfigs[serverId],
+              sortDirection: direction,
+            },
+          },
+        }))
+      },
+
+      toggleSortDirection: (serverId) => {
+        const currentConfig = get().serverSortConfigs[serverId] ?? DEFAULT_SORT
+        const current = currentConfig.sortDirection
+        set((state) => ({
+          serverSortConfigs: {
+            ...state.serverSortConfigs,
+            [serverId]: {
+              ...DEFAULT_SORT,
+              ...state.serverSortConfigs[serverId],
+              sortDirection: current === 'asc' ? 'desc' : 'asc',
+            },
+          },
+        }))
+      },
+
+      getSortConfig: (serverId) => {
+        return get().serverSortConfigs[serverId] ?? DEFAULT_SORT
+      },
+
+      hasCustomSort: (serverId) => {
+        const config = get().serverSortConfigs[serverId]
+        return config ? config.sortBy !== 'position' : false
+      },
+
+      updateLastAccessed: (channelId) => {
+        set((state) => ({
+          lastAccessedAt: {
+            ...state.lastAccessedAt,
+            [channelId]: new Date().toISOString(),
+          },
+        }))
+      },
+
+      getLastAccessed: (channelId) => {
+        return get().lastAccessedAt[channelId]
+      },
+    }),
+    {
+      name: 'channel-sort-storage',
+      partialize: (state) => ({
+        serverSortConfigs: state.serverSortConfigs,
+        lastAccessedAt: state.lastAccessedAt,
+      }),
+    },
+  ),
+)

--- a/packages/shared/src/types/channel.types.ts
+++ b/packages/shared/src/types/channel.types.ts
@@ -26,7 +26,12 @@ export interface UpdateChannelRequest {
 }
 
 /** Channel sorting options */
-export type ChannelSortBy = 'createdAt' | 'updatedAt' | 'lastMessageAt' | 'lastAccessedAt'
+export type ChannelSortBy =
+  | 'position'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'lastMessageAt'
+  | 'lastAccessedAt'
 
 export type ChannelSortDirection = 'asc' | 'desc'
 


### PR DESCRIPTION
## Summary

- Add channel sorting functionality for Web端
- Reference mobile implementation in server page

## Changes

- **ChannelSortButton** component for sorting channel list
- **useChannelSort** hook for managing sort state per server
- **channel-sort store** using Zustand with localStorage persistence
- Add `position` to `ChannelSortBy` type in shared package

## Features

- Sort by: 默认顺序 (position), 最新消息 (lastMessageAt), 访问时间 (lastAccessedAt), 创建时间, 更新时间
- Toggle sort direction (asc/desc)
- Track last accessed time per channel
- Per-server sort preference persisted in localStorage

## Screenshot

Sort button appears in server header next to settings button.

## Test Plan

1. Open a server with multiple channels
2. Click sort button in header
3. Select different sort options
4. Verify channels reorder correctly
5. Refresh page - sort preference should persist