### PR TITLE
fix(web): enable scripts in HTML preview iframes

### DIFF
--- a/apps/web/src/components/chat/file-preview-panel.tsx
+++ b/apps/web/src/components/chat/file-preview-panel.tsx
@@ -671,7 +671,7 @@ function HTMLPreview({ text, url }: { text?: string; url: string }) {
     <iframe
       src={iframeSrc}
       title="HTML Preview"
-      sandbox="allow-same-origin"
+      sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
       className="w-full h-full border-0 bg-white rounded"
     />
   )

--- a/apps/web/src/components/server/server-home.tsx
+++ b/apps/web/src/components/server/server-home.tsx
@@ -510,7 +510,7 @@ document.addEventListener('click', function(e) {
             srcDoc={htmlContent}
             title={`${server.name} homepage`}
             className="w-full h-full border-0"
-            sandbox="allow-scripts allow-same-origin"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
           />
         )}
       </div>


### PR DESCRIPTION
## Problem
Web 端 HTML 预览的 iframe sandbox 只设置了 `allow-same-origin`，导致 JavaScript 无法执行并报错。

## Solution
更新 iframe sandbox 属性，添加完整的权限：
- `allow-scripts` - 允许 JavaScript 执行
- `allow-same-origin` - 允许同源访问
- `allow-forms` - 允许表单提交
- `allow-popups` - 允许打开新窗口
- `allow-modals` - 允许模态对话框

## Files Changed
- `apps/web/src/components/chat/file-preview-panel.tsx` - HTML 文件预览
- `apps/web/src/components/server/server-home.tsx` - 服务器首页 srcDoc iframe