### PR TITLE
feat(web): add public/private toggle to create server dialog

### DIFF
--- a/apps/web/src/components/server/server-sidebar.tsx
+++ b/apps/web/src/components/server/server-sidebar.tsx
@@ -1,6 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { Check, Compass, Copy, Info, Lock, LogOut, Plus, UserPlus, Volume2 } from 'lucide-react'
+import {
+  Check,
+  Compass,
+  Copy,
+  Globe,
+  Info,
+  Lock,
+  LogOut,
+  Plus,
+  UserPlus,
+  Volume2,
+} from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSocketEvent } from '../../hooks/use-socket'
@@ -10,8 +21,8 @@ import { getCatAvatar } from '../../lib/pixel-cats'
 import { useAuthStore } from '../../stores/auth.store'
 import { useChatStore } from '../../stores/chat.store'
 import { useUIStore } from '../../stores/ui.store'
-import { ContextMenu, type ContextMenuGroup } from '../common/context-menu'
 import { useConfirmStore } from '../common/confirm-dialog'
+import { ContextMenu, type ContextMenuGroup } from '../common/context-menu'
 
 interface ServerEntry {
   server: {
@@ -44,6 +55,7 @@ export function ServerSidebar({ onNavigate }: { onNavigate?: () => void } = {}) 
   const [showCreate, setShowCreate] = useState(false)
   const [showJoin, setShowJoin] = useState(false)
   const [newName, setNewName] = useState('')
+  const [isPublic, setIsPublic] = useState(true)
   const [joinCode, setJoinCode] = useState('')
   const [copiedId, setCopiedId] = useState(false)
   const [contextMenu, setContextMenu] = useState<{
@@ -95,15 +107,16 @@ export function ServerSidebar({ onNavigate }: { onNavigate?: () => void } = {}) 
   })
 
   const createServer = useMutation({
-    mutationFn: (name: string) =>
+    mutationFn: ({ name, isPublic }: { name: string; isPublic: boolean }) =>
       fetchApi<{ id: string; slug: string | null }>('/api/servers', {
         method: 'POST',
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name, isPublic }),
       }),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['servers'] })
       setShowCreate(false)
       setNewName('')
+      setIsPublic(true)
       handleSelect(data.id, data.slug)
     },
   })
@@ -395,12 +408,44 @@ export function ServerSidebar({ onNavigate }: { onNavigate?: () => void } = {}) 
                   newName.trim()
                 ) {
                   e.preventDefault()
-                  createServer.mutate(newName.trim())
+                  createServer.mutate({ name: newName.trim(), isPublic })
                 }
               }}
               placeholder={t('server.serverName')}
               className="w-full bg-bg-tertiary text-text-primary rounded-lg px-4 py-3 outline-none focus:ring-2 focus:ring-primary mb-4"
             />
+            {/* Public/Private toggle */}
+            <div className="flex items-center justify-between mb-4 p-3 bg-bg-tertiary rounded-lg">
+              <div className="flex items-center gap-3">
+                <div className="w-8 h-8 rounded-full bg-bg-primary flex items-center justify-center">
+                  {isPublic ? (
+                    <Globe size={16} className="text-text-primary" />
+                  ) : (
+                    <Lock size={16} className="text-text-primary" />
+                  )}
+                </div>
+                <div>
+                  <div className="text-text-primary font-medium text-sm">
+                    {isPublic ? t('server.publicServer') : t('server.privateServer')}
+                  </div>
+                  <div className="text-text-muted text-xs">
+                    {isPublic ? t('server.publicServerDesc') : t('server.privateServerDesc')}
+                  </div>
+                </div>
+              </div>
+              <button
+                onClick={() => setIsPublic(!isPublic)}
+                className={`relative w-11 h-6 rounded-full transition-colors ${
+                  isPublic ? 'bg-primary' : 'bg-bg-primary'
+                }`}
+              >
+                <span
+                  className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${
+                    isPublic ? 'translate-x-5' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </div>
             <div className="flex justify-end gap-3">
               <button
                 onClick={() => setShowCreate(false)}
@@ -409,7 +454,9 @@ export function ServerSidebar({ onNavigate }: { onNavigate?: () => void } = {}) 
                 {t('common.cancel')}
               </button>
               <button
-                onClick={() => newName.trim() && createServer.mutate(newName.trim())}
+                onClick={() =>
+                  newName.trim() && createServer.mutate({ name: newName.trim(), isPublic })
+                }
                 disabled={!newName.trim() || createServer.isPending}
                 className="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded-lg transition disabled:opacity-50 font-bold"
               >
@@ -483,12 +530,14 @@ export function ServerSidebar({ onNavigate }: { onNavigate?: () => void } = {}) 
                 {
                   icon: Info,
                   label: t('server.serverInfo'),
-                  onClick: () => handleSelect(contextMenu.server.server.id, contextMenu.server.server.slug),
+                  onClick: () =>
+                    handleSelect(contextMenu.server.server.id, contextMenu.server.server.slug),
                 },
                 {
                   icon: UserPlus,
                   label: t('server.inviteMembers'),
-                  onClick: () => handleSelect(contextMenu.server.server.id, contextMenu.server.server.slug),
+                  onClick: () =>
+                    handleSelect(contextMenu.server.server.id, contextMenu.server.server.slug),
                 },
               ],
             },
@@ -496,7 +545,9 @@ export function ServerSidebar({ onNavigate }: { onNavigate?: () => void } = {}) 
               items: [
                 {
                   icon: Volume2,
-                  label: (notificationPreference?.mutedServerIds ?? []).includes(contextMenu.server.server.id)
+                  label: (notificationPreference?.mutedServerIds ?? []).includes(
+                    contextMenu.server.server.id,
+                  )
                     ? '取消静音服务器'
                     : '静音服务器通知',
                   onClick: () => {

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -192,7 +192,11 @@
     "leaveServer": "Leave Server",
     "leaveConfirm": "Are you sure you want to leave \"{{name}}\"?",
     "publicBadge": "Public",
-    "homeWelcome": "Select a channel from the sidebar to start chatting, or explore the server."
+    "homeWelcome": "Select a channel from the sidebar to start chatting, or explore the server.",
+    "publicServer": "Public Server",
+    "privateServer": "Private Server",
+    "publicServerDesc": "Discoverable by everyone on the Discover page",
+    "privateServerDesc": "Join by invite code only"
   },
   "channel": {
     "serverSettings": "Server Settings",

--- a/apps/web/src/lib/locales/ja.json
+++ b/apps/web/src/lib/locales/ja.json
@@ -192,7 +192,11 @@
     "leaveServer": "サーバーから退出",
     "leaveConfirm": "サーバー \"{{name}}\" から退出しますか？",
     "publicBadge": "公開",
-    "homeWelcome": "サイドバーからチャンネルを選択してチャットを開始するか、サーバーを探索してください。"
+    "homeWelcome": "サイドバーからチャンネルを選択してチャットを開始するか、サーバーを探索してください。",
+    "publicServer": "公開サーバー",
+    "privateServer": "非公開サーバー",
+    "publicServerDesc": "誰でも探索ページで発見できます",
+    "privateServerDesc": "招待コードでのみ参加可能"
   },
   "channel": {
     "serverSettings": "サーバー設定",

--- a/apps/web/src/lib/locales/ko.json
+++ b/apps/web/src/lib/locales/ko.json
@@ -192,7 +192,11 @@
     "leaveServer": "서버 나가기",
     "leaveConfirm": "서버 \"{{name}}\"에서 나가시겠습니까?",
     "publicBadge": "공개",
-    "homeWelcome": "사이드바에서 채널을 선택하여 채팅을 시작하거나 서버를 탐색하세요."
+    "homeWelcome": "사이드바에서 채널을 선택하여 채팅을 시작하거나 서버를 탐색하세요.",
+    "publicServer": "공개 서버",
+    "privateServer": "비공개 서버",
+    "publicServerDesc": "누구나 탐색 페이지에서 발견할 수 있습니다",
+    "privateServerDesc": "초대 코드로만 참가 가능"
   },
   "channel": {
     "serverSettings": "서버 설정",

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -192,7 +192,11 @@
     "leaveServer": "离开服务器",
     "leaveConfirm": "确定要离开服务器 \"{{name}}\" 吗？",
     "publicBadge": "公开",
-    "homeWelcome": "从侧栏选择频道开始聊天，或浏览服务器。"
+    "homeWelcome": "从侧栏选择频道开始聊天，或浏览服务器。",
+    "publicServer": "公开服务器",
+    "privateServer": "私有服务器",
+    "publicServerDesc": "所有人都可以在探索页面发现",
+    "privateServerDesc": "仅通过邀请码加入"
   },
   "channel": {
     "serverSettings": "服务器设置",

--- a/apps/web/src/lib/locales/zh-TW.json
+++ b/apps/web/src/lib/locales/zh-TW.json
@@ -192,7 +192,11 @@
     "leaveServer": "離開伺服器",
     "leaveConfirm": "確定要離開伺服器 \"{{name}}\" 嗎？",
     "publicBadge": "公開",
-    "homeWelcome": "從側欄選擇頻道開始聊天，或瀏覽伺服器。"
+    "homeWelcome": "從側欄選擇頻道開始聊天，或瀏覽伺服器。",
+    "publicServer": "公開伺服器",
+    "privateServer": "私有伺服器",
+    "publicServerDesc": "所有人都可以在探索頁面發現",
+    "privateServerDesc": "僅透過邀請碼加入"
   },
   "channel": {
     "serverSettings": "伺服器設定",


### PR DESCRIPTION
## Summary

Add a public/private toggle to the web create server dialog, allowing users to choose server visibility when creating a new server.

## Changes

- Add `isPublic` state to server-sidebar.tsx, default to `true` (public)
- Update `createServer` mutation to include `isPublic` parameter
- Add toggle UI with Globe/Lock icons and descriptions
- Add translations for all supported languages (zh-CN, zh-TW, en, ja, ko)

## UI Preview

The create server dialog now includes a toggle switch that allows users to choose between:
- **Public Server**: Discoverable by everyone on the Discover page (default)
- **Private Server**: Join by invite code only

## Testing

- [x] Build passes
- [x] Toggle defaults to public (isPublic = true)
- [x] Toggle state is passed to API correctly