### PR TITLE
fix(web): handle clipboard write errors in server home copy link

### DIFF
--- a/apps/web/src/components/server/server-home.tsx
+++ b/apps/web/src/components/server/server-home.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Check, Copy, ExternalLink, Home, Settings } from 'lucide-rea
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { fetchApi } from '../../lib/api'
+import { copyToClipboardSilent } from '../../lib/clipboard'
 import { useChatStore } from '../../stores/chat.store'
 import { useUIStore } from '../../stores/ui.store'
 
@@ -434,12 +435,14 @@ document.addEventListener('click', function(e) {
     ? rawHtml.replace('</body>', `${linkInterceptorScript}</body>`)
     : rawHtml + linkInterceptorScript
 
-  const handleCopyLink = () => {
+  const handleCopyLink = async () => {
     const slug = server.slug || server.id
     const url = `${window.location.origin}/s/${slug}`
-    navigator.clipboard.writeText(url)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    const success = await copyToClipboardSilent(url)
+    if (success) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
   }
 
   const handleOpenNewWindow = () => {

--- a/apps/web/src/lib/clipboard.ts
+++ b/apps/web/src/lib/clipboard.ts
@@ -1,0 +1,66 @@
+import { showToast } from './toast'
+
+/**
+ * Copy text to clipboard with fallback support.
+ * Tries modern Clipboard API first, falls back to legacy execCommand.
+ * Shows toast notification on success (unless silent is true).
+ */
+export async function copyToClipboard(
+  text: string,
+  options: { silent?: boolean; successMessage?: string } = {},
+): Promise<boolean> {
+  const { silent = false, successMessage = 'Copied to clipboard' } = options
+
+  try {
+    // Try modern Clipboard API first
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text)
+      if (!silent) {
+        showToast(successMessage, 'success')
+      }
+      return true
+    }
+  } catch {
+    // Fallback to legacy method
+  }
+
+  // Fallback: use execCommand (works in non-secure contexts)
+  try {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.style.position = 'fixed'
+    textarea.style.left = '-9999px'
+    textarea.style.top = '-9999px'
+    textarea.setAttribute('readonly', '')
+    document.body.appendChild(textarea)
+
+    textarea.select()
+    textarea.setSelectionRange(0, text.length)
+
+    const success = document.execCommand('copy')
+    document.body.removeChild(textarea)
+
+    if (success) {
+      if (!silent) {
+        showToast(successMessage, 'success')
+      }
+      return true
+    }
+  } catch {
+    // Ignore fallback errors
+  }
+
+  // All methods failed
+  if (!silent) {
+    showToast('Failed to copy to clipboard', 'error')
+  }
+  return false
+}
+
+/**
+ * Copy text to clipboard silently (no toast).
+ * Returns true if successful, false otherwise.
+ */
+export async function copyToClipboardSilent(text: string): Promise<boolean> {
+  return copyToClipboard(text, { silent: true })
+}

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -35,6 +35,7 @@ import { PriceDisplay } from '../components/shop/ui/currency'
 import { useAppStatus } from '../hooks/use-app-status'
 import { useUnreadCount } from '../hooks/use-unread-count'
 import { fetchApi } from '../lib/api'
+import { copyToClipboardSilent } from '../lib/clipboard'
 import { disconnectSocket } from '../lib/socket'
 import { useAuthStore } from '../stores/auth.store'
 import { type ThemeMode, useUIStore } from '../stores/ui.store'
@@ -972,11 +973,13 @@ function InviteManagement() {
     }
   }
 
-  const copyCode = (code: string, id: string) => {
+  const copyCode = async (code: string, id: string) => {
     const registerUrl = `${window.location.origin}/app/register?code=${code}`
-    navigator.clipboard.writeText(registerUrl)
-    setCopiedId(id)
-    setTimeout(() => setCopiedId(null), 2000)
+    const success = await copyToClipboardSilent(registerUrl)
+    if (success) {
+      setCopiedId(id)
+      setTimeout(() => setCopiedId(null), 2000)
+    }
   }
 
   const handleAddFriend = async (username: string, userId: string) => {


### PR DESCRIPTION
## Problem
The copy invite link button in settings page was not working because `navigator.clipboard.writeText()` is an async API that can fail in:
- Non-secure contexts (HTTP, not HTTPS)
- Without proper user gesture
- When permission is denied

## Solution
Created a robust clipboard utility (`clipboard.ts`) that:
1. **Tries modern Clipboard API first** - `navigator.clipboard.writeText()`
2. **Falls back to legacy method** - `document.execCommand('copy')` using hidden textarea
3. **Provides feedback options** - Silent mode for UI state, toast mode for user feedback

## Changes
- **New file**: `apps/web/src/lib/clipboard.ts` - Clipboard utility with fallback
- **Updated**: `apps/web/src/components/server/server-home.tsx` - Use new utility
- **Updated**: `apps/web/src/pages/settings.tsx` - Use new utility

## API
```ts
// With toast notification
await copyToClipboard(text, { successMessage: 'Copied!' })

// Silent (no toast, returns boolean)
const success = await copyToClipboardSilent(text)
```

## Testing
- [x] Build passes
- [x] Lint passes
- [ ] Manual test: Copy invite link in settings page
- [ ] Manual test: Copy server link in server home page