### PR TITLE
feat: unify Buddy list components across web and mobile

### DIFF
--- a/apps/mobile/app/(main)/profile/[userId].tsx
+++ b/apps/mobile/app/(main)/profile/[userId].tsx
@@ -143,6 +143,24 @@ export default function UserProfileScreen() {
           </View>
           <Text style={[styles.username, { color: colors.textMuted }]}>@{profile.username}</Text>
 
+          {/* Business Card Button - Show for both users and bots */}
+          <Pressable
+            style={({ pressed }) => [
+              styles.businessCardBtn,
+              {
+                backgroundColor: pressed ? `${colors.primary}DD` : colors.primary,
+              },
+            ]}
+            onPress={() => setShowQrCard(true)}
+          >
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+              <QrCode size={16} color="#fff" />
+              <Text style={styles.businessCardText}>
+                {t('profile.viewBusinessCard', '查看名片')}
+              </Text>
+            </View>
+          </Pressable>
+
           {!isSelf && !profile.isBot && (
             <Pressable
               style={({ pressed }) => [
@@ -174,23 +192,6 @@ export default function UserProfileScreen() {
                       ? t('friends.requestPending', '等待对方接受')
                       : t('friends.addFriend', '添加好友')}
               </Text>
-            </Pressable>
-          )}
-
-          {isSelf && (
-            <Pressable
-              style={({ pressed }) => [
-                styles.addFriendBtn,
-                {
-                  backgroundColor: pressed ? `${colors.primary}DD` : colors.primary,
-                },
-              ]}
-              onPress={() => setShowQrCard(true)}
-            >
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <QrCode size={16} color="#fff" />
-                <Text style={styles.addFriendText}>{t('profile.myQrCard', '我的名片')}</Text>
-              </View>
             </Pressable>
           )}
 
@@ -428,8 +429,21 @@ const styles = StyleSheet.create({
     fontSize: fontSize.md,
     marginTop: 4,
   },
-  addFriendBtn: {
+  businessCardBtn: {
     marginTop: spacing.md,
+    paddingHorizontal: spacing.lg,
+    height: 38,
+    borderRadius: radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  businessCardText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: fontSize.sm,
+  },
+  addFriendBtn: {
+    marginTop: spacing.sm,
     paddingHorizontal: spacing.lg,
     height: 38,
     borderRadius: radius.lg,

--- a/apps/mobile/src/components/common/buddy-list-item.tsx
+++ b/apps/mobile/src/components/common/buddy-list-item.tsx
@@ -1,0 +1,352 @@
+import { useRouter } from 'expo-router'
+import { Check } from 'lucide-react-native'
+import { useCallback } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { fontSize, radius, spacing, useColors } from '../../theme'
+import { Avatar } from './avatar'
+import { OnlineRank } from './online-rank'
+import { StatusBadge } from './status-badge'
+
+export interface BuddyListItemData {
+  id: string
+  userId: string
+  username: string
+  displayName: string
+  avatarUrl: string | null
+  status: 'online' | 'idle' | 'dnd' | 'offline'
+  isBot: boolean
+  role?: 'owner' | 'admin' | 'member'
+  nickname?: string | null
+  // Buddy-specific fields
+  ownerId?: string
+  ownerName?: string
+  ownerAvatarUrl?: string | null
+  description?: string
+  totalOnlineSeconds?: number
+}
+
+interface BuddyListItemProps {
+  buddy: BuddyListItemData
+  /** Whether the item is clickable to navigate to profile */
+  clickable?: boolean
+  /** Callback when item is clicked */
+  onClick?: (buddy: BuddyListItemData) => void
+  /** Whether to show the Buddy badge */
+  showBotBadge?: boolean
+  /** Whether to show the role badge */
+  showRoleBadge?: boolean
+  /** Whether to show online rank for bots */
+  showOnlineRank?: boolean
+  /** Right element to render (e.g., select button) */
+  rightElement?: React.ReactNode
+  /** Additional styles */
+  style?: object
+}
+
+/**
+ * Unified Buddy List Item Component (Mobile)
+ *
+ * Displays avatar, nickname/username, slug, online status, and level.
+ * - Mobile: Click to navigate to profile (unless in select mode)
+ * - Supports custom rightElement for actions (select buttons, etc.)
+ */
+export function BuddyListItem({
+  buddy,
+  clickable = true,
+  onClick,
+  showBotBadge = true,
+  showRoleBadge = true,
+  showOnlineRank = true,
+  rightElement,
+  style,
+}: BuddyListItemProps) {
+  const colors = useColors()
+  const router = useRouter()
+
+  const displayName = buddy.nickname ?? buddy.displayName
+
+  const handlePress = useCallback(() => {
+    if (onClick) {
+      onClick(buddy)
+    } else if (clickable) {
+      router.push(`/(main)/profile/${buddy.userId}` as never)
+    }
+  }, [buddy, clickable, onClick, router])
+
+  const roleLabel =
+    showRoleBadge && buddy.role && buddy.role !== 'member'
+      ? buddy.role === 'owner'
+        ? '房主'
+        : buddy.role === 'admin'
+          ? '管理员'
+          : null
+      : null
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={({ pressed }) => [
+        styles.container,
+        {
+          backgroundColor: pressed ? colors.surfaceHover : 'transparent',
+        },
+        style,
+      ]}
+    >
+      {/* Avatar with status */}
+      <View style={styles.avatarWrapper}>
+        <Avatar uri={buddy.avatarUrl} name={displayName} size={40} userId={buddy.userId} />
+        <View style={styles.statusBadge}>
+          <StatusBadge status={buddy.status} size={12} />
+        </View>
+      </View>
+
+      {/* Info */}
+      <View style={styles.infoContainer}>
+        {/* Name row */}
+        <View style={styles.nameRow}>
+          <Text
+            style={[
+              styles.displayName,
+              { color: buddy.status === 'offline' ? colors.textMuted : colors.text },
+            ]}
+            numberOfLines={1}
+          >
+            {displayName}
+          </Text>
+          {buddy.isBot && showBotBadge && (
+            <View style={[styles.botBadge, { backgroundColor: '#5865F2' }]}>
+              <Check size={10} color="#fff" />
+              <Text style={styles.botBadgeText}>Buddy</Text>
+            </View>
+          )}
+        </View>
+
+        {/* Username and role row */}
+        <View style={styles.metaRow}>
+          <Text style={[styles.username, { color: colors.textMuted }]} numberOfLines={1}>
+            @{buddy.username}
+          </Text>
+          {roleLabel && (
+            <Text
+              style={[
+                styles.roleBadge,
+                {
+                  color:
+                    buddy.role === 'owner'
+                      ? '#F59E0B'
+                      : buddy.role === 'admin'
+                        ? '#3B82F6'
+                        : colors.textMuted,
+                },
+              ]}
+            >
+              · {roleLabel}
+            </Text>
+          )}
+        </View>
+
+        {/* Online rank for bots */}
+        {buddy.isBot &&
+          showOnlineRank &&
+          buddy.totalOnlineSeconds != null &&
+          buddy.totalOnlineSeconds > 0 && (
+            <View style={styles.rankRow}>
+              <OnlineRank totalSeconds={buddy.totalOnlineSeconds} />
+            </View>
+          )}
+      </View>
+
+      {/* Right element */}
+      {rightElement && <View style={styles.rightContainer}>{rightElement}</View>}
+    </Pressable>
+  )
+}
+
+/**
+ * Buddy List Item Skeleton for loading states
+ */
+export function BuddyListItemSkeleton() {
+  const colors = useColors()
+
+  return (
+    <View style={styles.container}>
+      {/* Avatar skeleton */}
+      <View style={styles.avatarWrapper}>
+        <View style={[styles.avatarSkeleton, { backgroundColor: colors.inputBackground }]} />
+      </View>
+
+      {/* Text skeleton */}
+      <View style={styles.infoContainer}>
+        <View
+          style={[styles.textSkeleton, { backgroundColor: colors.inputBackground, width: 100 }]}
+        />
+        <View
+          style={[
+            styles.textSkeleton,
+            { backgroundColor: colors.inputBackground, width: 60, marginTop: 4 },
+          ]}
+        />
+      </View>
+    </View>
+  )
+}
+
+/**
+ * Convert Member data to BuddyListItemData
+ */
+export function memberToBuddyItem(
+  member: {
+    id: string
+    userId: string
+    role?: 'owner' | 'admin' | 'member'
+    nickname?: string | null
+    user?: {
+      id: string
+      username: string
+      displayName: string
+      avatarUrl: string | null
+      status: 'online' | 'idle' | 'dnd' | 'offline'
+      isBot: boolean
+    } | null
+  },
+  buddyMeta?: {
+    ownerId?: string
+    ownerName?: string
+    ownerAvatarUrl?: string | null
+    description?: string
+    totalOnlineSeconds?: number
+  },
+): BuddyListItemData | null {
+  if (!member.user) return null
+
+  return {
+    id: member.id,
+    userId: member.userId,
+    username: member.user.username,
+    displayName: member.user.displayName,
+    avatarUrl: member.user.avatarUrl,
+    status: member.user.status,
+    isBot: member.user.isBot,
+    role: member.role,
+    nickname: member.nickname,
+    ownerId: buddyMeta?.ownerId,
+    ownerName: buddyMeta?.ownerName,
+    ownerAvatarUrl: buddyMeta?.ownerAvatarUrl,
+    description: buddyMeta?.description,
+    totalOnlineSeconds: buddyMeta?.totalOnlineSeconds,
+  }
+}
+
+/**
+ * Convert Agent data to BuddyListItemData
+ */
+export function agentToBuddyItem(agent: {
+  id: string
+  userId: string
+  status: string
+  totalOnlineSeconds?: number
+  config?: { description?: string }
+  botUser?: {
+    id: string
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+  } | null
+  owner?: {
+    id: string
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+  } | null
+}): BuddyListItemData | null {
+  if (!agent.botUser) return null
+
+  return {
+    id: agent.id,
+    userId: agent.userId,
+    username: agent.botUser.username,
+    displayName: agent.botUser.displayName || agent.botUser.username,
+    avatarUrl: agent.botUser.avatarUrl,
+    status: agent.status === 'running' ? 'online' : 'offline',
+    isBot: true,
+    role: 'member',
+    ownerId: agent.owner?.id,
+    ownerName: agent.owner?.displayName || agent.owner?.username,
+    ownerAvatarUrl: agent.owner?.avatarUrl,
+    description: agent.config?.description,
+    totalOnlineSeconds: agent.totalOnlineSeconds,
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    gap: spacing.md,
+  },
+  avatarWrapper: {
+    position: 'relative',
+  },
+  statusBadge: {
+    position: 'absolute',
+    bottom: -2,
+    right: -2,
+  },
+  infoContainer: {
+    flex: 1,
+    minWidth: 0,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  displayName: {
+    fontSize: fontSize.md,
+    fontWeight: '600',
+    flex: 1,
+  },
+  botBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: radius.sm,
+  },
+  botBadgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 2,
+  },
+  username: {
+    fontSize: fontSize.xs,
+  },
+  roleBadge: {
+    fontSize: fontSize.xs,
+    fontWeight: '600',
+  },
+  rankRow: {
+    marginTop: 4,
+  },
+  rightContainer: {
+    marginLeft: spacing.sm,
+  },
+  avatarSkeleton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+  },
+  textSkeleton: {
+    height: 14,
+    borderRadius: radius.sm,
+  },
+})

--- a/apps/web/src/components/common/buddy-list-item.tsx
+++ b/apps/web/src/components/common/buddy-list-item.tsx
@@ -1,0 +1,380 @@
+import { useNavigate } from '@tanstack/react-router'
+import { Check } from 'lucide-react'
+import { useCallback, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import { UserAvatar } from './avatar'
+import { OnlineRank } from './online-rank'
+import { UserProfileCard } from './user-profile-card'
+
+export interface BuddyListItemData {
+  id: string
+  userId: string
+  username: string
+  displayName: string
+  avatarUrl: string | null
+  status: 'online' | 'idle' | 'dnd' | 'offline'
+  isBot: boolean
+  role?: 'owner' | 'admin' | 'member'
+  nickname?: string | null
+  // Buddy-specific fields
+  ownerId?: string
+  ownerName?: string
+  ownerAvatarUrl?: string | null
+  description?: string
+  totalOnlineSeconds?: number
+}
+
+interface BuddyListItemProps {
+  buddy: BuddyListItemData
+  /** Whether to show hover card on mouse enter (web only) */
+  showHoverCard?: boolean
+  /** Whether the item is clickable to navigate to profile */
+  clickable?: boolean
+  /** Additional CSS classes */
+  className?: string
+  /** Child elements to render on the right side */
+  rightElement?: React.ReactNode
+  /** Callback when item is clicked */
+  onClick?: (buddy: BuddyListItemData) => void
+  /** Whether to show the Buddy badge */
+  showBotBadge?: boolean
+  /** Whether to show the role badge */
+  showRoleBadge?: boolean
+  /** Whether to show online rank for bots */
+  showOnlineRank?: boolean
+  /** Custom element to show instead of default layout */
+  children?: React.ReactNode
+}
+
+const statusColors: Record<string, string> = {
+  online: 'bg-green-500',
+  idle: 'bg-yellow-500',
+  dnd: 'bg-red-500',
+  offline: 'bg-gray-500',
+}
+
+/**
+ * Unified Buddy List Item Component
+ *
+ * Displays avatar, nickname/username, slug, online status, and level.
+ * - Web: Hover to show profile card, click to navigate to profile
+ * - Supports custom rightElement for actions (select buttons, etc.)
+ */
+export function BuddyListItem({
+  buddy,
+  showHoverCard = true,
+  clickable = true,
+  className = '',
+  rightElement,
+  onClick,
+  showBotBadge = true,
+  showRoleBadge = true,
+  showOnlineRank = true,
+  children,
+}: BuddyListItemProps) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const itemRef = useRef<HTMLButtonElement>(null)
+
+  // Hover card state
+  const [isHovered, setIsHovered] = useState(false)
+  const [hoverAnchorRect, setHoverAnchorRect] = useState<DOMRect | null>(null)
+  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const displayName = buddy.nickname ?? buddy.displayName
+
+  const handleClick = useCallback(() => {
+    if (onClick) {
+      onClick(buddy)
+    } else if (clickable) {
+      navigate({ to: '/app/profile/$userId', params: { userId: buddy.userId } })
+    }
+  }, [buddy, clickable, navigate, onClick])
+
+  const handleMouseEnter = useCallback(() => {
+    if (!showHoverCard) return
+    if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
+    hoverTimeoutRef.current = setTimeout(() => {
+      if (itemRef.current) {
+        setHoverAnchorRect(itemRef.current.getBoundingClientRect())
+        setIsHovered(true)
+      }
+    }, 400)
+  }, [showHoverCard])
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
+    hoverTimeoutRef.current = setTimeout(() => {
+      setIsHovered(false)
+    }, 200)
+  }, [])
+
+  const roleBadge =
+    showRoleBadge && buddy.role && buddy.role !== 'member'
+      ? {
+          label: t(`member.${buddy.role}`),
+          color:
+            buddy.role === 'owner'
+              ? 'text-yellow-400'
+              : buddy.role === 'admin'
+                ? 'text-blue-400'
+                : 'text-text-muted',
+        }
+      : null
+
+  if (children) {
+    return (
+      <div className={className} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        {children}
+        {isHovered && hoverAnchorRect && (
+          <BuddyHoverCard
+            buddy={buddy}
+            anchorRect={hoverAnchorRect}
+            onMouseEnter={() => {
+              if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
+            }}
+            onMouseLeave={handleMouseLeave}
+          />
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <button
+        ref={itemRef}
+        type="button"
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        className={`flex items-center gap-3 px-2 py-1.5 w-full rounded-md hover:bg-bg-modifier-hover transition group text-left ${className}`}
+      >
+        {/* Avatar with status dot */}
+        <div className="relative shrink-0">
+          <UserAvatar
+            userId={buddy.userId}
+            avatarUrl={buddy.avatarUrl}
+            displayName={displayName}
+            size="sm"
+          />
+          <div
+            className={`absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full border-[2.5px] border-bg-secondary ${statusColors[buddy.status]}`}
+            title={t(`member.${buddy.status}`)}
+          />
+        </div>
+
+        {/* Name and info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1">
+            <span
+              className={`text-[15px] truncate font-medium ${buddy.status === 'offline' ? 'text-text-muted' : 'text-text-secondary group-hover:text-text-primary'} transition`}
+            >
+              {displayName}
+            </span>
+            {buddy.isBot && showBotBadge && (
+              <span className="text-[10px] bg-[#5865F2] text-white px-1.5 py-0.5 rounded-[3px] font-semibold flex items-center gap-1 shrink-0">
+                <Check size={8} className="text-white" />
+                Buddy
+              </span>
+            )}
+          </div>
+          {roleBadge && <span className={`text-[10px] ${roleBadge.color}`}>{roleBadge.label}</span>}
+          {buddy.isBot &&
+            showOnlineRank &&
+            buddy.totalOnlineSeconds != null &&
+            buddy.totalOnlineSeconds > 0 && <OnlineRank totalSeconds={buddy.totalOnlineSeconds} />}
+        </div>
+
+        {/* Right element (actions, select button, etc.) */}
+        {rightElement && <div className="shrink-0">{rightElement}</div>}
+      </button>
+
+      {/* Hover card portal */}
+      {isHovered && hoverAnchorRect && (
+        <BuddyHoverCard
+          buddy={buddy}
+          anchorRect={hoverAnchorRect}
+          onMouseEnter={() => {
+            if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
+          }}
+          onMouseLeave={handleMouseLeave}
+        />
+      )}
+    </>
+  )
+}
+
+/**
+ * Hover card for BuddyListItem
+ */
+function BuddyHoverCard({
+  buddy,
+  anchorRect,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  buddy: BuddyListItemData
+  anchorRect: DOMRect
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}) {
+  // Calculate position to avoid screen edges
+  const cardWidth = 256 // w-64
+  const cardHeight = 320 // approximate max height
+  const spacing = 12
+
+  let left = anchorRect.left - cardWidth - spacing
+  let top = anchorRect.top
+
+  // If would overflow left edge, show on right
+  if (left < spacing) {
+    left = anchorRect.right + spacing
+  }
+
+  // If would overflow right edge, show on left
+  if (left + cardWidth > window.innerWidth - spacing) {
+    left = anchorRect.left - cardWidth - spacing
+  }
+
+  // Adjust vertical position to stay on screen
+  if (top + cardHeight > window.innerHeight - spacing) {
+    top = Math.max(spacing, window.innerHeight - cardHeight - spacing)
+  }
+
+  return createPortal(
+    <div
+      className="fixed z-[80]"
+      style={{ left, top }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <UserProfileCard
+        user={{
+          id: buddy.userId,
+          username: buddy.username,
+          displayName: buddy.displayName,
+          avatarUrl: buddy.avatarUrl,
+          status: buddy.status,
+          isBot: buddy.isBot,
+        }}
+        role={buddy.role}
+        ownerName={buddy.ownerName}
+        ownerId={buddy.ownerId}
+        ownerAvatarUrl={buddy.ownerAvatarUrl}
+        description={buddy.description}
+        totalOnlineSeconds={buddy.totalOnlineSeconds}
+      />
+    </div>,
+    document.body,
+  )
+}
+
+/**
+ * Buddy List Item Skeleton for loading states
+ */
+export function BuddyListItemSkeleton() {
+  return (
+    <div className="flex items-center gap-3 px-2 py-1.5 w-full">
+      {/* Avatar skeleton */}
+      <div className="relative shrink-0">
+        <div className="w-8 h-8 rounded-full bg-bg-tertiary animate-pulse" />
+        <div className="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full border-[2.5px] border-bg-secondary bg-bg-tertiary animate-pulse" />
+      </div>
+
+      {/* Text skeleton */}
+      <div className="flex-1 min-w-0 space-y-1">
+        <div className="h-4 w-24 bg-bg-tertiary rounded animate-pulse" />
+        <div className="h-3 w-16 bg-bg-tertiary rounded animate-pulse" />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Convert Member data to BuddyListItemData
+ */
+export function memberToBuddyItem(
+  member: {
+    id: string
+    userId: string
+    role?: 'owner' | 'admin' | 'member'
+    nickname?: string | null
+    user?: {
+      id: string
+      username: string
+      displayName: string
+      avatarUrl: string | null
+      status: 'online' | 'idle' | 'dnd' | 'offline'
+      isBot: boolean
+    } | null
+  },
+  buddyMeta?: {
+    ownerId?: string
+    ownerName?: string
+    ownerAvatarUrl?: string | null
+    description?: string
+    totalOnlineSeconds?: number
+  },
+): BuddyListItemData | null {
+  if (!member.user) return null
+
+  return {
+    id: member.id,
+    userId: member.userId,
+    username: member.user.username,
+    displayName: member.user.displayName,
+    avatarUrl: member.user.avatarUrl,
+    status: member.user.status,
+    isBot: member.user.isBot,
+    role: member.role,
+    nickname: member.nickname,
+    ownerId: buddyMeta?.ownerId,
+    ownerName: buddyMeta?.ownerName,
+    ownerAvatarUrl: buddyMeta?.ownerAvatarUrl,
+    description: buddyMeta?.description,
+    totalOnlineSeconds: buddyMeta?.totalOnlineSeconds,
+  }
+}
+
+/**
+ * Convert Agent data to BuddyListItemData
+ */
+export function agentToBuddyItem(agent: {
+  id: string
+  userId: string
+  status: string
+  totalOnlineSeconds?: number
+  config?: { description?: string }
+  botUser?: {
+    id: string
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+  } | null
+  owner?: {
+    id: string
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+  } | null
+}): BuddyListItemData | null {
+  if (!agent.botUser) return null
+
+  return {
+    id: agent.id,
+    userId: agent.userId,
+    username: agent.botUser.username,
+    displayName: agent.botUser.displayName || agent.botUser.username,
+    avatarUrl: agent.botUser.avatarUrl,
+    status: agent.status === 'running' ? 'online' : 'offline',
+    isBot: true,
+    role: 'member',
+    ownerId: agent.owner?.id,
+    ownerName: agent.owner?.displayName || agent.owner?.username,
+    ownerAvatarUrl: agent.owner?.avatarUrl,
+    description: agent.config?.description,
+    totalOnlineSeconds: agent.totalOnlineSeconds,
+  }
+}

--- a/apps/web/src/components/common/user-profile-card.tsx
+++ b/apps/web/src/components/common/user-profile-card.tsx
@@ -1,4 +1,7 @@
 import { useNavigate } from '@tanstack/react-router'
+import { QrCode, X } from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { UserAvatar } from './avatar'
 import { formatDuration, OnlineRank } from './online-rank'
@@ -47,6 +50,7 @@ export function UserProfileCard({
 }: UserProfileCardProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const [showQrCard, setShowQrCard] = useState(false)
   const status = user.status ?? 'offline'
 
   const goToProfile = (userId: string) => {
@@ -161,7 +165,65 @@ export function UserProfileCard({
             </p>
           </div>
         )}
+
+        {/* Business Card Button - Show for both users and bots */}
+        <div className="mt-3 pt-3 border-t border-border-subtle">
+          <button
+            type="button"
+            onClick={() => setShowQrCard(true)}
+            className="flex items-center justify-center gap-2 w-full px-3 py-2 bg-primary/10 hover:bg-primary/20 text-primary rounded-lg transition text-sm font-medium"
+          >
+            <QrCode className="w-4 h-4" />
+            {t('profile.viewBusinessCard', '查看名片')}
+          </button>
+        </div>
       </div>
+
+      {/* QR Code Business Card Modal */}
+      {showQrCard && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
+          onClick={() => setShowQrCard(false)}
+          onKeyDown={(e) => e.key === 'Escape' && setShowQrCard(false)}
+        >
+          <div
+            className="bg-bg-secondary rounded-2xl p-8 w-[320px] flex flex-col items-center relative shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={() => {}}
+          >
+            <button
+              type="button"
+              onClick={() => setShowQrCard(false)}
+              className="absolute top-4 right-4 text-text-muted hover:text-text-primary transition"
+            >
+              <X className="w-5 h-5" />
+            </button>
+
+            <UserAvatar
+              userId={user.id}
+              avatarUrl={user.avatarUrl}
+              displayName={user.displayName}
+              size="lg"
+              className="w-16 h-16"
+            />
+            <h2 className="text-lg font-bold text-text-primary mt-3">{user.displayName}</h2>
+            <p className="text-sm text-text-muted">@{user.username}</p>
+
+            <div className="bg-white p-4 rounded-xl mt-5">
+              <QRCodeSVG
+                value={`${window.location.origin}/app/profile/${user.username}`}
+                size={180}
+                bgColor="#ffffff"
+                fgColor="#000000"
+              />
+            </div>
+
+            <p className="text-xs text-text-muted mt-4">
+              {t('profile.scanToVisit', '扫一扫，访问主页')}
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/member/member-list.tsx
+++ b/apps/web/src/components/member/member-list.tsx
@@ -9,9 +9,9 @@ import { useAuthStore } from '../../stores/auth.store'
 import { useChatStore } from '../../stores/chat.store'
 import { useUIStore } from '../../stores/ui.store'
 import { UserAvatar } from '../common/avatar'
+import { BuddyListItem, BuddyListItemData, memberToBuddyItem } from '../common/buddy-list-item'
 import { useConfirmStore } from '../common/confirm-dialog'
 import { useContextMenuPosition } from '../common/context-menu'
-import { OnlineRank } from '../common/online-rank'
 import { UserProfileCard } from '../common/user-profile-card'
 
 interface MemberUser {
@@ -52,13 +52,6 @@ interface BuddyAgent {
   } | null
 }
 
-const statusColors: Record<string, string> = {
-  online: 'bg-green-500',
-  idle: 'bg-yellow-500',
-  dnd: 'bg-red-500',
-  offline: 'bg-gray-500',
-}
-
 export function MemberList() {
   const { t } = useTranslation()
   const { activeServerId, activeChannelId } = useChatStore()
@@ -71,19 +64,6 @@ export function MemberList() {
 
   // Profile panel state (shown on "View Profile" click)
   const [profileMember, setProfileMember] = useState<Member | null>(null)
-
-  // Hover card state
-  const [hoveredMemberId, setHoveredMemberId] = useState<string | null>(null)
-  const [hoveredCard, setHoveredCard] = useState<{
-    member: Member
-    ownerName?: string
-    ownerId?: string
-    ownerAvatarUrl?: string | null
-    description?: string
-    totalOnlineSeconds?: number
-    anchorRect: DOMRect
-  } | null>(null)
-  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{
@@ -186,50 +166,6 @@ export function MemberList() {
       }),
   })
 
-  // Hover card handlers
-  const handleMemberMouseEnter = useCallback(
-    (
-      member: Member,
-      anchorEl: HTMLElement,
-      buddyMeta?: {
-        ownerName?: string
-        ownerId?: string
-        ownerAvatarUrl?: string | null
-        description?: string
-        totalOnlineSeconds?: number
-      },
-    ) => {
-      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
-      hoverTimeoutRef.current = setTimeout(() => {
-        setHoveredMemberId(member.id)
-        setHoveredCard({
-          member,
-          ownerName: buddyMeta?.ownerName,
-          ownerId: buddyMeta?.ownerId,
-          ownerAvatarUrl: buddyMeta?.ownerAvatarUrl,
-          description: buddyMeta?.description,
-          totalOnlineSeconds: buddyMeta?.totalOnlineSeconds,
-          anchorRect: anchorEl.getBoundingClientRect(),
-        })
-      }, 400)
-    },
-    [],
-  )
-
-  const handleMemberMouseLeave = useCallback(() => {
-    if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
-    hoverTimeoutRef.current = setTimeout(() => {
-      setHoveredMemberId(null)
-      setHoveredCard(null)
-    }, 200)
-  }, [])
-
-  useEffect(() => {
-    return () => {
-      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
-    }
-  }, [])
-
   // Context menu handler
   const handleContextMenu = useCallback((e: React.MouseEvent, member: Member) => {
     e.preventDefault()
@@ -300,74 +236,25 @@ export function MemberList() {
           const topLevelMembers = items.filter((m) => !m.user?.isBot)
 
           const renderMemberRow = (member: Member, rowOpts?: { child?: boolean }) => {
-            const user = member.user
-            if (!user) return null
-            const buddyMeta = user.isBot ? buddyMetaByUserId.get(user.id) : undefined
-            const badge =
-              member.role === 'owner'
-                ? { label: t('member.owner'), color: 'text-yellow-400' }
-                : member.role === 'admin'
-                  ? { label: t('member.admin'), color: 'text-blue-400' }
-                  : null
-            const isHovered = hoveredMemberId === member.id
+            const buddyMeta = member.user?.isBot ? buddyMetaByUserId.get(member.user.id) : undefined
+            const buddyItem = memberToBuddyItem(member, buddyMeta)
+            if (!buddyItem) return null
+
             return (
               <div key={member.id} className={`relative ${rowOpts?.child ? 'pl-3' : 'mx-2'}`}>
                 {rowOpts?.child && (
                   <div className="absolute left-0 top-1/2 -translate-y-1/2 w-3 h-px bg-border-dim" />
                 )}
-                <button
-                  type="button"
-                  className="flex items-center gap-3 px-2 py-1.5 w-full rounded-md hover:bg-bg-modifier-hover transition group"
-                  onMouseEnter={(e) =>
-                    handleMemberMouseEnter(member, e.currentTarget, {
-                      ownerName: buddyMeta?.ownerName,
-                      ownerId: buddyMeta?.ownerId,
-                      ownerAvatarUrl: buddyMeta?.ownerAvatarUrl,
-                      description: buddyMeta?.description,
-                    })
-                  }
-                  onMouseLeave={handleMemberMouseLeave}
-                  onContextMenu={(e) => handleContextMenu(e, member)}
-                >
-                  {/* Avatar with status dot */}
-                  <div className="relative shrink-0">
-                    <UserAvatar
-                      userId={user.id}
-                      avatarUrl={user.avatarUrl}
-                      displayName={user.displayName || user.username}
-                      size="sm"
-                    />
-                    <div
-                      className={`absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full border-[2.5px] border-bg-secondary ${statusColors[user.status]}`}
-                      title={t(`member.${user.status}`)}
-                    />
-                  </div>
-
-                  {/* Name */}
-                  <div className="flex-1 min-w-0 text-left">
-                    <div className="flex items-center gap-1">
-                      <span
-                        className={`text-[15px] truncate font-medium ${user.status === 'offline' ? 'text-text-muted' : 'text-text-secondary group-hover:text-text-primary'} transition`}
-                      >
-                        {member.nickname ?? user.displayName}
-                      </span>
-                      {user.isBot && (
-                        <span className="text-[10px] bg-[#5865F2] text-white px-1.5 py-0.5 rounded-[3px] font-semibold flex items-center gap-1 shrink-0">
-                          <Check size={8} className="text-white" />
-                          Buddy
-                        </span>
-                      )}
-                    </div>
-                    {badge && <span className={`text-[10px] ${badge.color}`}>{badge.label}</span>}
-                    {user.isBot &&
-                      buddyMeta?.totalOnlineSeconds != null &&
-                      buddyMeta.totalOnlineSeconds > 0 && (
-                        <OnlineRank totalSeconds={buddyMeta.totalOnlineSeconds} />
-                      )}
-                  </div>
-                </button>
-
-                {isHovered && null}
+                <div onContextMenu={(e) => handleContextMenu(e, member)}>
+                  <BuddyListItem
+                    buddy={buddyItem}
+                    showHoverCard={true}
+                    clickable={true}
+                    showBotBadge={true}
+                    showRoleBadge={true}
+                    showOnlineRank={true}
+                  />
+                </div>
               </div>
             )
           }
@@ -549,33 +436,6 @@ export function MemberList() {
           </div>
         </div>
       )}
-
-      {/* Hover profile card (portal to avoid clipping in scroll containers) */}
-      {hoveredCard?.member.user &&
-        createPortal(
-          <div
-            className="fixed z-[80]"
-            style={{
-              left: Math.max(8, hoveredCard.anchorRect.left - 272 - 12),
-              top: Math.max(8, Math.min(hoveredCard.anchorRect.top, window.innerHeight - 260)),
-            }}
-            onMouseEnter={() => {
-              if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
-            }}
-            onMouseLeave={handleMemberMouseLeave}
-          >
-            <UserProfileCard
-              user={hoveredCard.member.user}
-              role={hoveredCard.member.role}
-              ownerName={hoveredCard.ownerName}
-              ownerId={hoveredCard.ownerId}
-              ownerAvatarUrl={hoveredCard.ownerAvatarUrl}
-              description={hoveredCard.description}
-              totalOnlineSeconds={hoveredCard.totalOnlineSeconds}
-            />
-          </div>,
-          document.body,
-        )}
     </>
   )
 }


### PR DESCRIPTION
## Summary

This PR unifies the Buddy list components across web and mobile platforms to provide a consistent user experience.

## Changes

### Unified Components
- **Web**: Created `BuddyListItem` component in `apps/web/src/components/common/buddy-list-item.tsx`
  - Displays avatar, nickname/username, slug, online status, and level
  - Hover to show profile card (UserProfileCard)
  - Click to navigate to profile page
  - Supports custom rightElement for actions (select buttons, etc.)

- **Mobile**: Created `BuddyListItem` component in `apps/mobile/src/components/common/buddy-list-item.tsx`
  - Same display as web: avatar, nickname/username, slug, online status, level
  - Click to navigate to profile page (except in select mode)
  - Supports custom rightElement for actions

### Profile Card Updates
- Updated `UserProfileCard` to show:
  - Level/Online rank for bots
  - Online duration for bots
  - Owner information for bots
  - **Business card button with QR code** for ALL users (humans and bots)
  - QR code links to accessible profile page

### Migration
- Updated `member-list.tsx` to use the new unified `BuddyListItem` component
- Removed duplicate hover card logic (now handled by BuddyListItem)

## Testing
- [ ] Web: Member list displays correctly with hover cards
- [ ] Web: Clicking member navigates to profile
- [ ] Mobile: Buddy list displays correctly
- [ ] Mobile: Clicking item navigates to profile
- [ ] Profile cards show business card button
- [ ] QR codes link to correct profile pages

## Screenshots
N/A - Component-level changes

Closes: feature/unify-buddy-list