### PR TITLE
fix(web): remove redundant /app prefix from internal navigation links

### DIFF
--- a/apps/web/src/components/channel/channel-sidebar.tsx
+++ b/apps/web/src/components/channel/channel-sidebar.tsx
@@ -1558,7 +1558,7 @@ function InvitePanel({
           ) : availableBuddies.length === 0 ? (
             <div className="text-center py-8 text-text-muted text-sm">
               暂无可用 Buddy，
-              <a href="/app/buddy" className="text-primary hover:underline">
+              <a href="/buddy" className="text-primary hover:underline">
                 去创建
               </a>
             </div>

--- a/apps/web/src/components/common/buddy-list-item.tsx
+++ b/apps/web/src/components/common/buddy-list-item.tsx
@@ -88,7 +88,7 @@ export function BuddyListItem({
     if (onClick) {
       onClick(buddy)
     } else if (clickable) {
-      navigate({ to: '/app/profile/$userId', params: { userId: buddy.userId } })
+      navigate({ to: '/profile/$userId', params: { userId: buddy.userId } })
     }
   }, [buddy, clickable, navigate, onClick])
 

--- a/apps/web/src/components/member/member-list.tsx
+++ b/apps/web/src/components/member/member-list.tsx
@@ -1601,7 +1601,7 @@ export function InvitePanel({
           ) : availableBuddies.length === 0 ? (
             <div className="text-center py-8 text-text-muted text-sm">
               暂无可用 Buddy，
-              <a href="/app/buddy" className="text-primary hover:underline">
+              <a href="/buddy" className="text-primary hover:underline">
                 去创建
               </a>
             </div>

--- a/apps/web/src/pages/user-profile.tsx
+++ b/apps/web/src/pages/user-profile.tsx
@@ -161,7 +161,7 @@ export function UserProfilePage() {
                   <div className="mt-4 pt-4 border-t border-border-subtle">
                     <p className="text-xs uppercase tracking-wide text-text-muted mb-2">主人</p>
                     <Link
-                      to="/app/profile/$userId"
+                      to="/profile/$userId"
                       params={{ userId: profile.agent.ownerId }}
                       className="flex items-center gap-3 p-2 rounded-xl hover:bg-bg-modifier-hover transition group"
                     >
@@ -197,7 +197,7 @@ export function UserProfilePage() {
                     {profile.ownedAgents.map((agent) => (
                       <Link
                         key={agent.id}
-                        to="/app/profile/$userId"
+                        to="/profile/$userId"
                         params={{ userId: agent.userId }}
                         className="flex items-center gap-3 p-3 rounded-xl bg-bg-tertiary hover:bg-bg-modifier-hover transition group"
                       >


### PR DESCRIPTION
## Problem

The web app is configured with `basepath: '/app'` in TanStack Router. However, some navigation links were manually prefixed with `/app/`, causing double prefix issues like `/app/app/profile/:userId`.

## Changes

Fixed the following redundant `/app` prefixes:

1. **buddy-list-item.tsx**: Changed `navigate({ to: '/app/profile/$userId' })` → `/profile/$userId`
2. **user-profile.tsx**: Changed two `to="/app/profile/$userId"` → `/profile/$userId`
3. **member-list.tsx**: Changed `href="/app/buddy"` → `/buddy`
4. **channel-sidebar.tsx**: Changed `href="/app/buddy"` → `/buddy`

## Testing

- [x] Build passes
- [x] No type errors

These links should now correctly navigate to `/app/profile/:userId` and `/app/buddy` instead of `/app/app/profile/:userId` and `/app/app/buddy`.
