### PR TITLE
feat(web): improve channel sorting UX with filter icon and keyword filter

### DIFF
--- a/apps/web/src/components/channel/channel-sidebar.tsx
+++ b/apps/web/src/components/channel/channel-sidebar.tsx
@@ -511,8 +511,8 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
   const isInChannel = /\/servers\/[^/]+\/channels\//.test(location.pathname)
   const isHomeActive = !isInChannel && !isInShop && !isInWorkspace && !isInApps
 
-  const renderChannelGroup = (label: string, items: Channel[], isFirstGroup: boolean) => {
-    if (items.length === 0 && !isFirstGroup) return null
+  const renderChannelGroup = (label: string, items: Channel[]) => {
+    if (items.length === 0) return null
     const isCollapsed = !!collapsedGroups[label]
     return (
       <div className="mb-4">
@@ -527,23 +527,6 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
               <ChevronDown size={12} className="shrink-0" />
             )}
             <span className="truncate">{label}</span>
-          </button>
-          {/* Sort/Filter button - only show for first group */}
-          {isFirstGroup && server?.id && (
-            <ChannelSortFilterButton
-              serverId={server.id}
-              filterKeyword={filterKeyword}
-              onFilterChange={setFilterKeyword}
-              hasActiveFilter={hasActiveFilter}
-            />
-          )}
-          <button
-            type="button"
-            onClick={() => setShowCreate(true)}
-            className="text-text-secondary hover:text-text-primary transition p-0.5 rounded hover:bg-bg-modifier-hover"
-            title={t('channel.createChannel')}
-          >
-            <Plus size={14} />
           </button>
         </div>
         {!isCollapsed &&
@@ -765,9 +748,35 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
           <span className="truncate">应用</span>
         </button>
         <div className="h-px bg-divider mx-4 mb-2" />
-        {renderChannelGroup(t('channel.announcement'), announcementChannels, true)}
-        {renderChannelGroup(t('channel.text'), textChannels, false)}
-        {renderChannelGroup(t('channel.voice'), voiceChannels, false)}
+
+        {/* Channel filter and sort bar */}
+        {server?.id && (
+          <div className="flex items-center justify-between px-4 py-2 mb-2">
+            <span className="text-[12px] font-bold tracking-wide uppercase text-text-secondary">
+              {t('channel.channels', { defaultValue: '频道' })}
+            </span>
+            <div className="flex items-center gap-1">
+              <ChannelSortFilterButton
+                serverId={server.id}
+                filterKeyword={filterKeyword}
+                onFilterChange={setFilterKeyword}
+                hasActiveFilter={hasActiveFilter}
+              />
+              <button
+                type="button"
+                onClick={() => setShowCreate(true)}
+                className="text-text-secondary hover:text-text-primary transition p-1 rounded hover:bg-bg-modifier-hover"
+                title={t('channel.createChannel')}
+              >
+                <Plus size={16} />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {renderChannelGroup(t('channel.announcement'), announcementChannels)}
+        {renderChannelGroup(t('channel.text'), textChannels)}
+        {renderChannelGroup(t('channel.voice'), voiceChannels)}
 
         {channels.length === 0 && (
           <p className="text-text-muted text-sm px-4 py-2">{t('channel.noChannels')}</p>

--- a/apps/web/src/components/channel/channel-sidebar.tsx
+++ b/apps/web/src/components/channel/channel-sidebar.tsx
@@ -32,9 +32,9 @@ import { joinChannel } from '../../lib/socket'
 import { useAuthStore } from '../../stores/auth.store'
 import { useChatStore } from '../../stores/chat.store'
 import { useUIStore } from '../../stores/ui.store'
-import { ContextMenu } from '../common/context-menu'
 import { useConfirmStore } from '../common/confirm-dialog'
-import { ChannelSortButton } from './channel-sort-button'
+import { ContextMenu } from '../common/context-menu'
+import { ChannelSortFilterButton } from './channel-sort-button'
 
 interface Channel {
   id: string
@@ -164,9 +164,16 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
     queryFn: () => fetchApi<Channel[]>(`/api/servers/${serverSlug}/channels`),
   })
 
-  // Channel sorting
+  // Channel sorting and filter
+  const [filterKeyword, setFilterKeyword] = useState('')
+  const hasActiveFilter = filterKeyword.trim().length > 0
   const { sortChannels, updateLastAccessed } = useChannelSort(server?.id)
-  const channels = sortChannels(rawChannels)
+  const sortedChannels = sortChannels(rawChannels)
+  const channels = hasActiveFilter
+    ? sortedChannels.filter((ch) =>
+        ch.name.toLowerCase().includes(filterKeyword.toLowerCase().trim()),
+      )
+    : sortedChannels
 
   const { data: scopedUnread } = useQuery({
     queryKey: ['notification-scoped-unread'],
@@ -504,8 +511,8 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
   const isInChannel = /\/servers\/[^/]+\/channels\//.test(location.pathname)
   const isHomeActive = !isInChannel && !isInShop && !isInWorkspace && !isInApps
 
-  const renderChannelGroup = (label: string, items: Channel[]) => {
-    if (items.length === 0) return null
+  const renderChannelGroup = (label: string, items: Channel[], isFirstGroup: boolean) => {
+    if (items.length === 0 && !isFirstGroup) return null
     const isCollapsed = !!collapsedGroups[label]
     return (
       <div className="mb-4">
@@ -521,6 +528,15 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
             )}
             <span className="truncate">{label}</span>
           </button>
+          {/* Sort/Filter button - only show for first group */}
+          {isFirstGroup && server?.id && (
+            <ChannelSortFilterButton
+              serverId={server.id}
+              filterKeyword={filterKeyword}
+              onFilterChange={setFilterKeyword}
+              hasActiveFilter={hasActiveFilter}
+            />
+          )}
           <button
             type="button"
             onClick={() => setShowCreate(true)}
@@ -634,16 +650,13 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
             <span className="w-2 h-2 rounded-full bg-danger shrink-0" title="该服务器有未读通知" />
           )}
         </div>
-        <div className="flex items-center gap-1">
-          {server?.id && <ChannelSortButton serverId={server.id} />}
-          <button
-            onClick={openServerEdit}
-            className="text-text-muted hover:text-text-primary transition"
-            title={t('channel.serverSettings')}
-          >
-            <Settings size={16} />
-          </button>
-        </div>
+        <button
+          onClick={openServerEdit}
+          className="text-text-muted hover:text-text-primary transition"
+          title={t('channel.serverSettings')}
+        >
+          <Settings size={16} />
+        </button>
       </div>
 
       {/* Channel list */}
@@ -752,9 +765,9 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
           <span className="truncate">应用</span>
         </button>
         <div className="h-px bg-divider mx-4 mb-2" />
-        {renderChannelGroup(t('channel.announcement'), announcementChannels)}
-        {renderChannelGroup(t('channel.text'), textChannels)}
-        {renderChannelGroup(t('channel.voice'), voiceChannels)}
+        {renderChannelGroup(t('channel.announcement'), announcementChannels, true)}
+        {renderChannelGroup(t('channel.text'), textChannels, false)}
+        {renderChannelGroup(t('channel.voice'), voiceChannels, false)}
 
         {channels.length === 0 && (
           <p className="text-text-muted text-sm px-4 py-2">{t('channel.noChannels')}</p>
@@ -1185,7 +1198,9 @@ export function ChannelSidebar({ serverSlug }: { serverSlug: string }) {
               items: [
                 {
                   icon: Volume2,
-                  label: (notificationPreference?.mutedChannelIds ?? []).includes(contextMenu.channel.id)
+                  label: (notificationPreference?.mutedChannelIds ?? []).includes(
+                    contextMenu.channel.id,
+                  )
                     ? '取消静音频道'
                     : '静音频道通知',
                   onClick: () => {

--- a/apps/web/src/components/channel/channel-sort-button.tsx
+++ b/apps/web/src/components/channel/channel-sort-button.tsx
@@ -6,9 +6,12 @@ import {
   Calendar,
   Check,
   Clock,
+  ListFilter,
   MessageSquare,
+  Search,
+  X,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useChannelSort } from '../../hooks/use-channel-sort'
 
@@ -18,14 +21,26 @@ interface SortOption {
   icon: typeof Calendar
 }
 
-interface ChannelSortButtonProps {
+interface ChannelSortFilterButtonProps {
   serverId: string
+  filterKeyword: string
+  onFilterChange: (keyword: string) => void
+  hasActiveFilter: boolean
 }
 
-export function ChannelSortButton({ serverId }: ChannelSortButtonProps) {
+export function ChannelSortFilterButton({
+  serverId,
+  filterKeyword,
+  onFilterChange,
+  hasActiveFilter,
+}: ChannelSortFilterButtonProps) {
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
-  const { sortBy, sortDirection, setSortBy, toggleSortDirection } = useChannelSort(serverId)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const { sortBy, sortDirection, setSortBy, toggleSortDirection, hasCustomSort } =
+    useChannelSort(serverId)
+
+  const isActive = hasCustomSort || hasActiveFilter
 
   const sortOptions: SortOption[] = [
     {
@@ -51,8 +66,20 @@ export function ChannelSortButton({ serverId }: ChannelSortButtonProps) {
     { value: 'updatedAt', label: t('sort.byUpdatedAt', { defaultValue: '更新时间' }), icon: Clock },
   ]
 
-  const currentOption = sortOptions.find((opt) => opt.value === sortBy) || sortOptions[0]!
   const DirectionIcon = sortDirection === 'asc' ? ArrowUp : ArrowDown
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen])
 
   const handleSelectSort = (value: ChannelSortBy) => {
     if (value === sortBy) {
@@ -60,19 +87,26 @@ export function ChannelSortButton({ serverId }: ChannelSortButtonProps) {
     } else {
       setSortBy(value)
     }
-    setIsOpen(false)
+  }
+
+  const handleClear = () => {
+    onFilterChange('')
+    setSortBy('position')
   }
 
   return (
-    <div className="relative">
+    <div className="relative" ref={dropdownRef}>
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium text-text-muted hover:text-text-secondary hover:bg-bg-modifier-hover transition"
+        className={`p-1.5 rounded-md transition shrink-0 ${
+          isActive
+            ? 'text-primary bg-primary/10'
+            : 'text-text-secondary hover:text-text-primary hover:bg-bg-modifier-hover'
+        }`}
+        title={t('sort.title', { defaultValue: '排序和筛选' })}
       >
-        <currentOption.icon size={14} />
-        <span className="hidden sm:inline">{currentOption.label}</span>
-        <DirectionIcon size={12} />
+        <ListFilter size={16} />
       </button>
 
       {isOpen && (
@@ -83,35 +117,75 @@ export function ChannelSortButton({ serverId }: ChannelSortButtonProps) {
             onClick={() => setIsOpen(false)}
             aria-label="Close"
           />
-          <div className="absolute right-0 top-full mt-1 z-50 w-56 bg-bg-tertiary rounded-lg shadow-lg border border-border-subtle py-1">
-            <div className="px-3 py-2 text-xs font-bold uppercase text-text-muted border-b border-border-subtle">
-              {t('sort.title', { defaultValue: '排序方式' })}
+          <div className="absolute right-0 top-full mt-1 z-50 w-64 bg-bg-tertiary rounded-lg shadow-lg border border-border-subtle py-2">
+            {/* Filter Input */}
+            <div className="px-3 pb-2 border-b border-border-subtle">
+              <div className="flex items-center gap-2 px-2 py-1.5 bg-bg-primary/50 rounded-md">
+                <Search size={14} className="text-text-muted shrink-0" />
+                <input
+                  type="text"
+                  value={filterKeyword}
+                  onChange={(e) => onFilterChange(e.target.value)}
+                  placeholder={t('sort.filterPlaceholder', { defaultValue: '搜索频道...' })}
+                  className="flex-1 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-muted"
+                />
+                {filterKeyword && (
+                  <button
+                    type="button"
+                    onClick={() => onFilterChange('')}
+                    className="text-text-muted hover:text-text-primary transition shrink-0"
+                  >
+                    <X size={14} />
+                  </button>
+                )}
+              </div>
             </div>
-            {sortOptions.map((option) => {
-              const Icon = option.icon
-              const isSelected = sortBy === option.value
-              return (
+
+            {/* Sort Options */}
+            <div className="py-1">
+              <div className="px-3 py-1.5 text-xs font-bold uppercase text-text-muted">
+                {t('sort.title', { defaultValue: '排序方式' })}
+              </div>
+              {sortOptions.map((option) => {
+                const Icon = option.icon
+                const isSelected = sortBy === option.value
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => handleSelectSort(option.value)}
+                    className={`flex items-center gap-2 w-full px-3 py-2 text-sm transition ${
+                      isSelected
+                        ? 'text-primary bg-primary/10'
+                        : 'text-text-secondary hover:bg-bg-modifier-hover hover:text-text-primary'
+                    }`}
+                  >
+                    <Icon size={16} className={isSelected ? 'text-primary' : 'text-text-muted'} />
+                    <span className="flex-1 text-left">{option.label}</span>
+                    {isSelected && (
+                      <>
+                        <DirectionIcon size={12} className="text-primary" />
+                        <Check size={14} className="text-primary" />
+                      </>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+
+            {/* Clear Button */}
+            {isActive && (
+              <div className="px-3 pt-2 border-t border-border-subtle">
                 <button
-                  key={option.value}
                   type="button"
-                  onClick={() => handleSelectSort(option.value)}
-                  className={`flex items-center gap-2 w-full px-3 py-2 text-sm transition ${
-                    isSelected
-                      ? 'bg-primary/10 text-primary'
-                      : 'text-text-secondary hover:bg-bg-modifier-hover hover:text-text-primary'
-                  }`}
+                  onClick={handleClear}
+                  className="flex items-center justify-center gap-2 w-full px-3 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-modifier-hover rounded-md transition"
                 >
-                  <Icon size={16} className={isSelected ? 'text-primary' : 'text-text-muted'} />
-                  <span className="flex-1 text-left">{option.label}</span>
-                  {isSelected && (
-                    <>
-                      <DirectionIcon size={12} className="text-primary" />
-                      <Check size={14} className="text-primary" />
-                    </>
-                  )}
+                  <X size={14} />
+                  {t('sort.clear', { defaultValue: '清除筛选' })}
                 </button>
-              )
-            })}
+              </div>
+            )}
           </div>
         </>
       )}

--- a/apps/web/src/components/channel/channel-sort-button.tsx
+++ b/apps/web/src/components/channel/channel-sort-button.tsx
@@ -117,7 +117,7 @@ export function ChannelSortFilterButton({
             onClick={() => setIsOpen(false)}
             aria-label="Close"
           />
-          <div className="absolute right-0 top-full mt-1 z-50 w-64 bg-bg-tertiary rounded-lg shadow-lg border border-border-subtle py-2">
+          <div className="absolute left-0 top-full mt-1 z-[100] w-64 bg-bg-tertiary rounded-lg shadow-lg border border-border-subtle py-2">
             {/* Filter Input */}
             <div className="px-3 pb-2 border-b border-border-subtle">
               <div className="flex items-center gap-2 px-2 py-1.5 bg-bg-primary/50 rounded-md">

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -1240,5 +1240,15 @@
     "hourShort": "h",
     "minShort": "m",
     "secShort": "s"
+  },
+  "sort": {
+    "title": "Sort & Filter",
+    "byPosition": "Default Order",
+    "byCreatedAt": "Created Time",
+    "byUpdatedAt": "Updated Time",
+    "byLastMessage": "Latest Message",
+    "byLastAccessed": "Last Accessed",
+    "filterPlaceholder": "Search channels...",
+    "clear": "Clear Filters"
   }
 }

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -237,7 +237,8 @@
     "noSearchResults": "No matching Buddy found",
     "homepageHtml": "Homepage HTML",
     "homepageHtmlPlaceholder": "<h1>Welcome!</h1>\n<p>This is the server homepage.</p>",
-    "homepageHtmlDesc": "Custom HTML for the server homepage. Leave empty to use the default."
+    "homepageHtmlDesc": "Custom HTML for the server homepage. Leave empty to use the default.",
+    "channels": "Channels"
   },
   "chat": {
     "selectChannel": "Select a channel to start chatting",

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -237,7 +237,8 @@
     "noSearchResults": "未找到匹配的 Buddy",
     "homepageHtml": "主页 HTML",
     "homepageHtmlPlaceholder": "<h1>欢迎！</h1>\n<p>这是服务器主页。</p>",
-    "homepageHtmlDesc": "服务器主页的自定义 HTML。留空使用默认主页。"
+    "homepageHtmlDesc": "服务器主页的自定义 HTML。留空使用默认主页。",
+    "channels": "频道"
   },
   "chat": {
     "selectChannel": "选择一个频道开始聊天",

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -1240,5 +1240,15 @@
     "hourShort": "时",
     "minShort": "分",
     "secShort": "秒"
+  },
+  "sort": {
+    "title": "排序和筛选",
+    "byPosition": "默认顺序",
+    "byCreatedAt": "创建时间",
+    "byUpdatedAt": "更新时间",
+    "byLastMessage": "最新消息",
+    "byLastAccessed": "访问时间",
+    "filterPlaceholder": "搜索频道...",
+    "clear": "清除筛选"
   }
 }


### PR DESCRIPTION
## Summary

改进 Web 端频道排序的产品体验：

## Changes

- 将排序按钮移到频道列表顶端（所有分类之上），显示为 "频道" 标题栏
- 使用 ListFilter 筛选图标代替文字按钮，更加紧凑
- 添加关键字过滤功能，支持按频道名称搜索
- 当有排序或筛选条件时，按钮高亮显示
- 下拉菜单中添加清除按钮，一键重置排序和筛选
- 去掉每个频道分类的冗余加号按钮，只保留顶部一个
- 空频道分类（如公告频道）自动隐藏
- 修复下拉菜单被左边栏遮挡的问题（改为左对齐）

## Screenshots

- 筛选按钮位于频道列表顶部，左侧显示"频道"标题
- 点击按钮弹出下拉菜单，包含搜索框和排序选项
- 搜索框支持实时过滤频道列表

## Testing

- [x] 构建成功
- [x] 类型检查通过
- [x] lint 检查通过

## Related

优化频道排序交互体验