### PR TITLE
feat: Buddy Dashboard - GitHub-style activity tracking

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -3,6 +3,7 @@ import { bodyLimit } from 'hono/body-limit'
 import { cors } from 'hono/cors'
 import type { AppContainer } from './container'
 import { createAdminHandler } from './handlers/admin.handler'
+import { createAgentDashboardHandler } from './handlers/agent-dashboard.handler'
 import { createAgentHandler } from './handlers/agent.handler'
 import { createAppHandler } from './handlers/app.handler'
 import { createAuthHandler } from './handlers/auth.handler'
@@ -93,6 +94,7 @@ export function createApp(container: AppContainer) {
   app.route('/api/notifications', createNotificationHandler(container))
   app.route('/api/media', createMediaHandler(container))
   app.route('/api/agents', createAgentHandler(container))
+  app.route('/api/agents', createAgentDashboardHandler(container))
   app.route('/api/invite-codes', createInviteHandler(container))
   app.route('/api/admin', createAdminHandler(container))
   app.route('/api', createTaskCenterHandler(container))

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -3,6 +3,7 @@ import type { Server as SocketIOServer } from 'socket.io'
 import { AgentDashboardDao } from './dao/agent-dashboard.dao'
 import { AgentDao } from './dao/agent.dao'
 import { AgentPolicyDao } from './dao/agent-policy.dao'
+import { AgentService } from './services/agent.service'
 import { AppDao } from './dao/app.dao'
 import { CartDao } from './dao/cart.dao'
 import { ChannelDao } from './dao/channel.dao'
@@ -75,6 +76,7 @@ export interface Cradle {
   notificationDao: NotificationDao
   agentDao: AgentDao
   agentPolicyDao: AgentPolicyDao
+  agentDashboardDao: AgentDashboardDao
   friendshipDao: FriendshipDao
   inviteCodeDao: InviteCodeDao
   oauthAppDao: OAuthAppDao
@@ -202,6 +204,7 @@ export function createAppContainer(db: Database): AppContainer {
     serverService: asClass(ServerService).singleton(),
     channelService: asClass(ChannelService).singleton(),
     messageService: asClass(MessageService).singleton(),
+    agentDao: asClass(AgentDao).singleton(),
     searchService: asClass(SearchService).singleton(),
     notificationService: asClass(NotificationService).singleton(),
     permissionService: asClass(PermissionService).singleton(),

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -1,5 +1,6 @@
 import { type AwilixContainer, asClass, asValue, createContainer, InjectionMode } from 'awilix'
 import type { Server as SocketIOServer } from 'socket.io'
+import { AgentDashboardDao } from './dao/agent-dashboard.dao'
 import { AgentDao } from './dao/agent.dao'
 import { AgentPolicyDao } from './dao/agent-policy.dao'
 import { AppDao } from './dao/app.dao'
@@ -30,6 +31,7 @@ import { WorkspaceNodeDao } from './dao/workspace-node.dao'
 import type { Database } from './db'
 // Lib
 import { logger } from './lib/logger'
+import { AgentDashboardService } from './services/agent-dashboard.service'
 import { AgentService } from './services/agent.service'
 import { AgentPolicyService } from './services/agent-policy.service'
 import { AppService } from './services/app.service'
@@ -104,6 +106,9 @@ export interface Cradle {
   rentalUsageDao: RentalUsageDao
   rentalViolationDao: RentalViolationDao
 
+  // Dashboard DAOs
+  agentDashboardDao: AgentDashboardDao
+
   // Services
   authService: AuthService
   oauthService: OAuthService
@@ -131,6 +136,7 @@ export interface Cradle {
   rentalService: RentalService
   taskCenterService: TaskCenterService
   voiceEnhanceService: VoiceEnhanceService
+  agentDashboardService: AgentDashboardService
 }
 
 export type AppContainer = AwilixContainer<Cradle>
@@ -186,6 +192,9 @@ export function createAppContainer(db: Database): AppContainer {
     rentalUsageDao: asClass(RentalUsageDao).singleton(),
     rentalViolationDao: asClass(RentalViolationDao).singleton(),
 
+    // Dashboard DAOs
+    agentDashboardDao: asClass(AgentDashboardDao).singleton(),
+
     // Services
     authService: asClass(AuthService).singleton(),
     oauthService: asClass(OAuthService).singleton(),
@@ -213,6 +222,7 @@ export function createAppContainer(db: Database): AppContainer {
     rentalService: asClass(RentalService).singleton(),
     taskCenterService: asClass(TaskCenterService).singleton(),
     voiceEnhanceService: asClass(VoiceEnhanceService).singleton(),
+    agentDashboardService: asClass(AgentDashboardService).singleton(),
   })
 
   return container

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -1,9 +1,8 @@
 import { type AwilixContainer, asClass, asValue, createContainer, InjectionMode } from 'awilix'
 import type { Server as SocketIOServer } from 'socket.io'
-import { AgentDashboardDao } from './dao/agent-dashboard.dao'
 import { AgentDao } from './dao/agent.dao'
+import { AgentDashboardDao } from './dao/agent-dashboard.dao'
 import { AgentPolicyDao } from './dao/agent-policy.dao'
-import { AgentService } from './services/agent.service'
 import { AppDao } from './dao/app.dao'
 import { CartDao } from './dao/cart.dao'
 import { ChannelDao } from './dao/channel.dao'
@@ -32,8 +31,8 @@ import { WorkspaceNodeDao } from './dao/workspace-node.dao'
 import type { Database } from './db'
 // Lib
 import { logger } from './lib/logger'
-import { AgentDashboardService } from './services/agent-dashboard.service'
 import { AgentService } from './services/agent.service'
+import { AgentDashboardService } from './services/agent-dashboard.service'
 import { AgentPolicyService } from './services/agent-policy.service'
 import { AppService } from './services/app.service'
 // Service classes
@@ -204,7 +203,6 @@ export function createAppContainer(db: Database): AppContainer {
     serverService: asClass(ServerService).singleton(),
     channelService: asClass(ChannelService).singleton(),
     messageService: asClass(MessageService).singleton(),
-    agentDao: asClass(AgentDao).singleton(),
     searchService: asClass(SearchService).singleton(),
     notificationService: asClass(NotificationService).singleton(),
     permissionService: asClass(PermissionService).singleton(),

--- a/apps/server/src/dao/agent-dashboard.dao.ts
+++ b/apps/server/src/dao/agent-dashboard.dao.ts
@@ -1,0 +1,245 @@
+import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm'
+import type { Database } from '../db'
+import { agentActivityEvents, agentDailyStats, agentHourlyStats } from '../db/schema'
+
+export class AgentDashboardDao {
+  constructor(private deps: { db: Database }) {}
+
+  private get db() {
+    return this.deps.db
+  }
+
+  /* ───────────── Daily Stats ───────────── */
+
+  async findDailyStats(agentId: string, startDate: Date, endDate: Date) {
+    return this.db
+      .select()
+      .from(agentDailyStats)
+      .where(
+        and(
+          eq(agentDailyStats.agentId, agentId),
+          gte(agentDailyStats.date, startDate.toISOString().split('T')[0]),
+          lte(agentDailyStats.date, endDate.toISOString().split('T')[0])
+        )
+      )
+      .orderBy(agentDailyStats.date)
+  }
+
+  async upsertDailyStats(
+    agentId: string,
+    date: string,
+    data: { messageCount?: number; onlineSeconds?: number }
+  ) {
+    const existing = await this.db
+      .select()
+      .from(agentDailyStats)
+      .where(and(eq(agentDailyStats.agentId, agentId), eq(agentDailyStats.date, date)))
+      .limit(1)
+
+    if (existing.length > 0) {
+      // Update existing
+      const updates: Record<string, SQL | number> = { updatedAt: sql`NOW()` }
+      if (data.messageCount !== undefined) {
+        updates.messageCount = sql`${agentDailyStats.messageCount} + ${data.messageCount}`
+      }
+      if (data.onlineSeconds !== undefined) {
+        updates.onlineSeconds = sql`${agentDailyStats.onlineSeconds} + ${data.onlineSeconds}`
+      }
+
+      const result = await this.db
+        .update(agentDailyStats)
+        .set(updates)
+        .where(eq(agentDailyStats.id, existing[0].id))
+        .returning()
+      return result[0]
+    }
+
+    // Insert new
+    const result = await this.db
+      .insert(agentDailyStats)
+      .values({
+        agentId,
+        date,
+        messageCount: data.messageCount ?? 0,
+        onlineSeconds: data.onlineSeconds ?? 0,
+      })
+      .returning()
+    return result[0]
+  }
+
+  async incrementMessageCount(agentId: string, date: string) {
+    return this.upsertDailyStats(agentId, date, { messageCount: 1 })
+  }
+
+  async getTotalMessages(agentId: string) {
+    const result = await this.db
+      .select({ total: sql<number>`SUM(${agentDailyStats.messageCount})` })
+      .from(agentDailyStats)
+      .where(eq(agentDailyStats.agentId, agentId))
+    return result[0]?.total ?? 0
+  }
+
+  async getActiveDaysCount(agentId: string, days: number) {
+    const since = new Date()
+    since.setDate(since.getDate() - days)
+
+    const result = await this.db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(agentDailyStats)
+      .where(
+        and(
+          eq(agentDailyStats.agentId, agentId),
+          gte(agentDailyStats.date, since.toISOString().split('T')[0]),
+          sql`${agentDailyStats.messageCount} > 0`
+        )
+      )
+    return result[0]?.count ?? 0
+  }
+
+  /* ───────────── Hourly Stats ───────────── */
+
+  async findHourlyStats(agentId: string) {
+    return this.db
+      .select()
+      .from(agentHourlyStats)
+      .where(eq(agentHourlyStats.agentId, agentId))
+      .orderBy(agentHourlyStats.hourOfDay)
+  }
+
+  async upsertHourlyStats(
+    agentId: string,
+    hourOfDay: number,
+    data: { messageCount?: number; activityCount?: number }
+  ) {
+    const existing = await this.db
+      .select()
+      .from(agentHourlyStats)
+      .where(and(eq(agentHourlyStats.agentId, agentId), eq(agentHourlyStats.hourOfDay, hourOfDay)))
+      .limit(1)
+
+    if (existing.length > 0) {
+      const updates: Record<string, SQL | number> = { updatedAt: sql`NOW()` }
+      if (data.messageCount !== undefined) {
+        updates.messageCount = sql`${agentHourlyStats.messageCount} + ${data.messageCount}`
+      }
+      if (data.activityCount !== undefined) {
+        updates.activityCount = sql`${agentHourlyStats.activityCount} + ${data.activityCount}`
+      }
+
+      const result = await this.db
+        .update(agentHourlyStats)
+        .set(updates)
+        .where(eq(agentHourlyStats.id, existing[0].id))
+        .returning()
+      return result[0]
+    }
+
+    const result = await this.db
+      .insert(agentHourlyStats)
+      .values({
+        agentId,
+        hourOfDay,
+        messageCount: data.messageCount ?? 0,
+        activityCount: data.activityCount ?? 0,
+      })
+      .returning()
+    return result[0]
+  }
+
+  async incrementHourlyMessage(agentId: string, hourOfDay: number) {
+    return this.upsertHourlyStats(agentId, hourOfDay, { messageCount: 1, activityCount: 1 })
+  }
+
+  /* ───────────── Activity Events ───────────── */
+
+  async createEvent(
+    agentId: string,
+    eventType: string,
+    eventData: Record<string, unknown> = {}
+  ) {
+    const result = await this.db
+      .insert(agentActivityEvents)
+      .values({
+        agentId,
+        eventType,
+        eventData,
+      })
+      .returning()
+    return result[0]
+  }
+
+  async findRecentEvents(agentId: string, limit = 10) {
+    return this.db
+      .select()
+      .from(agentActivityEvents)
+      .where(eq(agentActivityEvents.agentId, agentId))
+      .orderBy(desc(agentActivityEvents.createdAt))
+      .limit(limit)
+  }
+
+  async deleteOldEvents(beforeDate: Date) {
+    await this.db
+      .delete(agentActivityEvents)
+      .where(lte(agentActivityEvents.createdAt, beforeDate))
+  }
+
+  /* ───────────── Streak Calculation ───────────── */
+
+  async calculateStreaks(agentId: string): Promise<{ current: number; longest: number }> {
+    // Get all daily stats ordered by date
+    const stats = await this.db
+      .select({ date: agentDailyStats.date, messageCount: agentDailyStats.messageCount })
+      .from(agentDailyStats)
+      .where(eq(agentDailyStats.agentId, agentId))
+      .orderBy(desc(agentDailyStats.date))
+
+    if (stats.length === 0) {
+      return { current: 0, longest: 0 }
+    }
+
+    let currentStreak = 0
+    let longestStreak = 0
+    let tempStreak = 0
+    let prevDate: Date | null = null
+
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    // Check if today or yesterday has activity for current streak
+    const mostRecent = new Date(stats[0].date)
+    mostRecent.setHours(0, 0, 0, 0)
+    const daysSinceLastActivity = Math.floor((today.getTime() - mostRecent.getTime()) / (1000 * 60 * 60 * 24))
+
+    for (const stat of stats) {
+      if (stat.messageCount === 0) continue
+
+      const currentDate = new Date(stat.date)
+      currentDate.setHours(0, 0, 0, 0)
+
+      if (prevDate === null) {
+        tempStreak = 1
+      } else {
+        const diffDays = Math.floor((prevDate.getTime() - currentDate.getTime()) / (1000 * 60 * 60 * 24))
+        if (diffDays === 1) {
+          tempStreak++
+        } else {
+          longestStreak = Math.max(longestStreak, tempStreak)
+          tempStreak = 1
+        }
+      }
+
+      prevDate = currentDate
+    }
+
+    longestStreak = Math.max(longestStreak, tempStreak)
+
+    // Current streak is only valid if last activity was today or yesterday
+    if (daysSinceLastActivity <= 1) {
+      currentStreak = tempStreak
+    } else {
+      currentStreak = 0
+    }
+
+    return { current: currentStreak, longest: longestStreak }
+  }
+}

--- a/apps/server/src/dao/agent-dashboard.dao.ts
+++ b/apps/server/src/dao/agent-dashboard.dao.ts
@@ -1,7 +1,10 @@
-import { getDateString } from '@shadowob/shared'
 import { and, desc, eq, gte, lte, type SQL, sql } from 'drizzle-orm'
 import type { Database } from '../db'
 import { agentActivityEvents, agentDailyStats, agentHourlyStats } from '../db/schema'
+
+function getDateString(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
 
 export class AgentDashboardDao {
   constructor(private deps: { db: Database }) {}

--- a/apps/server/src/dao/agent-dashboard.dao.ts
+++ b/apps/server/src/dao/agent-dashboard.dao.ts
@@ -1,5 +1,5 @@
-import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm'
-import { getDateString } from '@shadowob/shared/utils/date'
+import { getDateString } from '@shadowob/shared'
+import { and, desc, eq, gte, lte, type SQL, sql } from 'drizzle-orm'
 import type { Database } from '../db'
 import { agentActivityEvents, agentDailyStats, agentHourlyStats } from '../db/schema'
 
@@ -20,8 +20,8 @@ export class AgentDashboardDao {
         and(
           eq(agentDailyStats.agentId, agentId),
           gte(agentDailyStats.date, getDateString(startDate)),
-          lte(agentDailyStats.date, getDateString(endDate))
-        )
+          lte(agentDailyStats.date, getDateString(endDate)),
+        ),
       )
       .orderBy(agentDailyStats.date)
   }
@@ -29,7 +29,7 @@ export class AgentDashboardDao {
   async upsertDailyStats(
     agentId: string,
     date: string,
-    data: { messageCount?: number; onlineSeconds?: number }
+    data: { messageCount?: number; onlineSeconds?: number },
   ) {
     const existing = await this.db
       .select()
@@ -91,8 +91,8 @@ export class AgentDashboardDao {
         and(
           eq(agentDailyStats.agentId, agentId),
           gte(agentDailyStats.date, getDateString(since)),
-          sql`${agentDailyStats.messageCount} > 0`
-        )
+          sql`${agentDailyStats.messageCount} > 0`,
+        ),
       )
     return result[0]?.count ?? 0
   }
@@ -110,7 +110,7 @@ export class AgentDashboardDao {
   async upsertHourlyStats(
     agentId: string,
     hourOfDay: number,
-    data: { messageCount?: number; activityCount?: number }
+    data: { messageCount?: number; activityCount?: number },
   ) {
     const existing = await this.db
       .select()
@@ -153,11 +153,7 @@ export class AgentDashboardDao {
 
   /* ───────────── Activity Events ───────────── */
 
-  async createEvent(
-    agentId: string,
-    eventType: string,
-    eventData: Record<string, unknown> = {}
-  ) {
+  async createEvent(agentId: string, eventType: string, eventData: Record<string, unknown> = {}) {
     const result = await this.db
       .insert(agentActivityEvents)
       .values({
@@ -179,9 +175,7 @@ export class AgentDashboardDao {
   }
 
   async deleteOldEvents(beforeDate: Date) {
-    await this.db
-      .delete(agentActivityEvents)
-      .where(lte(agentActivityEvents.createdAt, beforeDate))
+    await this.db.delete(agentActivityEvents).where(lte(agentActivityEvents.createdAt, beforeDate))
   }
 
   /* ───────────── Streak Calculation ───────────── */
@@ -209,7 +203,9 @@ export class AgentDashboardDao {
     // Check if today or yesterday has activity for current streak
     const mostRecent = new Date(stats[0].date)
     mostRecent.setHours(0, 0, 0, 0)
-    const daysSinceLastActivity = Math.floor((today.getTime() - mostRecent.getTime()) / (1000 * 60 * 60 * 24))
+    const daysSinceLastActivity = Math.floor(
+      (today.getTime() - mostRecent.getTime()) / (1000 * 60 * 60 * 24),
+    )
 
     for (const stat of stats) {
       if (stat.messageCount === 0) continue
@@ -220,7 +216,9 @@ export class AgentDashboardDao {
       if (prevDate === null) {
         tempStreak = 1
       } else {
-        const diffDays = Math.floor((prevDate.getTime() - currentDate.getTime()) / (1000 * 60 * 60 * 24))
+        const diffDays = Math.floor(
+          (prevDate.getTime() - currentDate.getTime()) / (1000 * 60 * 60 * 24),
+        )
         if (diffDays === 1) {
           tempStreak++
         } else {

--- a/apps/server/src/dao/agent-dashboard.dao.ts
+++ b/apps/server/src/dao/agent-dashboard.dao.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm'
+import { getDateString } from '@shadowob/shared/utils/date'
 import type { Database } from '../db'
 import { agentActivityEvents, agentDailyStats, agentHourlyStats } from '../db/schema'
 
@@ -18,8 +19,8 @@ export class AgentDashboardDao {
       .where(
         and(
           eq(agentDailyStats.agentId, agentId),
-          gte(agentDailyStats.date, startDate.toISOString().split('T')[0]),
-          lte(agentDailyStats.date, endDate.toISOString().split('T')[0])
+          gte(agentDailyStats.date, getDateString(startDate)),
+          lte(agentDailyStats.date, getDateString(endDate))
         )
       )
       .orderBy(agentDailyStats.date)
@@ -89,7 +90,7 @@ export class AgentDashboardDao {
       .where(
         and(
           eq(agentDailyStats.agentId, agentId),
-          gte(agentDailyStats.date, since.toISOString().split('T')[0]),
+          gte(agentDailyStats.date, getDateString(since)),
           sql`${agentDailyStats.messageCount} > 0`
         )
       )

--- a/apps/server/src/dao/claw-listing.dao.ts
+++ b/apps/server/src/dao/claw-listing.dao.ts
@@ -23,6 +23,14 @@ export class ClawListingDao {
       .offset(opts?.offset ?? 0)
   }
 
+  async findByAgentId(agentId: string) {
+    return this.db
+      .select()
+      .from(clawListings)
+      .where(eq(clawListings.agentId, agentId))
+      .orderBy(desc(clawListings.createdAt))
+  }
+
   /** Helper: get IDs of listings currently actively rented */
   async getActivelyRentedListingIds(): Promise<string[]> {
     const rows = await this.db

--- a/apps/server/src/dao/rental-contract.dao.ts
+++ b/apps/server/src/dao/rental-contract.dao.ts
@@ -126,6 +126,16 @@ export class RentalContractDao {
     return this.db.select().from(rentalContracts).where(eq(rentalContracts.status, 'active'))
   }
 
+  /** Find contracts by listing IDs */
+  async findByListingIds(listingIds: string[]) {
+    if (listingIds.length === 0) return []
+    return this.db
+      .select()
+      .from(rentalContracts)
+      .where(inArray(rentalContracts.listingId, listingIds))
+      .orderBy(desc(rentalContracts.createdAt))
+  }
+
   async create(data: {
     contractNo: string
     listingId: string

--- a/apps/server/src/db/migrations/0029_add_agent_dashboard.sql
+++ b/apps/server/src/db/migrations/0029_add_agent_dashboard.sql
@@ -1,0 +1,52 @@
+-- Migration: Add agent dashboard tables
+-- Created: 2025-03-27
+
+-- Daily activity statistics for dashboard heatmap
+CREATE TABLE IF NOT EXISTS agent_daily_stats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  message_count INTEGER DEFAULT 0 NOT NULL,
+  online_seconds INTEGER DEFAULT 0 NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  UNIQUE(agent_id, date)
+);
+
+-- Indexes for daily stats
+CREATE INDEX idx_agent_daily_stats_agent_id ON agent_daily_stats(agent_id);
+CREATE INDEX idx_agent_daily_stats_date ON agent_daily_stats(date);
+CREATE INDEX idx_agent_daily_stats_agent_date ON agent_daily_stats(agent_id, date);
+
+-- Hourly activity distribution for time-of-day analytics
+CREATE TABLE IF NOT EXISTS agent_hourly_stats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  hour_of_day INTEGER NOT NULL CHECK (hour_of_day BETWEEN 0 AND 23),
+  message_count INTEGER DEFAULT 0 NOT NULL,
+  activity_count INTEGER DEFAULT 0 NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  UNIQUE(agent_id, hour_of_day)
+);
+
+-- Indexes for hourly stats
+CREATE INDEX idx_agent_hourly_stats_agent_id ON agent_hourly_stats(agent_id);
+
+-- Activity events for recent activity feed
+CREATE TABLE IF NOT EXISTS agent_activity_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  event_type VARCHAR(50) NOT NULL,
+  event_data JSONB DEFAULT '{}' NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+-- Indexes for activity events
+CREATE INDEX idx_agent_activity_events_agent_id ON agent_activity_events(agent_id);
+CREATE INDEX idx_agent_activity_events_created_at ON agent_activity_events(created_at DESC);
+CREATE INDEX idx_agent_activity_events_agent_created ON agent_activity_events(agent_id, created_at DESC);
+
+-- Add comments for documentation
+COMMENT ON TABLE agent_daily_stats IS 'Daily aggregated statistics for Buddy Dashboard heatmap';
+COMMENT ON TABLE agent_hourly_stats IS 'Hourly activity distribution for time-of-day analytics';
+COMMENT ON TABLE agent_activity_events IS 'Recent activity events for dashboard feed (kept for 90 days)';

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1774591500000,
       "tag": "0028_add_message_metadata",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1774591600000,
+      "tag": "0029_add_agent_dashboard",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/agent-dashboard.ts
+++ b/apps/server/src/db/schema/agent-dashboard.ts
@@ -1,0 +1,47 @@
+import { integer, jsonb, pgTable, timestamp, uuid, date, varchar } from 'drizzle-orm/pg-core'
+import { agents } from './agents'
+
+/**
+ * Agent daily activity statistics
+ * Tracks daily message counts and online time for dashboard heatmap
+ */
+export const agentDailyStats = pgTable('agent_daily_stats', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  agentId: uuid('agent_id')
+    .notNull()
+    .references(() => agents.id, { onDelete: 'cascade' }),
+  date: date('date').notNull(),
+  messageCount: integer('message_count').default(0).notNull(),
+  onlineSeconds: integer('online_seconds').default(0).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+})
+
+/**
+ * Agent hourly activity distribution
+ * Aggregated statistics for hour-of-day activity patterns
+ */
+export const agentHourlyStats = pgTable('agent_hourly_stats', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  agentId: uuid('agent_id')
+    .notNull()
+    .references(() => agents.id, { onDelete: 'cascade' }),
+  hourOfDay: integer('hour_of_day').notNull(), // 0-23
+  messageCount: integer('message_count').default(0).notNull(),
+  activityCount: integer('activity_count').default(0).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+})
+
+/**
+ * Agent activity events
+ * Recent events for activity feed (kept for 90 days)
+ */
+export const agentActivityEvents = pgTable('agent_activity_events', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  agentId: uuid('agent_id')
+    .notNull()
+    .references(() => agents.id, { onDelete: 'cascade' }),
+  eventType: varchar('event_type', { length: 50 }).notNull(), // 'message', 'status_change', 'rental_start', 'rental_end', 'policy_update'
+  eventData: jsonb('event_data').$type<Record<string, unknown>>().default({}).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+})

--- a/apps/server/src/db/schema/index.ts
+++ b/apps/server/src/db/schema/index.ts
@@ -1,5 +1,10 @@
 export { agentPolicies } from './agent-policies'
 export { agentStatusEnum, agents } from './agents'
+export {
+  agentActivityEvents,
+  agentDailyStats,
+  agentHourlyStats,
+} from './agent-dashboard'
 export { appSourceEnum, appStatusEnum, apps } from './apps'
 export { attachments } from './attachments'
 export { channelMembers } from './channel-members'

--- a/apps/server/src/handlers/agent-dashboard.handler.ts
+++ b/apps/server/src/handlers/agent-dashboard.handler.ts
@@ -1,0 +1,44 @@
+import { Hono } from 'hono'
+import type { AppContainer } from '../container'
+import { authMiddleware } from '../middleware/auth.middleware'
+
+export function createAgentDashboardHandler(container: AppContainer) {
+  const handler = new Hono()
+
+  handler.use('*', authMiddleware)
+
+  // GET /api/agents/:id/dashboard - Get full dashboard data
+  handler.get('/:id/dashboard', async (c) => {
+    const agentDashboardService = container.resolve('agentDashboardService')
+    const user = c.get('user')
+    const agentId = c.req.param('id')
+
+    try {
+      const dashboard = await agentDashboardService.getDashboard(agentId, user.userId)
+      return c.json(dashboard)
+    } catch (err) {
+      const status = (err as { status?: number }).status ?? 500
+      const message = (err as Error).message ?? 'Internal Server Error'
+      return c.json({ error: message }, status as 404 | 403 | 500)
+    }
+  })
+
+  // POST /api/agents/:id/dashboard/events - Add activity event (internal use)
+  handler.post('/:id/dashboard/events', async (c) => {
+    const agentDashboardService = container.resolve('agentDashboardService')
+    const user = c.get('user')
+    const agentId = c.req.param('id')
+    const body = await c.req.json<{ eventType: string; eventData?: Record<string, unknown> }>()
+
+    try {
+      await agentDashboardService.addEvent(agentId, body.eventType, body.eventData ?? {})
+      return c.json({ success: true })
+    } catch (err) {
+      const status = (err as { status?: number }).status ?? 500
+      const message = (err as Error).message ?? 'Internal Server Error'
+      return c.json({ error: message }, status as 500)
+    }
+  })
+
+  return handler
+}

--- a/apps/server/src/services/agent-dashboard.service.test.ts
+++ b/apps/server/src/services/agent-dashboard.service.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentDashboardDao } from '../dao/agent-dashboard.dao'
+import type { AgentDao } from '../dao/agent.dao'
+import type { ClawListingDao } from '../dao/claw-listing.dao'
+import type { RentalContractDao } from '../dao/rental-contract.dao'
+import type { UserDao } from '../dao/user.dao'
+import { AgentDashboardService } from './agent-dashboard.service'
+
+// Mock logger
+const mockLogger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+} as any
+
+describe('AgentDashboardService', () => {
+  // Mock DAOs
+  const mockAgentDashboardDao = {
+    findDailyStats: vi.fn(),
+    findHourlyStats: vi.fn(),
+    getTotalMessages: vi.fn(),
+    getActiveDaysCount: vi.fn(),
+    calculateStreaks: vi.fn(),
+    findRecentEvents: vi.fn(),
+    incrementMessageCount: vi.fn(),
+    incrementHourlyMessage: vi.fn(),
+    upsertDailyStats: vi.fn(),
+    createEvent: vi.fn(),
+    deleteOldEvents: vi.fn(),
+  } as unknown as AgentDashboardDao
+
+  const mockAgentDao = {
+    findById: vi.fn(),
+    findByUserId: vi.fn(),
+  } as unknown as AgentDao
+
+  const mockRentalContractDao = {
+    findByListingIds: vi.fn(),
+  } as unknown as RentalContractDao
+
+  const mockClawListingDao = {
+    findByAgentId: vi.fn(),
+  } as unknown as ClawListingDao
+
+  const mockUserDao = {
+    findById: vi.fn(),
+  } as unknown as UserDao
+
+  const service = new AgentDashboardService({
+    agentDashboardDao: mockAgentDashboardDao,
+    agentDao: mockAgentDao,
+    rentalContractDao: mockRentalContractDao,
+    clawListingDao: mockClawListingDao,
+    userDao: mockUserDao,
+    logger: mockLogger,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getDashboard', () => {
+    it('should return dashboard data for agent owner', async () => {
+      const agentId = 'agent-123'
+      const userId = 'user-123'
+
+      // Mock agent
+      mockAgentDao.findById.mockResolvedValue({
+        id: agentId,
+        ownerId: userId,
+        totalOnlineSeconds: 3600,
+      })
+
+      // Mock stats
+      mockAgentDashboardDao.findDailyStats.mockResolvedValue([
+        { date: '2025-03-26', messageCount: 10 },
+        { date: '2025-03-27', messageCount: 5 },
+      ])
+      mockAgentDashboardDao.findHourlyStats.mockResolvedValue([
+        { hourOfDay: 9, messageCount: 5 },
+        { hourOfDay: 14, messageCount: 10 },
+      ])
+      mockAgentDashboardDao.getTotalMessages.mockResolvedValue(100)
+      mockAgentDashboardDao.getActiveDaysCount.mockResolvedValue(15)
+      mockAgentDashboardDao.calculateStreaks.mockResolvedValue({ current: 5, longest: 10 })
+      mockAgentDashboardDao.findRecentEvents.mockResolvedValue([
+        {
+          id: 'event-1',
+          eventType: 'message',
+          eventData: { preview: 'Hello' },
+          createdAt: new Date(),
+        },
+      ])
+
+      // Mock rental stats
+      mockClawListingDao.findByAgentId.mockResolvedValue([])
+
+      const result = await service.getDashboard(agentId, userId)
+
+      expect(result).toBeDefined()
+      expect(result.stats.totalMessages).toBe(100)
+      expect(result.stats.totalOnlineSeconds).toBe(3600)
+      expect(result.stats.activeDays30d).toBe(15)
+      expect(result.stats.currentStreak).toBe(5)
+      expect(result.stats.longestStreak).toBe(10)
+      expect(result.activityHeatmap).toHaveLength(365)
+      expect(result.weeklyActivity).toHaveLength(7)
+      expect(result.hourlyDistribution).toHaveLength(24)
+      expect(result.monthlyTrend).toHaveLength(12)
+      expect(result.recentEvents).toHaveLength(1)
+    })
+
+    it('should throw 404 if agent not found', async () => {
+      mockAgentDao.findById.mockResolvedValue(null)
+
+      await expect(service.getDashboard('agent-123', 'user-123')).rejects.toMatchObject({
+        status: 404,
+        message: 'Agent not found',
+      })
+    })
+
+    it('should throw 403 if user is not owner or tenant', async () => {
+      mockAgentDao.findById.mockResolvedValue({
+        id: 'agent-123',
+        ownerId: 'owner-123',
+      })
+
+      await expect(service.getDashboard('agent-123', 'other-user')).rejects.toMatchObject({
+        status: 403,
+        message: 'Forbidden',
+      })
+    })
+  })
+
+  describe('recordMessage', () => {
+    it('should record message count and hourly stats', async () => {
+      const agentId = 'agent-123'
+
+      await service.recordMessage(agentId)
+
+      expect(mockAgentDashboardDao.incrementMessageCount).toHaveBeenCalled()
+      expect(mockAgentDashboardDao.incrementHourlyMessage).toHaveBeenCalled()
+    })
+  })
+
+  describe('recordOnlineTime', () => {
+    it('should record online time for today', async () => {
+      const agentId = 'agent-123'
+      const seconds = 300
+
+      await service.recordOnlineTime(agentId, seconds)
+
+      expect(mockAgentDashboardDao.upsertDailyStats).toHaveBeenCalledWith(
+        agentId,
+        expect.any(String),
+        { onlineSeconds: seconds }
+      )
+    })
+  })
+
+  describe('addEvent', () => {
+    it('should create activity event', async () => {
+      const agentId = 'agent-123'
+      const eventType = 'status_change'
+      const eventData = { status: 'online' }
+
+      await service.addEvent(agentId, eventType, eventData)
+
+      expect(mockAgentDashboardDao.createEvent).toHaveBeenCalledWith(agentId, eventType, eventData)
+    })
+  })
+
+  describe('cleanupOldEvents', () => {
+    it('should delete events older than 90 days', async () => {
+      await service.cleanupOldEvents()
+
+      expect(mockAgentDashboardDao.deleteOldEvents).toHaveBeenCalled()
+      expect(mockLogger.info).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/server/src/services/agent-dashboard.service.ts
+++ b/apps/server/src/services/agent-dashboard.service.ts
@@ -66,6 +66,8 @@ export class AgentDashboardService {
       agentDashboardDao: AgentDashboardDao
       agentDao: AgentDao
       rentalContractDao: RentalContractDao
+      clawListingDao: ClawListingDao
+      userDao: UserDao
       logger: Logger
     }
   ) {}
@@ -203,13 +205,69 @@ export class AgentDashboardService {
   }
 
   private async getRentalStats(agentId: string): Promise<RentalStats> {
-    // Get all contracts where this agent was rented
-    // This requires joining with clawListings to find by agentId
-    // For now, return placeholder data
+    // Find listings for this agent
+    const listings = await this.deps.clawListingDao.findByAgentId(agentId)
+
+    if (listings.length === 0) {
+      return {
+        totalRentals: 0,
+        totalIncome: 0,
+        averageDuration: 0,
+      }
+    }
+
+    const listingIds = listings.map((l) => l.id)
+
+    // Get all contracts for these listings
+    const contracts = await this.deps.rentalContractDao.findByListingIds(listingIds)
+
+    if (contracts.length === 0) {
+      return {
+        totalRentals: 0,
+        totalIncome: 0,
+        averageDuration: 0,
+      }
+    }
+
+    // Calculate stats
+    const completedContracts = contracts.filter((c) => c.status === 'completed')
+    const totalRentals = completedContracts.length
+
+    // Calculate total income from usage records
+    let totalIncome = 0
+    for (const contract of completedContracts) {
+      totalIncome += contract.totalCost ?? 0
+    }
+
+    // Calculate average duration
+    let totalDuration = 0
+    for (const contract of completedContracts) {
+      if (contract.startsAt && contract.terminatedAt) {
+        const duration = new Date(contract.terminatedAt).getTime() - new Date(contract.startsAt).getTime()
+        totalDuration += duration / (1000 * 60 * 60 * 24) // Convert to days
+      }
+    }
+    const averageDuration = totalRentals > 0 ? totalDuration / totalRentals : 0
+
+    // Find current tenant (active contract)
+    const activeContract = contracts.find((c) => c.status === 'active')
+    let currentTenant: RentalStats['currentTenant']
+    if (activeContract) {
+      const tenant = await this.deps.userDao.findById(activeContract.tenantId)
+      if (tenant) {
+        currentTenant = {
+          id: tenant.id,
+          username: tenant.username,
+          displayName: tenant.displayName ?? tenant.username,
+        }
+      }
+    }
+
     return {
-      totalRentals: 0,
-      totalIncome: 0,
-      averageDuration: 0,
+      totalRentals,
+      totalIncome,
+      averageDuration,
+      currentTenant,
     }
   }
 

--- a/apps/server/src/services/agent-dashboard.service.ts
+++ b/apps/server/src/services/agent-dashboard.service.ts
@@ -1,6 +1,27 @@
-import { calculateActivityLevel, DASHBOARD_CONSTANTS, getDateString } from '@shadowob/shared'
 import type { Logger } from 'pino'
 import type { AgentDao } from '../dao/agent.dao'
+
+// Dashboard constants
+const DASHBOARD_CONSTANTS = {
+  HEATMAP_DAYS: 365,
+  WEEKLY_DAYS: 7,
+  MONTHLY_MONTHS: 12,
+  ACTIVE_DAYS_WINDOW: 30,
+  EVENT_RETENTION_DAYS: 90,
+} as const
+
+function getDateString(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function calculateActivityLevel(count: number): 0 | 1 | 2 | 3 | 4 {
+  if (count >= 100) return 4
+  if (count >= 51) return 3
+  if (count >= 11) return 2
+  if (count >= 1) return 1
+  return 0
+}
+
 import type { AgentDashboardDao } from '../dao/agent-dashboard.dao'
 import type { RentalContractDao } from '../dao/rental-contract.dao'
 

--- a/apps/server/src/services/agent-dashboard.service.ts
+++ b/apps/server/src/services/agent-dashboard.service.ts
@@ -1,13 +1,7 @@
-import {
-  ACTIVITY_LEVELS,
-  calculateActivityLevel,
-  DASHBOARD_CONSTANTS,
-  getDateString,
-  getDaysAgoDateString,
-} from '@shadowob/shared/utils/date'
+import { calculateActivityLevel, DASHBOARD_CONSTANTS, getDateString } from '@shadowob/shared'
 import type { Logger } from 'pino'
-import type { AgentDashboardDao } from '../dao/agent-dashboard.dao'
 import type { AgentDao } from '../dao/agent.dao'
+import type { AgentDashboardDao } from '../dao/agent-dashboard.dao'
 import type { RentalContractDao } from '../dao/rental-contract.dao'
 
 export interface DashboardStats {
@@ -76,7 +70,7 @@ export class AgentDashboardService {
       clawListingDao: ClawListingDao
       userDao: UserDao
       logger: Logger
-    }
+    },
   ) {}
 
   /**
@@ -98,26 +92,26 @@ export class AgentDashboardService {
     }
 
     const now = new Date()
-    const oneYearAgo = new Date(now.getTime() - DASHBOARD_CONSTANTS.HEATMAP_DAYS * 24 * 60 * 60 * 1000)
-    const sevenDaysAgo = new Date(now.getTime() - DASHBOARD_CONSTANTS.WEEKLY_DAYS * 24 * 60 * 60 * 1000)
-    const twelveMonthsAgo = new Date(now.getTime() - DASHBOARD_CONSTANTS.MONTHLY_MONTHS * 30 * 24 * 60 * 60 * 1000)
+    const oneYearAgo = new Date(
+      now.getTime() - DASHBOARD_CONSTANTS.HEATMAP_DAYS * 24 * 60 * 60 * 1000,
+    )
+    const sevenDaysAgo = new Date(
+      now.getTime() - DASHBOARD_CONSTANTS.WEEKLY_DAYS * 24 * 60 * 60 * 1000,
+    )
+    const twelveMonthsAgo = new Date(
+      now.getTime() - DASHBOARD_CONSTANTS.MONTHLY_MONTHS * 30 * 24 * 60 * 60 * 1000,
+    )
 
     // Fetch all data in parallel
-    const [
-      dailyStats,
-      hourlyStats,
-      totalMessages,
-      activeDays30d,
-      streaks,
-      recentEvents,
-    ] = await Promise.all([
-      this.deps.agentDashboardDao.findDailyStats(agentId, oneYearAgo, now),
-      this.deps.agentDashboardDao.findHourlyStats(agentId),
-      this.deps.agentDashboardDao.getTotalMessages(agentId),
-      this.deps.agentDashboardDao.getActiveDaysCount(agentId, 30),
-      this.deps.agentDashboardDao.calculateStreaks(agentId),
-      this.deps.agentDashboardDao.findRecentEvents(agentId, 10),
-    ])
+    const [dailyStats, hourlyStats, totalMessages, activeDays30d, streaks, recentEvents] =
+      await Promise.all([
+        this.deps.agentDashboardDao.findDailyStats(agentId, oneYearAgo, now),
+        this.deps.agentDashboardDao.findHourlyStats(agentId),
+        this.deps.agentDashboardDao.getTotalMessages(agentId),
+        this.deps.agentDashboardDao.getActiveDaysCount(agentId, 30),
+        this.deps.agentDashboardDao.calculateStreaks(agentId),
+        this.deps.agentDashboardDao.findRecentEvents(agentId, 10),
+      ])
 
     // Build activity heatmap (last 365 days)
     const activityHeatmap = this.buildActivityHeatmap(dailyStats)
@@ -186,7 +180,7 @@ export class AgentDashboardService {
   async addEvent(
     agentId: string,
     eventType: string,
-    eventData: Record<string, unknown> = {}
+    eventData: Record<string, unknown> = {},
   ): Promise<void> {
     await this.deps.agentDashboardDao.createEvent(agentId, eventType, eventData)
   }
@@ -256,7 +250,8 @@ export class AgentDashboardService {
     let totalDuration = 0
     for (const contract of completedContracts) {
       if (contract.startsAt && contract.terminatedAt) {
-        const duration = new Date(contract.terminatedAt).getTime() - new Date(contract.startsAt).getTime()
+        const duration =
+          new Date(contract.terminatedAt).getTime() - new Date(contract.startsAt).getTime()
         totalDuration += duration / (1000 * 60 * 60 * 24) // Convert to days
       }
     }
@@ -285,7 +280,7 @@ export class AgentDashboardService {
   }
 
   private buildActivityHeatmap(
-    dailyStats: { date: string; messageCount: number }[]
+    dailyStats: { date: string; messageCount: number }[],
   ): ActivityHeatmapItem[] {
     const statsMap = new Map(dailyStats.map((s) => [s.date, s.messageCount]))
 
@@ -309,7 +304,7 @@ export class AgentDashboardService {
 
   private buildWeeklyActivity(
     dailyStats: { date: string; messageCount: number }[],
-    since: Date
+    _since: Date,
   ): WeeklyActivityItem[] {
     const statsMap = new Map(dailyStats.map((s) => [s.date, s.messageCount]))
     const result: WeeklyActivityItem[] = []
@@ -328,7 +323,7 @@ export class AgentDashboardService {
   }
 
   private buildHourlyDistribution(
-    hourlyStats: { hourOfDay: number; messageCount: number }[]
+    hourlyStats: { hourOfDay: number; messageCount: number }[],
   ): HourlyDistributionItem[] {
     // Initialize all 24 hours with 0
     const result: HourlyDistributionItem[] = []
@@ -346,7 +341,7 @@ export class AgentDashboardService {
 
   private buildMonthlyTrend(
     dailyStats: { date: string; messageCount: number }[],
-    since: Date
+    _since: Date,
   ): MonthlyTrendItem[] {
     const monthlyMap = new Map<string, number>()
 

--- a/apps/server/src/services/agent-dashboard.service.ts
+++ b/apps/server/src/services/agent-dashboard.service.ts
@@ -1,0 +1,307 @@
+import type { Logger } from 'pino'
+import type { AgentDashboardDao } from '../dao/agent-dashboard.dao'
+import type { AgentDao } from '../dao/agent.dao'
+import type { RentalContractDao } from '../dao/rental-contract.dao'
+
+export interface DashboardStats {
+  totalMessages: number
+  totalOnlineSeconds: number
+  activeDays30d: number
+  currentStreak: number
+  longestStreak: number
+}
+
+export interface ActivityHeatmapItem {
+  date: string
+  messageCount: number
+  level: 0 | 1 | 2 | 3 | 4
+}
+
+export interface WeeklyActivityItem {
+  date: string
+  messageCount: number
+}
+
+export interface HourlyDistributionItem {
+  hour: number
+  messageCount: number
+}
+
+export interface MonthlyTrendItem {
+  month: string
+  messageCount: number
+}
+
+export interface ActivityEvent {
+  id: string
+  type: string
+  data: Record<string, unknown>
+  createdAt: string
+}
+
+export interface RentalStats {
+  totalRentals: number
+  totalIncome: number
+  averageDuration: number
+  currentTenant?: {
+    id: string
+    username: string
+    displayName: string
+  }
+}
+
+export interface AgentDashboardResponse {
+  activityHeatmap: ActivityHeatmapItem[]
+  stats: DashboardStats
+  weeklyActivity: WeeklyActivityItem[]
+  hourlyDistribution: HourlyDistributionItem[]
+  monthlyTrend: MonthlyTrendItem[]
+  recentEvents: ActivityEvent[]
+  rentalStats?: RentalStats
+}
+
+export class AgentDashboardService {
+  constructor(
+    private deps: {
+      agentDashboardDao: AgentDashboardDao
+      agentDao: AgentDao
+      rentalContractDao: RentalContractDao
+      logger: Logger
+    }
+  ) {}
+
+  /**
+   * Get full dashboard data for an agent
+   */
+  async getDashboard(agentId: string, userId: string): Promise<AgentDashboardResponse> {
+    // Verify agent exists and user has access
+    const agent = await this.deps.agentDao.findById(agentId)
+    if (!agent) {
+      throw Object.assign(new Error('Agent not found'), { status: 404 })
+    }
+
+    // Check permissions (owner or tenant can view full dashboard)
+    const isOwner = agent.ownerId === userId
+    const isTenant = await this.checkIsTenant(agentId, userId)
+
+    if (!isOwner && !isTenant) {
+      throw Object.assign(new Error('Forbidden'), { status: 403 })
+    }
+
+    const now = new Date()
+    const oneYearAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000)
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+    const twelveMonthsAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000)
+
+    // Fetch all data in parallel
+    const [
+      dailyStats,
+      hourlyStats,
+      totalMessages,
+      activeDays30d,
+      streaks,
+      recentEvents,
+    ] = await Promise.all([
+      this.deps.agentDashboardDao.findDailyStats(agentId, oneYearAgo, now),
+      this.deps.agentDashboardDao.findHourlyStats(agentId),
+      this.deps.agentDashboardDao.getTotalMessages(agentId),
+      this.deps.agentDashboardDao.getActiveDaysCount(agentId, 30),
+      this.deps.agentDashboardDao.calculateStreaks(agentId),
+      this.deps.agentDashboardDao.findRecentEvents(agentId, 10),
+    ])
+
+    // Build activity heatmap (last 365 days)
+    const activityHeatmap = this.buildActivityHeatmap(dailyStats)
+
+    // Build weekly activity (last 7 days)
+    const weeklyActivity = this.buildWeeklyActivity(dailyStats, sevenDaysAgo)
+
+    // Build hourly distribution
+    const hourlyDistribution = this.buildHourlyDistribution(hourlyStats)
+
+    // Build monthly trend (last 12 months)
+    const monthlyTrend = this.buildMonthlyTrend(dailyStats, twelveMonthsAgo)
+
+    // Get rental stats if owner
+    let rentalStats: RentalStats | undefined
+    if (isOwner) {
+      rentalStats = await this.getRentalStats(agentId)
+    }
+
+    return {
+      activityHeatmap,
+      stats: {
+        totalMessages,
+        totalOnlineSeconds: agent.totalOnlineSeconds ?? 0,
+        activeDays30d,
+        currentStreak: streaks.current,
+        longestStreak: streaks.longest,
+      },
+      weeklyActivity,
+      hourlyDistribution,
+      monthlyTrend,
+      recentEvents: recentEvents.map((e) => ({
+        id: e.id,
+        type: e.eventType,
+        data: e.eventData as Record<string, unknown>,
+        createdAt: e.createdAt.toISOString(),
+      })),
+      rentalStats,
+    }
+  }
+
+  /**
+   * Record a message sent by the agent
+   */
+  async recordMessage(agentId: string): Promise<void> {
+    const today = new Date().toISOString().split('T')[0]
+    const hour = new Date().getHours()
+
+    await Promise.all([
+      this.deps.agentDashboardDao.incrementMessageCount(agentId, today),
+      this.deps.agentDashboardDao.incrementHourlyMessage(agentId, hour),
+    ])
+  }
+
+  /**
+   * Record online time for the agent
+   */
+  async recordOnlineTime(agentId: string, seconds: number): Promise<void> {
+    const today = new Date().toISOString().split('T')[0]
+    await this.deps.agentDashboardDao.upsertDailyStats(agentId, today, { onlineSeconds: seconds })
+  }
+
+  /**
+   * Add an activity event
+   */
+  async addEvent(
+    agentId: string,
+    eventType: string,
+    eventData: Record<string, unknown> = {}
+  ): Promise<void> {
+    await this.deps.agentDashboardDao.createEvent(agentId, eventType, eventData)
+  }
+
+  /**
+   * Clean up old events (keep last 90 days)
+   */
+  async cleanupOldEvents(): Promise<void> {
+    const cutoffDate = new Date()
+    cutoffDate.setDate(cutoffDate.getDate() - 90)
+    await this.deps.agentDashboardDao.deleteOldEvents(cutoffDate)
+    this.deps.logger.info({ cutoffDate }, 'Cleaned up old agent activity events')
+  }
+
+  /* ───────────── Private Helpers ───────────── */
+
+  private async checkIsTenant(agentId: string, userId: string): Promise<boolean> {
+    // Check if user has an active rental contract for this agent
+    const contracts = await this.deps.rentalContractDao.findByTenantId(userId, { status: 'active' })
+    // Need to check if any contract's listing is for this agent
+    // This is a simplified check - in production, you'd join with listings
+    return false // TODO: Implement proper tenant check
+  }
+
+  private async getRentalStats(agentId: string): Promise<RentalStats> {
+    // Get all contracts where this agent was rented
+    // This requires joining with clawListings to find by agentId
+    // For now, return placeholder data
+    return {
+      totalRentals: 0,
+      totalIncome: 0,
+      averageDuration: 0,
+    }
+  }
+
+  private buildActivityHeatmap(
+    dailyStats: { date: string; messageCount: number }[]
+  ): ActivityHeatmapItem[] {
+    const statsMap = new Map(dailyStats.map((s) => [s.date, s.messageCount]))
+
+    // Generate last 365 days
+    const result: ActivityHeatmapItem[] = []
+    const today = new Date()
+
+    for (let i = 364; i >= 0; i--) {
+      const date = new Date(today)
+      date.setDate(date.getDate() - i)
+      const dateStr = date.toISOString().split('T')[0]
+      const count = statsMap.get(dateStr) ?? 0
+
+      // Calculate level based on message count
+      let level: 0 | 1 | 2 | 3 | 4 = 0
+      if (count >= 100) level = 4
+      else if (count >= 51) level = 3
+      else if (count >= 11) level = 2
+      else if (count >= 1) level = 1
+
+      result.push({ date: dateStr, messageCount: count, level })
+    }
+
+    return result
+  }
+
+  private buildWeeklyActivity(
+    dailyStats: { date: string; messageCount: number }[],
+    since: Date
+  ): WeeklyActivityItem[] {
+    const statsMap = new Map(dailyStats.map((s) => [s.date, s.messageCount]))
+    const result: WeeklyActivityItem[] = []
+
+    for (let i = 6; i >= 0; i--) {
+      const date = new Date()
+      date.setDate(date.getDate() - i)
+      const dateStr = date.toISOString().split('T')[0]
+      result.push({
+        date: dateStr,
+        messageCount: statsMap.get(dateStr) ?? 0,
+      })
+    }
+
+    return result
+  }
+
+  private buildHourlyDistribution(
+    hourlyStats: { hourOfDay: number; messageCount: number }[]
+  ): HourlyDistributionItem[] {
+    // Initialize all 24 hours with 0
+    const result: HourlyDistributionItem[] = []
+    const statsMap = new Map(hourlyStats.map((s) => [s.hourOfDay, s.messageCount]))
+
+    for (let hour = 0; hour < 24; hour++) {
+      result.push({
+        hour,
+        messageCount: statsMap.get(hour) ?? 0,
+      })
+    }
+
+    return result
+  }
+
+  private buildMonthlyTrend(
+    dailyStats: { date: string; messageCount: number }[],
+    since: Date
+  ): MonthlyTrendItem[] {
+    const monthlyMap = new Map<string, number>()
+
+    for (const stat of dailyStats) {
+      const month = stat.date.substring(0, 7) // YYYY-MM
+      monthlyMap.set(month, (monthlyMap.get(month) ?? 0) + stat.messageCount)
+    }
+
+    // Generate last 12 months
+    const result: MonthlyTrendItem[] = []
+    const today = new Date()
+
+    for (let i = 11; i >= 0; i--) {
+      const date = new Date(today.getFullYear(), today.getMonth() - i, 1)
+      const monthStr = date.toISOString().substring(0, 7)
+      result.push({
+        month: monthStr,
+        messageCount: monthlyMap.get(monthStr) ?? 0,
+      })
+    }
+
+    return result
+  }
+}

--- a/apps/server/src/services/agent-dashboard.service.ts
+++ b/apps/server/src/services/agent-dashboard.service.ts
@@ -1,3 +1,10 @@
+import {
+  ACTIVITY_LEVELS,
+  calculateActivityLevel,
+  DASHBOARD_CONSTANTS,
+  getDateString,
+  getDaysAgoDateString,
+} from '@shadowob/shared/utils/date'
 import type { Logger } from 'pino'
 import type { AgentDashboardDao } from '../dao/agent-dashboard.dao'
 import type { AgentDao } from '../dao/agent.dao'
@@ -91,9 +98,9 @@ export class AgentDashboardService {
     }
 
     const now = new Date()
-    const oneYearAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000)
-    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
-    const twelveMonthsAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000)
+    const oneYearAgo = new Date(now.getTime() - DASHBOARD_CONSTANTS.HEATMAP_DAYS * 24 * 60 * 60 * 1000)
+    const sevenDaysAgo = new Date(now.getTime() - DASHBOARD_CONSTANTS.WEEKLY_DAYS * 24 * 60 * 60 * 1000)
+    const twelveMonthsAgo = new Date(now.getTime() - DASHBOARD_CONSTANTS.MONTHLY_MONTHS * 30 * 24 * 60 * 60 * 1000)
 
     // Fetch all data in parallel
     const [
@@ -185,11 +192,11 @@ export class AgentDashboardService {
   }
 
   /**
-   * Clean up old events (keep last 90 days)
+   * Clean up old events (keep last N days)
    */
   async cleanupOldEvents(): Promise<void> {
     const cutoffDate = new Date()
-    cutoffDate.setDate(cutoffDate.getDate() - 90)
+    cutoffDate.setDate(cutoffDate.getDate() - DASHBOARD_CONSTANTS.EVENT_RETENTION_DAYS)
     await this.deps.agentDashboardDao.deleteOldEvents(cutoffDate)
     this.deps.logger.info({ cutoffDate }, 'Cleaned up old agent activity events')
   }
@@ -197,11 +204,17 @@ export class AgentDashboardService {
   /* ───────────── Private Helpers ───────────── */
 
   private async checkIsTenant(agentId: string, userId: string): Promise<boolean> {
-    // Check if user has an active rental contract for this agent
+    // Find listings for this agent
+    const listings = await this.deps.clawListingDao.findByAgentId(agentId)
+    if (listings.length === 0) {
+      return false
+    }
+
+    const listingIds = listings.map((l) => l.id)
+
+    // Check if user has an active contract for any of these listings
     const contracts = await this.deps.rentalContractDao.findByTenantId(userId, { status: 'active' })
-    // Need to check if any contract's listing is for this agent
-    // This is a simplified check - in production, you'd join with listings
-    return false // TODO: Implement proper tenant check
+    return contracts.some((contract) => listingIds.includes(contract.listingId))
   }
 
   private async getRentalStats(agentId: string): Promise<RentalStats> {
@@ -280,19 +293,14 @@ export class AgentDashboardService {
     const result: ActivityHeatmapItem[] = []
     const today = new Date()
 
-    for (let i = 364; i >= 0; i--) {
+    for (let i = DASHBOARD_CONSTANTS.HEATMAP_DAYS - 1; i >= 0; i--) {
       const date = new Date(today)
       date.setDate(date.getDate() - i)
-      const dateStr = date.toISOString().split('T')[0]
+      const dateStr = getDateString(date)
       const count = statsMap.get(dateStr) ?? 0
 
       // Calculate level based on message count
-      let level: 0 | 1 | 2 | 3 | 4 = 0
-      if (count >= 100) level = 4
-      else if (count >= 51) level = 3
-      else if (count >= 11) level = 2
-      else if (count >= 1) level = 1
-
+      const level = calculateActivityLevel(count)
       result.push({ date: dateStr, messageCount: count, level })
     }
 
@@ -306,10 +314,10 @@ export class AgentDashboardService {
     const statsMap = new Map(dailyStats.map((s) => [s.date, s.messageCount]))
     const result: WeeklyActivityItem[] = []
 
-    for (let i = 6; i >= 0; i--) {
+    for (let i = DASHBOARD_CONSTANTS.WEEKLY_DAYS - 1; i >= 0; i--) {
       const date = new Date()
       date.setDate(date.getDate() - i)
-      const dateStr = date.toISOString().split('T')[0]
+      const dateStr = getDateString(date)
       result.push({
         date: dateStr,
         messageCount: statsMap.get(dateStr) ?? 0,
@@ -347,11 +355,11 @@ export class AgentDashboardService {
       monthlyMap.set(month, (monthlyMap.get(month) ?? 0) + stat.messageCount)
     }
 
-    // Generate last 12 months
+    // Generate last N months
     const result: MonthlyTrendItem[] = []
     const today = new Date()
 
-    for (let i = 11; i >= 0; i--) {
+    for (let i = DASHBOARD_CONSTANTS.MONTHLY_MONTHS - 1; i >= 0; i--) {
       const date = new Date(today.getFullYear(), today.getMonth() - i, 1)
       const monthStr = date.toISOString().substring(0, 7)
       result.push({

--- a/apps/server/src/services/message.service.ts
+++ b/apps/server/src/services/message.service.ts
@@ -1,5 +1,5 @@
-import type { AgentDashboardDao } from '../dao/agent-dashboard.dao'
 import type { AgentDao } from '../dao/agent.dao'
+import type { AgentDashboardDao } from '../dao/agent-dashboard.dao'
 import type { ChannelDao } from '../dao/channel.dao'
 import type { MessageDao } from '../dao/message.dao'
 import type { UserDao } from '../dao/user.dao'
@@ -12,13 +12,15 @@ import type {
 } from '../validators/message.schema'
 
 export class MessageService {
-  constructor(private deps: {
-    messageDao: MessageDao
-    userDao: UserDao
-    channelDao: ChannelDao
-    agentDao: AgentDao
-    agentDashboardDao: AgentDashboardDao
-  }) {}
+  constructor(
+    private deps: {
+      messageDao: MessageDao
+      userDao: UserDao
+      channelDao: ChannelDao
+      agentDao: AgentDao
+      agentDashboardDao: AgentDashboardDao
+    },
+  ) {}
 
   async getByChannelId(channelId: string, limit?: number, cursor?: string) {
     return this.deps.messageDao.findByChannelId(channelId, limit, cursor)
@@ -66,8 +68,11 @@ export class MessageService {
       try {
         const agent = await this.deps.agentDao.findByUserId(authorId)
         if (agent) {
-          const { getDateString } = await import('@shadowob/shared/utils/date')
-          await this.deps.agentDashboardDao.incrementMessageCount(agent.id, getDateString(new Date()))
+          const { getDateString } = await import('@shadowob/shared')
+          await this.deps.agentDashboardDao.incrementMessageCount(
+            agent.id,
+            getDateString(new Date()),
+          )
           await this.deps.agentDashboardDao.incrementHourlyMessage(agent.id, new Date().getHours())
           await this.deps.agentDashboardDao.createEvent(agent.id, 'message', {
             preview: input.content.substring(0, 100),
@@ -78,7 +83,10 @@ export class MessageService {
       } catch (err) {
         // Non-critical: don't fail message creation if stats tracking fails
         // But log for monitoring
-        this.deps.logger?.warn?.({ err, agentId: authorId, messageId: message.id }, 'Failed to track dashboard stats')
+        this.deps.logger?.warn?.(
+          { err, agentId: authorId, messageId: message.id },
+          'Failed to track dashboard stats',
+        )
       }
     }
 

--- a/apps/server/src/services/message.service.ts
+++ b/apps/server/src/services/message.service.ts
@@ -1,3 +1,5 @@
+import type { AgentDashboardDao } from '../dao/agent-dashboard.dao'
+import type { AgentDao } from '../dao/agent.dao'
 import type { ChannelDao } from '../dao/channel.dao'
 import type { MessageDao } from '../dao/message.dao'
 import type { UserDao } from '../dao/user.dao'
@@ -10,7 +12,13 @@ import type {
 } from '../validators/message.schema'
 
 export class MessageService {
-  constructor(private deps: { messageDao: MessageDao; userDao: UserDao; channelDao: ChannelDao }) {}
+  constructor(private deps: {
+    messageDao: MessageDao
+    userDao: UserDao
+    channelDao: ChannelDao
+    agentDao: AgentDao
+    agentDashboardDao: AgentDashboardDao
+  }) {}
 
   async getByChannelId(channelId: string, limit?: number, cursor?: string) {
     return this.deps.messageDao.findByChannelId(channelId, limit, cursor)
@@ -53,8 +61,25 @@ export class MessageService {
       }
     }
 
+    // Track message stats for Buddy Dashboard if author is a bot
+    if (user?.isBot) {
+      try {
+        const agent = await this.deps.agentDao.findByUserId(authorId)
+        if (agent) {
+          await this.deps.agentDashboardDao.incrementMessageCount(agent.id, new Date().toISOString().split('T')[0])
+          await this.deps.agentDashboardDao.incrementHourlyMessage(agent.id, new Date().getHours())
+          await this.deps.agentDashboardDao.createEvent(agent.id, 'message', {
+            preview: input.content.substring(0, 100),
+            channelId,
+            messageId: message.id,
+          })
+        }
+      } catch {
+        // Non-critical: don't fail message creation if stats tracking fails
+      }
+    }
+
     // Attach author info and attachments for broadcasting
-    const user = await this.deps.userDao.findById(authorId)
     const messageAttachments = await this.deps.messageDao.getAttachments(message.id)
     return {
       ...message,
@@ -63,7 +88,7 @@ export class MessageService {
             id: user.id,
             username: user.username,
             displayName: user.displayName,
-            avatarUrl: user.avatarUrl,
+            avatarName: user.avatarUrl,
             status: user.status,
             isBot: user.isBot,
           }

--- a/apps/server/src/services/message.service.ts
+++ b/apps/server/src/services/message.service.ts
@@ -63,6 +63,10 @@ export class MessageService {
       }
     }
 
+    // Attach author info and attachments for broadcasting
+    const user = await this.deps.userDao.findById(authorId)
+    const messageAttachments = await this.deps.messageDao.getAttachments(message.id)
+
     // Track message stats for Buddy Dashboard if author is a bot
     if (user?.isBot) {
       try {
@@ -90,8 +94,6 @@ export class MessageService {
       }
     }
 
-    // Attach author info and attachments for broadcasting
-    const messageAttachments = await this.deps.messageDao.getAttachments(message.id)
     return {
       ...message,
       author: user

--- a/apps/server/src/services/message.service.ts
+++ b/apps/server/src/services/message.service.ts
@@ -66,7 +66,8 @@ export class MessageService {
       try {
         const agent = await this.deps.agentDao.findByUserId(authorId)
         if (agent) {
-          await this.deps.agentDashboardDao.incrementMessageCount(agent.id, new Date().toISOString().split('T')[0])
+          const { getDateString } = await import('@shadowob/shared/utils/date')
+          await this.deps.agentDashboardDao.incrementMessageCount(agent.id, getDateString(new Date()))
           await this.deps.agentDashboardDao.incrementHourlyMessage(agent.id, new Date().getHours())
           await this.deps.agentDashboardDao.createEvent(agent.id, 'message', {
             preview: input.content.substring(0, 100),
@@ -74,8 +75,10 @@ export class MessageService {
             messageId: message.id,
           })
         }
-      } catch {
+      } catch (err) {
         // Non-critical: don't fail message creation if stats tracking fails
+        // But log for monitoring
+        this.deps.logger?.warn?.({ err, agentId: authorId, messageId: message.id }, 'Failed to track dashboard stats')
       }
     }
 

--- a/apps/server/src/services/message.service.ts
+++ b/apps/server/src/services/message.service.ts
@@ -68,7 +68,7 @@ export class MessageService {
       try {
         const agent = await this.deps.agentDao.findByUserId(authorId)
         if (agent) {
-          const { getDateString } = await import('@shadowob/shared')
+          const getDateString = (date: Date): string => date.toISOString().slice(0, 10)
           await this.deps.agentDashboardDao.incrementMessageCount(
             agent.id,
             getDateString(new Date()),

--- a/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 import { ActivityHeatmap } from '../activity-heatmap'
 
 // @vitest-environment jsdom
-import '@testing-library/jest-dom'
 
 // Mock i18next
 vi.mock('react-i18next', () => ({
@@ -23,13 +22,13 @@ describe('ActivityHeatmap', () => {
 
   it('renders without crashing', () => {
     render(<ActivityHeatmap data={mockData} />)
-    expect(screen.getByText('buddyDashboard.activityHeatmap')).toBeInTheDocument()
+    expect(screen.getByText('buddyDashboard.activityHeatmap')).toBeTruthy()
   })
 
   it('renders legend with all levels', () => {
     render(<ActivityHeatmap data={mockData} />)
-    expect(screen.getByText('buddyDashboard.less')).toBeInTheDocument()
-    expect(screen.getByText('buddyDashboard.more')).toBeInTheDocument()
+    expect(screen.getByText('buddyDashboard.less')).toBeTruthy()
+    expect(screen.getByText('buddyDashboard.more')).toBeTruthy()
   })
 
   it('renders heatmap cells', () => {

--- a/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ActivityHeatmap } from '../activity-heatmap'
+
+// @vitest-environment jsdom
 
 // Mock i18next
 vi.mock('react-i18next', () => ({

--- a/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ActivityHeatmap } from '../activity-heatmap'
 
 // @vitest-environment jsdom
+import '@testing-library/jest-dom'
 
 // Mock i18next
 vi.mock('react-i18next', () => ({

--- a/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
@@ -7,7 +7,7 @@ import { ActivityHeatmap } from '../activity-heatmap'
 // Mock i18next
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, defaultValue?: string) => defaultValue || key,
   }),
 }))
 
@@ -22,13 +22,13 @@ describe('ActivityHeatmap', () => {
 
   it('renders without crashing', () => {
     render(<ActivityHeatmap data={mockData} />)
-    expect(screen.getByText('buddyDashboard.activityHeatmap')).toBeTruthy()
+    expect(screen.getByText('Activity Heatmap')).toBeTruthy()
   })
 
   it('renders legend with all levels', () => {
     render(<ActivityHeatmap data={mockData} />)
-    expect(screen.getByText('buddyDashboard.less')).toBeTruthy()
-    expect(screen.getByText('buddyDashboard.more')).toBeTruthy()
+    expect(screen.getByText('Less')).toBeTruthy()
+    expect(screen.getByText('More')).toBeTruthy()
   })
 
   it('renders heatmap cells', () => {

--- a/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/activity-heatmap.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ActivityHeatmap } from '../activity-heatmap'
+
+// Mock i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+describe('ActivityHeatmap', () => {
+  const mockData = [
+    { date: '2025-03-20', messageCount: 0, level: 0 as const },
+    { date: '2025-03-21', messageCount: 5, level: 1 as const },
+    { date: '2025-03-22', messageCount: 25, level: 2 as const },
+    { date: '2025-03-23', messageCount: 75, level: 3 as const },
+    { date: '2025-03-24', messageCount: 150, level: 4 as const },
+  ]
+
+  it('renders without crashing', () => {
+    render(<ActivityHeatmap data={mockData} />)
+    expect(screen.getByText('buddyDashboard.activityHeatmap')).toBeInTheDocument()
+  })
+
+  it('renders legend with all levels', () => {
+    render(<ActivityHeatmap data={mockData} />)
+    expect(screen.getByText('buddyDashboard.less')).toBeInTheDocument()
+    expect(screen.getByText('buddyDashboard.more')).toBeInTheDocument()
+  })
+
+  it('renders heatmap cells', () => {
+    const { container } = render(<ActivityHeatmap data={mockData} />)
+    const cells = container.querySelectorAll('[title]')
+    expect(cells.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 import { StatsCards } from '../stats-cards'
 
 // @vitest-environment jsdom
-import '@testing-library/jest-dom'
 
 // Mock i18next
 vi.mock('react-i18next', () => ({
@@ -29,23 +28,23 @@ describe('StatsCards', () => {
   it('renders all stat cards', () => {
     render(<StatsCards stats={mockStats} />)
 
-    expect(screen.getByText('buddyDashboard.totalMessages')).toBeInTheDocument()
-    expect(screen.getByText('buddyDashboard.onlineTime')).toBeInTheDocument()
-    expect(screen.getByText('buddyDashboard.activeDays')).toBeInTheDocument()
-    expect(screen.getByText('buddyDashboard.currentStreak')).toBeInTheDocument()
+    expect(screen.getByText('buddyDashboard.totalMessages')).toBeTruthy()
+    expect(screen.getByText('buddyDashboard.onlineTime')).toBeTruthy()
+    expect(screen.getByText('buddyDashboard.activeDays')).toBeTruthy()
+    expect(screen.getByText('buddyDashboard.currentStreak')).toBeTruthy()
   })
 
   it('displays correct values', () => {
     render(<StatsCards stats={mockStats} />)
 
-    expect(screen.getByText('1,234')).toBeInTheDocument() // totalMessages
-    expect(screen.getByText('1h 1m')).toBeInTheDocument() // online time
-    expect(screen.getByText('15')).toBeInTheDocument() // active days
-    expect(screen.getByText('buddyDashboard.days {"count":5}')).toBeInTheDocument() // streak
+    expect(screen.getByText('1,234')).toBeTruthy() // totalMessages
+    expect(screen.getByText('1h 1m')).toBeTruthy() // online time
+    expect(screen.getByText('15')).toBeTruthy() // active days
+    expect(screen.getByText('buddyDashboard.days {"count":5}')).toBeTruthy() // streak
   })
 
   it('shows best streak when available', () => {
     render(<StatsCards stats={mockStats} />)
-    expect(screen.getByText(/buddyDashboard.best/)).toBeInTheDocument()
+    expect(screen.getByText(/buddyDashboard.best/)).toBeTruthy()
   })
 })

--- a/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { StatsCards } from '../stats-cards'
 
 // @vitest-environment jsdom
+import '@testing-library/jest-dom'
 
 // Mock i18next
 vi.mock('react-i18next', () => ({

--- a/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { StatsCards } from '../stats-cards'
+
+// @vitest-environment jsdom
 
 // Mock i18next
 vi.mock('react-i18next', () => ({

--- a/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { StatsCards } from '../stats-cards'
+
+// Mock i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (params) {
+        return `${key} ${JSON.stringify(params)}`
+      }
+      return key
+    },
+  }),
+}))
+
+describe('StatsCards', () => {
+  const mockStats = {
+    totalMessages: 1234,
+    totalOnlineSeconds: 3665, // 1h 1m 5s
+    activeDays30d: 15,
+    currentStreak: 5,
+    longestStreak: 10,
+  }
+
+  it('renders all stat cards', () => {
+    render(<StatsCards stats={mockStats} />)
+
+    expect(screen.getByText('buddyDashboard.totalMessages')).toBeInTheDocument()
+    expect(screen.getByText('buddyDashboard.onlineTime')).toBeInTheDocument()
+    expect(screen.getByText('buddyDashboard.activeDays')).toBeInTheDocument()
+    expect(screen.getByText('buddyDashboard.currentStreak')).toBeInTheDocument()
+  })
+
+  it('displays correct values', () => {
+    render(<StatsCards stats={mockStats} />)
+
+    expect(screen.getByText('1,234')).toBeInTheDocument() // totalMessages
+    expect(screen.getByText('1h 1m')).toBeInTheDocument() // online time
+    expect(screen.getByText('15')).toBeInTheDocument() // active days
+    expect(screen.getByText('buddyDashboard.days {"count":5}')).toBeInTheDocument() // streak
+  })
+
+  it('shows best streak when available', () => {
+    render(<StatsCards stats={mockStats} />)
+    expect(screen.getByText(/buddyDashboard.best/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
+++ b/apps/web/src/components/buddy-dashboard/__tests__/stats-cards.test.tsx
@@ -7,11 +7,9 @@ import { StatsCards } from '../stats-cards'
 // Mock i18next
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, params?: Record<string, unknown>) => {
-      if (params) {
-        return `${key} ${JSON.stringify(params)}`
-      }
-      return key
+    t: (key: string, defaultValue?: string) => {
+      // Return default value if provided, otherwise return key
+      return defaultValue || key
     },
   }),
 }))
@@ -28,10 +26,10 @@ describe('StatsCards', () => {
   it('renders all stat cards', () => {
     render(<StatsCards stats={mockStats} />)
 
-    expect(screen.getByText('buddyDashboard.totalMessages')).toBeTruthy()
-    expect(screen.getByText('buddyDashboard.onlineTime')).toBeTruthy()
-    expect(screen.getByText('buddyDashboard.activeDays')).toBeTruthy()
-    expect(screen.getByText('buddyDashboard.currentStreak')).toBeTruthy()
+    expect(screen.getByText('Total Messages')).toBeTruthy()
+    expect(screen.getByText('Online Time')).toBeTruthy()
+    expect(screen.getByText('Active Days (30d)')).toBeTruthy()
+    expect(screen.getByText('Current Streak')).toBeTruthy()
   })
 
   it('displays correct values', () => {
@@ -40,11 +38,11 @@ describe('StatsCards', () => {
     expect(screen.getByText('1,234')).toBeTruthy() // totalMessages
     expect(screen.getByText('1h 1m')).toBeTruthy() // online time
     expect(screen.getByText('15')).toBeTruthy() // active days
-    expect(screen.getByText('buddyDashboard.days {"count":5}')).toBeTruthy() // streak
+    expect(screen.getByText('5 days')).toBeTruthy() // streak
   })
 
   it('shows best streak when available', () => {
     render(<StatsCards stats={mockStats} />)
-    expect(screen.getByText(/buddyDashboard.best/)).toBeTruthy()
+    expect(screen.getByText(/Best/)).toBeTruthy()
   })
 })

--- a/apps/web/src/components/buddy-dashboard/activity-heatmap.tsx
+++ b/apps/web/src/components/buddy-dashboard/activity-heatmap.tsx
@@ -1,3 +1,4 @@
+import { ACTIVITY_LEVELS, type ActivityLevel } from '@shadowob/shared/utils/date'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -5,24 +6,24 @@ interface ActivityHeatmapProps {
   data: Array<{
     date: string
     messageCount: number
-    level: 0 | 1 | 2 | 3 | 4
+    level: ActivityLevel
   }>
 }
 
-const LEVEL_COLORS = {
-  0: 'bg-transparent',
-  1: 'bg-green-900/30',
-  2: 'bg-green-700/50',
-  3: 'bg-green-500/70',
-  4: 'bg-green-400',
+const LEVEL_COLORS: Record<ActivityLevel, string> = {
+  0: ACTIVITY_LEVELS[0].color,
+  1: ACTIVITY_LEVELS[1].color,
+  2: ACTIVITY_LEVELS[2].color,
+  3: ACTIVITY_LEVELS[3].color,
+  4: ACTIVITY_LEVELS[4].color,
 }
 
-const LEVEL_LABELS = {
-  0: 'No activity',
-  1: '1-10 messages',
-  2: '11-50 messages',
-  3: '51-100 messages',
-  4: '100+ messages',
+const LEVEL_LABELS: Record<ActivityLevel, string> = {
+  0: ACTIVITY_LEVELS[0].label,
+  1: ACTIVITY_LEVELS[1].label,
+  2: ACTIVITY_LEVELS[2].label,
+  3: ACTIVITY_LEVELS[3].label,
+  4: ACTIVITY_LEVELS[4].label,
 }
 
 export function ActivityHeatmap({ data }: ActivityHeatmapProps) {

--- a/apps/web/src/components/buddy-dashboard/activity-heatmap.tsx
+++ b/apps/web/src/components/buddy-dashboard/activity-heatmap.tsx
@@ -1,4 +1,4 @@
-import { ACTIVITY_LEVELS, type ActivityLevel } from '@shadowob/shared/utils/date'
+import { ACTIVITY_LEVELS, type ActivityLevel } from '@shadowob/shared'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -53,9 +53,7 @@ export function ActivityHeatmap({ data }: ActivityHeatmapProps) {
         const weekDays: typeof data = []
         for (let i = 0; i < 7; i++) {
           const day = days.find((d) => new Date(d.date).getDay() === i)
-          weekDays.push(
-            day ?? { date: '', messageCount: 0, level: 0 }
-          )
+          weekDays.push(day ?? { date: '', messageCount: 0, level: 0 })
         }
         return weekDays
       })
@@ -101,12 +99,14 @@ export function ActivityHeatmap({ data }: ActivityHeatmapProps) {
       {/* Heatmap grid */}
       <div className="flex gap-1">
         {weeks.map((week, weekIndex) => (
-          <div key={weekIndex} className="flex flex-col gap-1">
+          <div key={`week-${weekIndex}`} className="flex flex-col gap-1">
             {week.map((day, dayIndex) => (
               <div
-                key={dayIndex}
+                key={`day-${weekIndex}-${dayIndex}-${day.date || 'empty'}`}
                 className={`w-3 h-3 rounded-sm ${LEVEL_COLORS[day.level]} transition-all hover:ring-2 hover:ring-primary/50 cursor-pointer`}
-                title={day.date ? `${formatDate(day.date)}: ${day.messageCount} messages` : 'No data'}
+                title={
+                  day.date ? `${formatDate(day.date)}: ${day.messageCount} messages` : 'No data'
+                }
               />
             ))}
           </div>

--- a/apps/web/src/components/buddy-dashboard/activity-heatmap.tsx
+++ b/apps/web/src/components/buddy-dashboard/activity-heatmap.tsx
@@ -1,0 +1,131 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface ActivityHeatmapProps {
+  data: Array<{
+    date: string
+    messageCount: number
+    level: 0 | 1 | 2 | 3 | 4
+  }>
+}
+
+const LEVEL_COLORS = {
+  0: 'bg-transparent',
+  1: 'bg-green-900/30',
+  2: 'bg-green-700/50',
+  3: 'bg-green-500/70',
+  4: 'bg-green-400',
+}
+
+const LEVEL_LABELS = {
+  0: 'No activity',
+  1: '1-10 messages',
+  2: '11-50 messages',
+  3: '51-100 messages',
+  4: '100+ messages',
+}
+
+export function ActivityHeatmap({ data }: ActivityHeatmapProps) {
+  const { t } = useTranslation()
+
+  const weeks = useMemo(() => {
+    // Group data by week
+    const weekMap = new Map<string, typeof data>()
+
+    for (const day of data) {
+      const date = new Date(day.date)
+      const weekStart = new Date(date)
+      weekStart.setDate(date.getDate() - date.getDay())
+      const weekKey = weekStart.toISOString().split('T')[0]
+
+      if (!weekMap.has(weekKey)) {
+        weekMap.set(weekKey, [])
+      }
+      weekMap.get(weekKey)!.push(day)
+    }
+
+    // Convert to array and sort
+    return Array.from(weekMap.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([_, days]) => {
+        // Ensure 7 days per week
+        const weekDays: typeof data = []
+        for (let i = 0; i < 7; i++) {
+          const day = days.find((d) => new Date(d.date).getDay() === i)
+          weekDays.push(
+            day ?? { date: '', messageCount: 0, level: 0 }
+          )
+        }
+        return weekDays
+      })
+  }, [data])
+
+  const months = useMemo(() => {
+    const monthSet = new Set<string>()
+    for (const day of data) {
+      if (day.date) {
+        const date = new Date(day.date)
+        monthSet.add(date.toLocaleString('default', { month: 'short' }))
+      }
+    }
+    return Array.from(monthSet)
+  }, [data])
+
+  const formatDate = (dateStr: string) => {
+    if (!dateStr) return ''
+    const date = new Date(dateStr)
+    return date.toLocaleDateString('default', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  return (
+    <div className="bg-bg-secondary rounded-xl p-6 border border-border-subtle">
+      <h3 className="text-sm font-bold text-text-primary uppercase tracking-wider mb-4">
+        {t('buddyDashboard.activityHeatmap', 'Activity Heatmap')}
+      </h3>
+
+      {/* Month labels */}
+      <div className="flex gap-1 mb-1 text-xs text-text-muted">
+        {months.map((month) => (
+          <span key={month} className="w-8 text-center">
+            {month}
+          </span>
+        ))}
+      </div>
+
+      {/* Heatmap grid */}
+      <div className="flex gap-1">
+        {weeks.map((week, weekIndex) => (
+          <div key={weekIndex} className="flex flex-col gap-1">
+            {week.map((day, dayIndex) => (
+              <div
+                key={dayIndex}
+                className={`w-3 h-3 rounded-sm ${LEVEL_COLORS[day.level]} transition-all hover:ring-2 hover:ring-primary/50 cursor-pointer`}
+                title={day.date ? `${formatDate(day.date)}: ${day.messageCount} messages` : 'No data'}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 mt-4 text-xs text-text-muted">
+        <span>{t('buddyDashboard.less', 'Less')}</span>
+        <div className="flex gap-1">
+          {[0, 1, 2, 3, 4].map((level) => (
+            <div
+              key={level}
+              className={`w-3 h-3 rounded-sm ${LEVEL_COLORS[level as keyof typeof LEVEL_COLORS]}`}
+              title={LEVEL_LABELS[level as keyof typeof LEVEL_LABELS]}
+            />
+          ))}
+        </div>
+        <span>{t('buddyDashboard.more', 'More')}</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/buddy-dashboard/activity-heatmap.tsx
+++ b/apps/web/src/components/buddy-dashboard/activity-heatmap.tsx
@@ -1,4 +1,3 @@
-import { ACTIVITY_LEVELS, type ActivityLevel } from '@shadowob/shared'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -6,24 +5,26 @@ interface ActivityHeatmapProps {
   data: Array<{
     date: string
     messageCount: number
-    level: ActivityLevel
+    level: 0 | 1 | 2 | 3 | 4
   }>
 }
 
+type ActivityLevel = 0 | 1 | 2 | 3 | 4
+
 const LEVEL_COLORS: Record<ActivityLevel, string> = {
-  0: ACTIVITY_LEVELS[0].color,
-  1: ACTIVITY_LEVELS[1].color,
-  2: ACTIVITY_LEVELS[2].color,
-  3: ACTIVITY_LEVELS[3].color,
-  4: ACTIVITY_LEVELS[4].color,
+  0: 'bg-transparent',
+  1: 'bg-green-900/30',
+  2: 'bg-green-700/50',
+  3: 'bg-green-500/70',
+  4: 'bg-green-400',
 }
 
 const LEVEL_LABELS: Record<ActivityLevel, string> = {
-  0: ACTIVITY_LEVELS[0].label,
-  1: ACTIVITY_LEVELS[1].label,
-  2: ACTIVITY_LEVELS[2].label,
-  3: ACTIVITY_LEVELS[3].label,
-  4: ACTIVITY_LEVELS[4].label,
+  0: 'No activity',
+  1: '1-10 messages',
+  2: '11-50 messages',
+  3: '51-100 messages',
+  4: '100+ messages',
 }
 
 export function ActivityHeatmap({ data }: ActivityHeatmapProps) {

--- a/apps/web/src/components/buddy-dashboard/hourly-distribution.tsx
+++ b/apps/web/src/components/buddy-dashboard/hourly-distribution.tsx
@@ -1,0 +1,60 @@
+import { useTranslation } from 'react-i18next'
+
+interface HourlyDistributionProps {
+  data: Array<{
+    hour: number
+    messageCount: number
+  }>
+}
+
+export function HourlyDistribution({ data }: HourlyDistributionProps) {
+  const { t } = useTranslation()
+
+  const maxCount = Math.max(...data.map((d) => d.messageCount), 1)
+
+  const formatHour = (hour: number) => {
+    if (hour === 0) return '12am'
+    if (hour < 12) return `${hour}am`
+    if (hour === 12) return '12pm'
+    return `${hour - 12}pm`
+  }
+
+  // Show every 3rd hour label to save space
+  const showLabel = (hour: number) => hour % 3 === 0
+
+  return (
+    <div className="bg-bg-secondary rounded-xl p-6 border border-border-subtle">
+      <h3 className="text-sm font-bold text-text-primary uppercase tracking-wider mb-4">
+        {t('buddyDashboard.hourlyDistribution', 'Hourly Distribution')}
+      </h3>
+
+      <div className="grid grid-cols-12 gap-1 h-24">
+        {data.map((hour) => {
+          const intensity = maxCount > 0 ? hour.messageCount / maxCount : 0
+          const opacity = Math.max(0.1, intensity)
+
+          return (
+            <div
+              key={hour.hour}
+              className="flex flex-col items-center gap-1"
+            >
+              <div className="flex-1 w-full flex items-end">
+                <div
+                  className="w-full bg-primary rounded-sm transition-all hover:ring-2 hover:ring-primary/50 cursor-pointer"
+                  style={{
+                    height: `${Math.max(intensity * 100, 4)}%`,
+                    opacity,
+                  }}
+                  title={`${formatHour(hour.hour)}: ${hour.messageCount} messages`}
+                />
+              </div>
+              {showLabel(hour.hour) && (
+                <span className="text-[10px] text-text-muted">{formatHour(hour.hour)}</span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/buddy-dashboard/index.tsx
+++ b/apps/web/src/components/buddy-dashboard/index.tsx
@@ -1,0 +1,6 @@
+export { ActivityHeatmap } from './activity-heatmap'
+export { HourlyDistribution } from './hourly-distribution'
+export { MonthlyTrend } from './monthly-trend'
+export { RecentActivity } from './recent-activity'
+export { StatsCards } from './stats-cards'
+export { WeeklyActivityChart } from './weekly-activity-chart'

--- a/apps/web/src/components/buddy-dashboard/monthly-trend.tsx
+++ b/apps/web/src/components/buddy-dashboard/monthly-trend.tsx
@@ -1,0 +1,123 @@
+import { useTranslation } from 'react-i18next'
+
+interface MonthlyTrendProps {
+  data: Array<{
+    month: string
+    messageCount: number
+  }>
+}
+
+export function MonthlyTrend({ data }: MonthlyTrendProps) {
+  const { t } = useTranslation()
+
+  const maxCount = Math.max(...data.map((d) => d.messageCount), 1)
+  const minCount = Math.min(...data.map((d) => d.messageCount), 0)
+
+  const formatMonth = (monthStr: string) => {
+    const [year, month] = monthStr.split('-')
+    const date = new Date(Number(year), Number(month) - 1)
+    return date.toLocaleDateString('default', { month: 'short' })
+  }
+
+  // Generate SVG path for the line chart
+  const generatePath = () => {
+    if (data.length === 0) return ''
+
+    const width = 100
+    const height = 50
+    const padding = 5
+
+    const points = data.map((d, i) => {
+      const x = padding + (i / (data.length - 1)) * (width - 2 * padding)
+      const range = maxCount - minCount || 1
+      const y = height - padding - ((d.messageCount - minCount) / range) * (height - 2 * padding)
+      return `${x},${y}`
+    })
+
+    return `M ${points.join(' L ')}`
+  }
+
+  // Generate area path
+  const generateAreaPath = () => {
+    if (data.length === 0) return ''
+
+    const width = 100
+    const height = 50
+    const padding = 5
+
+    const points = data.map((d, i) => {
+      const x = padding + (i / (data.length - 1)) * (width - 2 * padding)
+      const range = maxCount - minCount || 1
+      const y = height - padding - ((d.messageCount - minCount) / range) * (height - 2 * padding)
+      return `${x},${y}`
+    })
+
+    const firstPoint = points[0].split(',')
+    const lastPoint = points[points.length - 1].split(',')
+
+    return `M ${points.join(' L ')} L ${lastPoint[0]},${height} L ${firstPoint[0]},${height} Z`
+  }
+
+  return (
+    <div className="bg-bg-secondary rounded-xl p-6 border border-border-subtle">
+      <h3 className="text-sm font-bold text-text-primary uppercase tracking-wider mb-4">
+        {t('buddyDashboard.monthlyTrend', 'Monthly Trend')}
+      </h3>
+
+      <div className="relative h-32">
+        <svg
+          viewBox="0 0 100 50"
+          className="w-full h-full overflow-visible"
+          preserveAspectRatio="none"
+        >
+          {/* Area under the line */}
+          <path
+            d={generateAreaPath()}
+            fill="currentColor"
+            className="text-primary/20"
+          />
+
+          {/* Line */}
+          <path
+            d={generatePath()}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="0.5"
+            className="text-primary"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+
+          {/* Data points */}
+          {data.map((d, i) => {
+            const width = 100
+            const height = 50
+            const padding = 5
+            const x = padding + (i / (data.length - 1)) * (width - 2 * padding)
+            const range = maxCount - minCount || 1
+            const y = height - padding - ((d.messageCount - minCount) / range) * (height - 2 * padding)
+
+            return (
+              <circle
+                key={i}
+                cx={x}
+                cy={y}
+                r="1"
+                className="fill-primary hover:fill-primary-hover cursor-pointer"
+              >
+                <title>{`${formatMonth(d.month)}: ${d.messageCount} messages`}</title>
+              </circle>
+            )
+          })}
+        </svg>
+
+        {/* Month labels */}
+        <div className="flex justify-between mt-2 text-[10px] text-text-muted">
+          {data.filter((_, i) => i % 3 === 0).map((d, i) => (
+            <span key={i}>{formatMonth(d.month)}</span>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/buddy-dashboard/recent-activity.tsx
+++ b/apps/web/src/components/buddy-dashboard/recent-activity.tsx
@@ -1,0 +1,112 @@
+import { MessageSquare, Power, RefreshCw, Settings, UserPlus } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface RecentActivityProps {
+  events: Array<{
+    id: string
+    type: string
+    data: Record<string, unknown>
+    createdAt: string
+  }>
+}
+
+const EVENT_ICONS: Record<string, typeof MessageSquare> = {
+  message: MessageSquare,
+  status_change: Power,
+  rental_start: UserPlus,
+  rental_end: UserPlus,
+  policy_update: Settings,
+}
+
+const EVENT_COLORS: Record<string, string> = {
+  message: 'text-blue-400 bg-blue-400/10',
+  status_change: 'text-green-400 bg-green-400/10',
+  rental_start: 'text-purple-400 bg-purple-400/10',
+  rental_end: 'text-orange-400 bg-orange-400/10',
+  policy_update: 'text-gray-400 bg-gray-400/10',
+}
+
+export function RecentActivity({ events }: RecentActivityProps) {
+  const { t } = useTranslation()
+
+  const formatTime = (dateStr: string) => {
+    const date = new Date(dateStr)
+    const now = new Date()
+    const diffMs = now.getTime() - date.getTime()
+    const diffMins = Math.floor(diffMs / 60000)
+    const diffHours = Math.floor(diffMs / 3600000)
+    const diffDays = Math.floor(diffMs / 86400000)
+
+    if (diffMins < 1) return t('buddyDashboard.justNow', 'Just now')
+    if (diffMins < 60) return t('buddyDashboard.minutesAgo', '{{count}}m ago', { count: diffMins })
+    if (diffHours < 24) return t('buddyDashboard.hoursAgo', '{{count}}h ago', { count: diffHours })
+    if (diffDays < 7) return t('buddyDashboard.daysAgo', '{{count}}d ago', { count: diffDays })
+    return date.toLocaleDateString('default', { month: 'short', day: 'numeric' })
+  }
+
+  const getEventDescription = (event: (typeof events)[0]) => {
+    switch (event.type) {
+      case 'message':
+        return event.data.preview
+          ? `"${String(event.data.preview).substring(0, 50)}..."`
+          : t('buddyDashboard.sentMessage', 'Sent a message')
+      case 'status_change':
+        return event.data.status === 'online'
+          ? t('buddyDashboard.wentOnline', 'Went online')
+          : t('buddyDashboard.wentOffline', 'Went offline')
+      case 'rental_start':
+        return t('buddyDashboard.rentalStarted', 'Rental started by @{{user}}', {
+          user: String(event.data.tenantUsername || 'user'),
+        })
+      case 'rental_end':
+        return t('buddyDashboard.rentalEnded', 'Rental ended')
+      case 'policy_update':
+        return t('buddyDashboard.policyUpdated', 'Policy settings updated')
+      default:
+        return event.type
+    }
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="bg-bg-secondary rounded-xl p-6 border border-border-subtle">
+        <h3 className="text-sm font-bold text-text-primary uppercase tracking-wider mb-4">
+          {t('buddyDashboard.recentActivity', 'Recent Activity')}
+        </h3>
+        <div className="text-center text-text-muted py-8">
+          {t('buddyDashboard.noActivity', 'No recent activity')}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-bg-secondary rounded-xl p-6 border border-border-subtle">
+      <h3 className="text-sm font-bold text-text-primary uppercase tracking-wider mb-4">
+        {t('buddyDashboard.recentActivity', 'Recent Activity')}
+      </h3>
+
+      <div className="space-y-3">
+        {events.map((event) => {
+          const Icon = EVENT_ICONS[event.type] || RefreshCw
+          const colorClass = EVENT_COLORS[event.type] || 'text-gray-400 bg-gray-400/10'
+
+          return (
+            <div
+              key={event.id}
+              className="flex items-start gap-3 p-3 rounded-lg hover:bg-bg-modifier-hover transition-colors"
+            >
+              <div className={`w-8 h-8 rounded-lg ${colorClass} flex items-center justify-center shrink-0`}>
+                <Icon className="w-4 h-4" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-text-primary">{getEventDescription(event)}</p>
+                <p className="text-xs text-text-muted mt-1">{formatTime(event.createdAt)}</p>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/buddy-dashboard/stats-cards.tsx
+++ b/apps/web/src/components/buddy-dashboard/stats-cards.tsx
@@ -1,3 +1,4 @@
+import { formatDurationShort } from '@shadowob/shared/utils/date'
 import { Calendar, Clock, Flame, MessageSquare } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -9,21 +10,6 @@ interface StatsCardsProps {
     currentStreak: number
     longestStreak: number
   }
-}
-
-function formatDuration(seconds: number): string {
-  const hours = Math.floor(seconds / 3600)
-  const minutes = Math.floor((seconds % 3600) / 60)
-
-  if (hours === 0) {
-    return `${minutes}m`
-  }
-  if (hours < 24) {
-    return `${hours}h ${minutes}m`
-  }
-  const days = Math.floor(hours / 24)
-  const remainingHours = hours % 24
-  return `${days}d ${remainingHours}h`
 }
 
 export function StatsCards({ stats }: StatsCardsProps) {
@@ -40,7 +26,7 @@ export function StatsCards({ stats }: StatsCardsProps) {
     {
       icon: Clock,
       label: t('buddyDashboard.onlineTime', 'Online Time'),
-      value: formatDuration(stats.totalOnlineSeconds),
+      value: formatDurationShort(stats.totalOnlineSeconds),
       color: 'text-green-400',
       bgColor: 'bg-green-400/10',
     },

--- a/apps/web/src/components/buddy-dashboard/stats-cards.tsx
+++ b/apps/web/src/components/buddy-dashboard/stats-cards.tsx
@@ -1,4 +1,4 @@
-import { formatDurationShort } from '@shadowob/shared/utils/date'
+import { formatDurationShort } from '@shadowob/shared'
 import { Calendar, Clock, Flame, MessageSquare } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -41,9 +41,10 @@ export function StatsCards({ stats }: StatsCardsProps) {
       icon: Flame,
       label: t('buddyDashboard.currentStreak', 'Current Streak'),
       value: `${stats.currentStreak} ${t('buddyDashboard.days', 'days')}`,
-      subValue: stats.longestStreak > 0
-        ? `${t('buddyDashboard.best', 'Best')}: ${stats.longestStreak}`
-        : undefined,
+      subValue:
+        stats.longestStreak > 0
+          ? `${t('buddyDashboard.best', 'Best')}: ${stats.longestStreak}`
+          : undefined,
       color: 'text-orange-400',
       bgColor: 'bg-orange-400/10',
     },
@@ -56,14 +57,14 @@ export function StatsCards({ stats }: StatsCardsProps) {
           key={card.label}
           className="bg-bg-secondary rounded-xl p-4 border border-border-subtle"
         >
-          <div className={`w-10 h-10 rounded-lg ${card.bgColor} flex items-center justify-center mb-3`}>
+          <div
+            className={`w-10 h-10 rounded-lg ${card.bgColor} flex items-center justify-center mb-3`}
+          >
             <card.icon className={`w-5 h-5 ${card.color}`} />
           </div>
           <div className="text-2xl font-bold text-text-primary">{card.value}</div>
           <div className="text-xs text-text-muted mt-1">{card.label}</div>
-          {card.subValue && (
-            <div className="text-xs text-text-muted mt-1">{card.subValue}</div>
-          )}
+          {card.subValue && <div className="text-xs text-text-muted mt-1">{card.subValue}</div>}
         </div>
       ))}
     </div>

--- a/apps/web/src/components/buddy-dashboard/stats-cards.tsx
+++ b/apps/web/src/components/buddy-dashboard/stats-cards.tsx
@@ -1,4 +1,3 @@
-import { formatDurationShort } from '@shadowob/shared'
 import { Calendar, Clock, Flame, MessageSquare } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -10,6 +9,21 @@ interface StatsCardsProps {
     currentStreak: number
     longestStreak: number
   }
+}
+
+function formatDurationShort(seconds: number): string {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+
+  if (hours === 0) {
+    return `${minutes}m`
+  }
+  if (hours < 24) {
+    return `${hours}h ${minutes}m`
+  }
+  const days = Math.floor(hours / 24)
+  const remainingHours = hours % 24
+  return `${days}d ${remainingHours}h`
 }
 
 export function StatsCards({ stats }: StatsCardsProps) {

--- a/apps/web/src/components/buddy-dashboard/stats-cards.tsx
+++ b/apps/web/src/components/buddy-dashboard/stats-cards.tsx
@@ -1,0 +1,85 @@
+import { Calendar, Clock, Flame, MessageSquare } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface StatsCardsProps {
+  stats: {
+    totalMessages: number
+    totalOnlineSeconds: number
+    activeDays30d: number
+    currentStreak: number
+    longestStreak: number
+  }
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+
+  if (hours === 0) {
+    return `${minutes}m`
+  }
+  if (hours < 24) {
+    return `${hours}h ${minutes}m`
+  }
+  const days = Math.floor(hours / 24)
+  const remainingHours = hours % 24
+  return `${days}d ${remainingHours}h`
+}
+
+export function StatsCards({ stats }: StatsCardsProps) {
+  const { t } = useTranslation()
+
+  const cards = [
+    {
+      icon: MessageSquare,
+      label: t('buddyDashboard.totalMessages', 'Total Messages'),
+      value: stats.totalMessages.toLocaleString(),
+      color: 'text-blue-400',
+      bgColor: 'bg-blue-400/10',
+    },
+    {
+      icon: Clock,
+      label: t('buddyDashboard.onlineTime', 'Online Time'),
+      value: formatDuration(stats.totalOnlineSeconds),
+      color: 'text-green-400',
+      bgColor: 'bg-green-400/10',
+    },
+    {
+      icon: Calendar,
+      label: t('buddyDashboard.activeDays', 'Active Days (30d)'),
+      value: stats.activeDays30d.toString(),
+      color: 'text-purple-400',
+      bgColor: 'bg-purple-400/10',
+    },
+    {
+      icon: Flame,
+      label: t('buddyDashboard.currentStreak', 'Current Streak'),
+      value: `${stats.currentStreak} ${t('buddyDashboard.days', 'days')}`,
+      subValue: stats.longestStreak > 0
+        ? `${t('buddyDashboard.best', 'Best')}: ${stats.longestStreak}`
+        : undefined,
+      color: 'text-orange-400',
+      bgColor: 'bg-orange-400/10',
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {cards.map((card) => (
+        <div
+          key={card.label}
+          className="bg-bg-secondary rounded-xl p-4 border border-border-subtle"
+        >
+          <div className={`w-10 h-10 rounded-lg ${card.bgColor} flex items-center justify-center mb-3`}>
+            <card.icon className={`w-5 h-5 ${card.color}`} />
+          </div>
+          <div className="text-2xl font-bold text-text-primary">{card.value}</div>
+          <div className="text-xs text-text-muted mt-1">{card.label}</div>
+          {card.subValue && (
+            <div className="text-xs text-text-muted mt-1">{card.subValue}</div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/buddy-dashboard/weekly-activity-chart.tsx
+++ b/apps/web/src/components/buddy-dashboard/weekly-activity-chart.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from 'react-i18next'
+
+interface WeeklyActivityChartProps {
+  data: Array<{
+    date: string
+    messageCount: number
+  }>
+}
+
+export function WeeklyActivityChart({ data }: WeeklyActivityChartProps) {
+  const { t } = useTranslation()
+
+  const maxCount = Math.max(...data.map((d) => d.messageCount), 1)
+
+  const formatDay = (dateStr: string) => {
+    const date = new Date(dateStr)
+    return date.toLocaleDateString('default', { weekday: 'short' })
+  }
+
+  return (
+    <div className="bg-bg-secondary rounded-xl p-6 border border-border-subtle">
+      <h3 className="text-sm font-bold text-text-primary uppercase tracking-wider mb-4">
+        {t('buddyDashboard.weeklyActivity', 'Weekly Activity')}
+      </h3>
+
+      <div className="flex items-end justify-between h-32 gap-2">
+        {data.map((day, index) => {
+          const height = maxCount > 0 ? (day.messageCount / maxCount) * 100 : 0
+          return (
+            <div key={index} className="flex-1 flex flex-col items-center gap-2">
+              <div className="w-full flex-1 flex items-end">
+                <div
+                  className="w-full bg-primary/60 hover:bg-primary rounded-t transition-all cursor-pointer relative group"
+                  style={{ height: `${Math.max(height, 4)}%` }}
+                >
+                  {/* Tooltip */}
+                  <div className="absolute -top-8 left-1/2 -translate-x-1/2 bg-bg-tertiary text-text-primary text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none">
+                    {day.messageCount} messages
+                  </div>
+                </div>
+              </div>
+              <span className="text-xs text-text-muted">{formatDay(day.date)}</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -13,6 +13,7 @@ import { AppLayout } from './components/layout/app-layout'
 import { RootLayout } from './components/layout/root-layout'
 import { queryClient } from './lib/query-client'
 import { AppPageRoute } from './pages/apps'
+import { BuddyDashboardPage } from './pages/buddy-dashboard'
 import { BuddyManagementPage } from './pages/buddy-management'
 import { ChannelView } from './pages/channel-view'
 import { ContractDetailPage } from './pages/contract-detail'
@@ -257,6 +258,12 @@ const userProfileRoute = createRoute({
   component: UserProfilePage,
 })
 
+const buddyDashboardRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/buddy/$agentId/dashboard',
+  component: BuddyDashboardPage,
+})
+
 const dmChatRoute = createRoute({
   getParentRoute: () => appRoute,
   path: '/dm/$dmChannelId',
@@ -291,6 +298,7 @@ const routeTree = rootRoute.addChildren([
     editListingRoute,
     marketplaceDetailRoute,
     userProfileRoute,
+    buddyDashboardRoute,
     dmChatRoute,
   ]),
 ])

--- a/apps/web/src/pages/buddy-dashboard.tsx
+++ b/apps/web/src/pages/buddy-dashboard.tsx
@@ -1,0 +1,188 @@
+import { useQuery } from '@tanstack/react-query'
+import { useParams } from '@tanstack/react-router'
+import { ChevronLeft, LayoutDashboard } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import {
+  ActivityHeatmap,
+  HourlyDistribution,
+  MonthlyTrend,
+  RecentActivity,
+  StatsCards,
+  WeeklyActivityChart,
+} from '../components/buddy-dashboard'
+import { UserAvatar } from '../components/common/avatar'
+import { fetchApi } from '../lib/api'
+
+interface DashboardData {
+  activityHeatmap: Array<{
+    date: string
+    messageCount: number
+    level: 0 | 1 | 2 | 3 | 4
+  }>
+  stats: {
+    totalMessages: number
+    totalOnlineSeconds: number
+    activeDays30d: number
+    currentStreak: number
+    longestStreak: number
+  }
+  weeklyActivity: Array<{
+    date: string
+    messageCount: number
+  }>
+  hourlyDistribution: Array<{
+    hour: number
+    messageCount: number
+  }>
+  monthlyTrend: Array<{
+    month: string
+    messageCount: number
+  }>
+  recentEvents: Array<{
+    id: string
+    type: string
+    data: Record<string, unknown>
+    createdAt: string
+  }>
+  rentalStats?: {
+    totalRentals: number
+    totalIncome: number
+    averageDuration: number
+    currentTenant?: {
+      id: string
+      username: string
+      displayName: string
+    }
+  }
+}
+
+export function BuddyDashboardPage() {
+  const { t } = useTranslation()
+  const { agentId } = useParams({ strict: false }) as { agentId: string }
+
+  const { data: dashboard, isLoading } = useQuery({
+    queryKey: ['buddy-dashboard', agentId],
+    queryFn: () => fetchApi<DashboardData>(`/api/agents/${agentId}/dashboard`),
+    enabled: !!agentId,
+    refetchInterval: 30000, // Refresh every 30 seconds
+  })
+
+  if (isLoading || !dashboard) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="animate-pulse text-text-muted text-lg font-bold">
+          {t('common.loading', 'Loading...')}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto bg-bg-primary">
+      <div className="max-w-5xl mx-auto px-4 py-6 md:px-6 md:py-8">
+        {/* Header */}
+        <div className="flex items-center gap-4 mb-6">
+          <button
+            type="button"
+            onClick={() => window.history.back()}
+            className="inline-flex items-center gap-2 text-text-muted hover:text-text-primary transition font-bold"
+          >
+            <ChevronLeft className="w-5 h-5" />
+            {t('common.back', 'Back')}
+          </button>
+        </div>
+
+        {/* Page Title */}
+        <div className="flex items-center gap-3 mb-8">
+          <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center">
+            <LayoutDashboard className="w-6 h-6 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-text-primary">
+              {t('buddyDashboard.title', 'Buddy Dashboard')}
+            </h1>
+            <p className="text-sm text-text-muted">
+              {t('buddyDashboard.subtitle', 'Activity and performance metrics')}
+            </p>
+          </div>
+        </div>
+
+        {/* Stats Cards */}
+        <div className="mb-8">
+          <StatsCards stats={dashboard.stats} />
+        </div>
+
+        {/* Activity Heatmap */}
+        <div className="mb-8">
+          <ActivityHeatmap data={dashboard.activityHeatmap} />
+        </div>
+
+        {/* Charts Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+          <WeeklyActivityChart data={dashboard.weeklyActivity} />
+          <HourlyDistribution data={dashboard.hourlyDistribution} />
+        </div>
+
+        {/* Monthly Trend */}
+        <div className="mb-8">
+          <MonthlyTrend data={dashboard.monthlyTrend} />
+        </div>
+
+        {/* Bottom Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <RecentActivity events={dashboard.recentEvents} />
+
+          {/* Rental Stats */}
+          {dashboard.rentalStats && (
+            <div className="bg-bg-secondary rounded-xl p-6 border border-border-subtle">
+              <h3 className="text-sm font-bold text-text-primary uppercase tracking-wider mb-4">
+                {t('buddyDashboard.rentalStats', 'Rental Statistics')}
+              </h3>
+
+              <div className="space-y-4">
+                <div className="flex justify-between items-center">
+                  <span className="text-text-muted">{t('buddyDashboard.totalRentals', 'Total Rentals')}</span>
+                  <span className="text-text-primary font-bold">
+                    {dashboard.rentalStats.totalRentals}
+                  </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                  <span className="text-text-muted">{t('buddyDashboard.totalIncome', 'Total Income')}</span>
+                  <span className="text-text-primary font-bold">
+                    {dashboard.rentalStats.totalIncome.toLocaleString()} 虾币
+                  </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                  <span className="text-text-muted">{t('buddyDashboard.avgDuration', 'Avg Duration')}</span>
+                  <span className="text-text-primary font-bold">
+                    {dashboard.rentalStats.averageDuration.toFixed(1)} {t('buddyDashboard.days', 'days')}
+                  </span>
+                </div>
+
+                {dashboard.rentalStats.currentTenant && (
+                  <div className="pt-4 border-t border-border-subtle">
+                    <span className="text-text-muted text-sm">
+                      {t('buddyDashboard.currentTenant', 'Current Tenant')}
+                    </span>
+                    <div className="flex items-center gap-2 mt-2">
+                      <UserAvatar
+                        userId={dashboard.rentalStats.currentTenant.id}
+                        displayName={dashboard.rentalStats.currentTenant.displayName}
+                        size="sm"
+                      />
+                      <span className="text-text-primary">
+                        @{dashboard.rentalStats.currentTenant.username}
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/user-profile.tsx
+++ b/apps/web/src/pages/user-profile.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link, useParams } from '@tanstack/react-router'
-import { ChevronLeft, QrCode, X } from 'lucide-react'
+import { ChevronLeft, LayoutDashboard, QrCode, X } from 'lucide-react'
 import { QRCodeSVG } from 'qrcode.react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -156,6 +156,18 @@ export function UserProfilePage() {
                       </p>
                     </div>
                   )}
+
+                  {/* Dashboard Link */}
+                  <div className="mt-4 pt-4 border-t border-border-subtle">
+                    <Link
+                      to="/buddy/$agentId/dashboard"
+                      params={{ agentId: profile.agent.id }}
+                      className="flex items-center gap-2 px-4 py-2 bg-primary/10 hover:bg-primary/20 text-primary rounded-lg transition font-medium text-sm"
+                    >
+                      <LayoutDashboard className="w-4 h-4" />
+                      {t('buddyDashboard.viewDashboard', 'View Dashboard')}
+                    </Link>
+                  </div>
 
                   {/* Owner link */}
                   <div className="mt-4 pt-4 border-t border-border-subtle">

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,0 +1,262 @@
+# Buddy Dashboard Code Review
+
+> **Date**: 2025-03-27  
+> **Reviewer**: 小炸  
+> **PR**: #105
+
+---
+
+## 总体评价
+
+代码质量良好，架构清晰，遵循了项目现有的设计模式。但存在一些可以改进的地方，特别是在 DRY 原则、错误处理和性能优化方面。
+
+---
+
+## 架构评估 ✅
+
+### 优点
+1. **分层清晰**: DAO → Service → Handler → Component 的分层结构符合项目规范
+2. **依赖注入**: 使用 Awilix 容器管理依赖，便于测试和维护
+3. **类型安全**: TypeScript 接口定义完整，类型覆盖良好
+4. **前后端分离**: API 设计 RESTful，组件职责单一
+
+### 建议
+- 考虑将 Dashboard 相关接口抽取到 `packages/shared` 共享类型
+
+---
+
+## DRY 原则 ⚠️
+
+### 问题 1: 日期格式化重复
+
+**位置**: `agent-dashboard.service.ts` (多处)
+
+```typescript
+// 重复代码
+new Date().toISOString().split('T')[0]
+```
+
+**建议**: 提取为工具函数
+```typescript
+// utils/date.ts
+export function getTodayDateString(): string {
+  return new Date().toISOString().split('T')[0]
+}
+```
+
+---
+
+### 问题 2: SVG 图表路径生成重复
+
+**位置**: `monthly-trend.tsx`
+
+`generatePath()` 和 `generateAreaPath()` 有大量重复计算逻辑。
+
+**建议**: 提取通用 SVG 工具函数
+```typescript
+// utils/svg-chart.ts
+export function generateLinePath(data: number[], width: number, height: number): string
+export function generateAreaPath(data: number[], width: number, height: number): string
+```
+
+---
+
+### 问题 3: 颜色/等级映射重复
+
+**位置**: 
+- `activity-heatmap.tsx`: `LEVEL_COLORS`
+- `agent-dashboard.service.ts`: level calculation
+
+**建议**: 统一在 shared 包中定义
+```typescript
+// packages/shared/src/constants/dashboard.ts
+export const ACTIVITY_LEVELS = {
+  0: { min: 0, max: 0, color: 'bg-transparent' },
+  1: { min: 1, max: 10, color: 'bg-green-900/30' },
+  // ...
+}
+
+export function calculateActivityLevel(count: number): 0 | 1 | 2 | 3 | 4
+```
+
+---
+
+### 问题 4: 时间格式化函数重复
+
+**位置**: 
+- `stats-cards.tsx`: `formatDuration`
+- `user-profile.tsx`: `formatDuration`
+- `buddy-management.tsx`: `formatOnlineDuration`
+
+**建议**: 统一使用 `packages/shared` 中的工具函数
+
+---
+
+## 性能优化 ⚠️
+
+### 问题 1: Heatmap 计算开销
+
+**位置**: `activity-heatmap.tsx`
+
+```typescript
+const weeks = useMemo(() => {
+  // 每次渲染都重新计算 365 天的分组
+}, [data])
+```
+
+**建议**: 
+- 数据在服务端预计算好周分组
+- 或使用虚拟化只渲染可见部分
+
+---
+
+### 问题 2: Dashboard API 查询过多
+
+**位置**: `agent-dashboard.service.ts` `getDashboard()`
+
+一次请求触发多个独立查询：
+- findDailyStats
+- findHourlyStats
+- getTotalMessages
+- getActiveDaysCount
+- calculateStreaks
+- findRecentEvents
+
+**建议**: 
+- 使用数据库聚合查询减少往返
+- 或实现 GraphQL 按需获取
+
+---
+
+### 问题 3: 缺少缓存
+
+Dashboard 数据变化不频繁，但没有缓存机制。
+
+**建议**:
+```typescript
+// 添加 Redis 缓存
+async getDashboard(agentId: string, userId: string) {
+  const cacheKey = `dashboard:${agentId}`
+  const cached = await redis.get(cacheKey)
+  if (cached) return JSON.parse(cached)
+  
+  const data = await this.buildDashboard(...)
+  await redis.setex(cacheKey, 300, JSON.stringify(data)) // 5分钟缓存
+  return data
+}
+```
+
+---
+
+## 错误处理 ⚠️
+
+### 问题 1: 静默捕获错误
+
+**位置**: `message.service.ts`
+
+```typescript
+try {
+  // track stats
+} catch {
+  // Non-critical: don't fail message creation if stats tracking fails
+}
+```
+
+**问题**: 错误被完全吞掉，无法监控统计丢失情况。
+
+**建议**:
+```typescript
+try {
+  // track stats
+} catch (err) {
+  logger.warn({ err, agentId, messageId }, 'Failed to track dashboard stats')
+}
+```
+
+---
+
+### 问题 2: TODO 未实现
+
+**位置**: `agent-dashboard.service.ts` `checkIsTenant()`
+
+```typescript
+return false // TODO: Implement proper tenant check
+```
+
+**建议**: 实现完整的租户检查逻辑，或抛出异常避免权限漏洞。
+
+---
+
+## 代码风格 ✅
+
+### 优点
+- 命名清晰，语义明确
+- 注释适当，关键逻辑有说明
+- 使用早期返回减少嵌套
+
+### 建议
+1. **Magic Numbers**: 365, 90, 等常量应提取为命名常量
+2. **函数长度**: `getDashboard()` 较长，可拆分为更小的函数
+
+---
+
+## 测试覆盖 ⚠️
+
+### 当前状态
+- Service 层有基础测试
+- Component 有简单渲染测试
+
+### 缺失
+- [ ] DAO 层测试
+- [ ] API Handler 测试
+- [ ] Integration 测试
+- [ ] E2E 测试
+
+---
+
+## 数据库设计 ✅
+
+### 优点
+- 索引设计合理
+- 外键约束正确
+- 分区键选择合适
+
+### 建议
+- `agent_activity_events` 表考虑按时间分区
+- 添加数据保留策略（自动清理 90 天前数据）
+
+---
+
+## 安全 ✅
+
+### 优点
+- 权限检查在 API 层完成
+- 用户只能访问自己的数据
+
+### 建议
+- 添加 rate limiting 防止频繁查询
+- 考虑敏感数据的脱敏处理
+
+---
+
+## 总结
+
+| 类别 | 评分 | 说明 |
+|------|------|------|
+| 架构 | A | 清晰的分层结构 |
+| DRY | B | 有重复代码需要提取 |
+| 性能 | B | 缺少缓存和查询优化 |
+| 错误处理 | B | 部分错误被静默捕获 |
+| 测试 | C | 覆盖不够全面 |
+| 安全 | A | 权限控制到位 |
+
+### 优先修复项
+1. [ ] 提取重复的时间格式化函数
+2. [ ] 添加 dashboard 数据缓存
+3. [ ] 完善错误日志记录
+4. [ ] 实现 `checkIsTenant()`
+5. [ ] 补充集成测试
+
+---
+
+*Review completed*

--- a/docs/prd/buddy-dashboard-prd.md
+++ b/docs/prd/buddy-dashboard-prd.md
@@ -1,0 +1,419 @@
+# Buddy Dashboard PRD
+
+> **Feature**: Buddy Activity Dashboard (GitHub-style)  
+> **Status**: Draft  
+> **Author**: 小炸  
+> **Date**: 2025-03-27
+
+---
+
+## 1. Overview
+
+### 1.1 Problem Statement
+Buddy owners currently lack visibility into their Buddy's activity and performance metrics. There's no centralized view to track:
+- Daily/weekly/monthly activity levels
+- Message volume and engagement
+- Online time statistics
+- Rental income and usage
+
+### 1.2 Solution
+Build a **GitHub-style Dashboard** embedded in each Buddy's profile page, providing:
+- Activity heatmap (contribution graph)
+- Key metrics cards
+- Usage statistics charts
+- Recent activity feed
+
+### 1.3 Success Criteria
+- [ ] Dashboard displays accurate activity data for the last 365 days
+- [ ] Heatmap shows daily activity intensity (messages sent)
+- [ ] Stats cards show total messages, online time, rentals, earnings
+- [ ] Mobile-responsive design
+- [ ] Data updates in real-time (or near real-time via polling)
+
+---
+
+## 2. User Stories
+
+### 2.1 As a Buddy Owner
+- I want to see my Buddy's activity over time so I can understand usage patterns
+- I want to see total online time to track reliability
+- I want to see message statistics to gauge engagement
+- I want to see rental income to track monetization
+
+### 2.2 As a Buddy Renter
+- I want to see the Buddy's recent activity before renting
+- I want to see uptime statistics to assess reliability
+
+### 2.3 As a Platform Admin
+- I want aggregate statistics on Buddy usage across the platform
+
+---
+
+## 3. Functional Requirements
+
+### 3.1 Dashboard Components
+
+#### 3.1.1 Activity Heatmap
+- **Visual**: GitHub-style contribution graph
+- **Time Range**: Last 365 days, grouped by week
+- **Color Scale**: 
+  - Level 0: No activity (transparent)
+  - Level 1: 1-10 messages (light green)
+  - Level 2: 11-50 messages (medium green)
+  - Level 3: 51-100 messages (dark green)
+  - Level 4: 100+ messages (intense green)
+- **Interaction**: Hover shows exact message count and date
+
+#### 3.1.2 Stats Cards (Top Row)
+| Metric | Description | Icon |
+|--------|-------------|------|
+| Total Messages | Lifetime message count | MessageSquare |
+| Online Time | Total online duration | Clock |
+| Active Days | Days with activity in last 30 days | Calendar |
+| Current Streak | Consecutive active days | Flame |
+
+#### 3.1.3 Usage Charts
+- **Weekly Activity**: Bar chart of messages per day (last 7 days)
+- **Hourly Distribution**: Heatmap of activity by hour of day
+- **Monthly Trend**: Line chart of messages per month (last 12 months)
+
+#### 3.1.4 Recent Activity Feed
+- Last 10 significant events:
+  - Message sent (with preview)
+  - Status change (online/offline)
+  - Rental started/ended
+  - Policy update
+
+#### 3.1.5 Rental Statistics (if applicable)
+- Total rentals
+- Total rental income
+- Average rental duration
+- Current tenant (if active)
+
+### 3.2 Data Requirements
+
+#### 3.2.1 New Tables
+
+```sql
+-- Agent activity tracking (daily aggregates)
+CREATE TABLE agent_daily_stats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  message_count INTEGER DEFAULT 0,
+  online_seconds INTEGER DEFAULT 0,
+  UNIQUE(agent_id, date)
+);
+
+-- Agent hourly activity distribution
+CREATE TABLE agent_hourly_stats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  hour_of_day INTEGER NOT NULL CHECK (hour_of_day BETWEEN 0 AND 23),
+  message_count INTEGER DEFAULT 0,
+  activity_count INTEGER DEFAULT 0,
+  UNIQUE(agent_id, hour_of_day)
+);
+
+-- Agent activity events (for feed)
+CREATE TABLE agent_activity_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  event_type VARCHAR(50) NOT NULL, -- 'message', 'status_change', 'rental_start', 'rental_end', 'policy_update'
+  event_data JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+#### 3.2.2 API Endpoints
+
+```typescript
+// GET /api/agents/:id/dashboard
+interface AgentDashboardResponse {
+  // Activity heatmap data (last 365 days)
+  activityHeatmap: Array<{
+    date: string; // ISO date
+    messageCount: number;
+    level: 0 | 1 | 2 | 3 | 4;
+  }>;
+
+  // Summary stats
+  stats: {
+    totalMessages: number;
+    totalOnlineSeconds: number;
+    activeDays30d: number;
+    currentStreak: number;
+    longestStreak: number;
+  };
+
+  // Weekly activity (last 7 days)
+  weeklyActivity: Array<{
+    date: string;
+    messageCount: number;
+  }>;
+
+  // Hourly distribution
+  hourlyDistribution: Array<{
+    hour: number; // 0-23
+    messageCount: number;
+  }>;
+
+  // Monthly trend (last 12 months)
+  monthlyTrend: Array<{
+    month: string; // YYYY-MM
+    messageCount: number;
+  }>;
+
+  // Recent events
+  recentEvents: Array<{
+    id: string;
+    type: string;
+    data: Record<string, unknown>;
+    createdAt: string;
+  }>;
+
+  // Rental stats (if owner)
+  rentalStats?: {
+    totalRentals: number;
+    totalIncome: number;
+    averageDuration: number;
+    currentTenant?: {
+      id: string;
+      username: string;
+      displayName: string;
+    };
+  };
+}
+```
+
+### 3.3 Backend Services
+
+#### 3.3.1 AgentDashboardService
+```typescript
+class AgentDashboardService {
+  // Get full dashboard data
+  async getDashboard(agentId: string, userId: string): Promise<AgentDashboardResponse>;
+
+  // Record message activity
+  async recordMessage(agentId: string): Promise<void>;
+
+  // Record online time
+  async recordOnlineTime(agentId: string, seconds: number): Promise<void>;
+
+  // Add activity event
+  async addEvent(agentId: string, type: string, data: Record<string, unknown>): Promise<void>;
+
+  // Calculate streaks
+  async calculateStreaks(agentId: string): Promise<{ current: number; longest: number }>;
+}
+```
+
+#### 3.3.2 Data Aggregation
+- Daily cron job to aggregate message counts from `messages` table
+- Real-time updates via WebSocket for live dashboard
+- Background job to clean up old event data (keep 90 days)
+
+---
+
+## 4. Non-Functional Requirements
+
+### 4.1 Performance
+- Dashboard API response time < 500ms
+- Heatmap data cached for 5 minutes
+- Lazy load charts and activity feed
+
+### 4.2 Scalability
+- Support 10,000+ Buddies with activity tracking
+- Efficient aggregation queries with proper indexing
+
+### 4.3 Security
+- Only owner and renters can view full dashboard
+- Public view shows limited stats (online time, total messages)
+
+---
+
+## 5. UI/UX Design
+
+### 5.1 Layout
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Buddy Profile Header                                       │
+├─────────────────────────────────────────────────────────────┤
+│  [Stats Cards Row]                                          │
+│  [Messages] [Online Time] [Active Days] [Streak]           │
+├─────────────────────────────────────────────────────────────┤
+│  Activity Heatmap (365 days)                               │
+│  ░░▓▓░░▓░░▓▓▓░░░▓▓░░▓░░░▓▓▓░░▓░░▓▓░░▓░░▓▓▓░░░            │
+├─────────────────────────────────────────────────────────────┤
+│  [Weekly Activity Chart]      [Hourly Distribution]        │
+├─────────────────────────────────────────────────────────────┤
+│  Monthly Trend                                              │
+│  ━╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╲╱╲╱╲╱╲╱╲╱╲        │
+├─────────────────────────────────────────────────────────────┤
+│  Recent Activity                    [Rental Stats]         │
+│  ├─ Message: "Hello world"          Total: 12 rentals      │
+│  ├─ Status: Online                  Income: 3,500 虾币     │
+│  └─ Rental started by @user         Avg: 2.3 days          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Color Scheme
+- Follow existing Shadow design system
+- Heatmap colors: green scale (`bg-green-100` to `bg-green-900`)
+- Card backgrounds: `bg-bg-secondary`
+- Border: `border-border-subtle`
+
+### 5.3 Responsive Breakpoints
+- Desktop: Full layout with side-by-side charts
+- Tablet: Stacked layout, 2-column stats grid
+- Mobile: Single column, compact heatmap
+
+---
+
+## 6. Technical Implementation
+
+### 6.1 Backend Tasks
+
+#### Task 1: Database Schema
+- [ ] Create `agent_daily_stats` table
+- [ ] Create `agent_hourly_stats` table
+- [ ] Create `agent_activity_events` table
+- [ ] Add indexes for efficient querying
+
+#### Task 2: DAO Layer
+- [ ] Create `agent-dashboard.dao.ts`
+- [ ] Implement CRUD operations for stats tables
+- [ ] Add aggregation queries for heatmap data
+
+#### Task 3: Service Layer
+- [ ] Create `agent-dashboard.service.ts`
+- [ ] Implement `getDashboard()` method
+- [ ] Implement `recordMessage()` method
+- [ ] Implement `recordOnlineTime()` method
+- [ ] Implement streak calculation logic
+
+#### Task 4: API Handler
+- [ ] Add `GET /api/agents/:id/dashboard` endpoint
+- [ ] Add permission checks (owner/renter only)
+- [ ] Add caching middleware
+
+#### Task 5: Message Tracking Integration
+- [ ] Hook into message sending flow
+- [ ] Update daily stats on each message
+- [ ] Add activity event for messages
+
+### 6.2 Frontend Tasks
+
+#### Task 1: Dashboard Page Component
+- [ ] Create `buddy-dashboard.tsx` page
+- [ ] Add route `/app/buddy/:agentId/dashboard`
+- [ ] Integrate with existing Buddy profile page
+
+#### Task 2: Stats Cards Component
+- [ ] Create `DashboardStatsCards` component
+- [ ] Display 4 key metrics with icons
+- [ ] Add loading states
+
+#### Task 3: Activity Heatmap Component
+- [ ] Create `ActivityHeatmap` component
+- [ ] Generate 365-day grid layout
+- [ ] Implement color level logic
+- [ ] Add hover tooltips
+
+#### Task 4: Charts Components
+- [ ] Create `WeeklyActivityChart` (bar chart)
+- [ ] Create `HourlyDistributionChart` (heatmap)
+- [ ] Create `MonthlyTrendChart` (line chart)
+- [ ] Use lightweight chart library (e.g., Recharts or custom SVG)
+
+#### Task 5: Activity Feed Component
+- [ ] Create `RecentActivityFeed` component
+- [ ] Display last 10 events
+- [ ] Format event types with icons
+
+#### Task 6: Rental Stats Component
+- [ ] Create `RentalStatsPanel` component
+- [ ] Show income and rental metrics
+- [ ] Display current tenant info
+
+### 6.3 Testing Tasks
+
+#### Backend Tests
+- [ ] Unit tests for AgentDashboardService
+- [ ] Integration tests for dashboard API
+- [ ] Performance tests for heatmap queries
+
+#### Frontend Tests
+- [ ] Unit tests for dashboard components
+- [ ] E2E tests for dashboard navigation
+- [ ] Visual regression tests for heatmap
+
+---
+
+## 7. Open Questions
+
+1. **Data Retention**: How long should we keep daily stats? (Proposal: 2 years)
+2. **Real-time Updates**: Should we use WebSocket or polling? (Proposal: polling every 30s)
+3. **Caching Strategy**: Redis or in-memory? (Proposal: Redis with 5min TTL)
+4. **Chart Library**: Custom SVG or existing library? (Proposal: lightweight custom SVG)
+
+---
+
+## 8. Appendix
+
+### 8.1 Related Files
+- `apps/server/src/dao/agent.dao.ts`
+- `apps/server/src/services/agent.service.ts`
+- `apps/server/src/handlers/agent.handler.ts`
+- `apps/web/src/pages/user-profile.tsx`
+- `apps/web/src/pages/buddy-management.tsx`
+
+### 8.2 Migration Script Template
+```sql
+-- Run this migration to create dashboard tables
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_daily_stats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  message_count INTEGER DEFAULT 0 NOT NULL,
+  online_seconds INTEGER DEFAULT 0 NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  UNIQUE(agent_id, date)
+);
+
+CREATE INDEX idx_agent_daily_stats_agent_id ON agent_daily_stats(agent_id);
+CREATE INDEX idx_agent_daily_stats_date ON agent_daily_stats(date);
+CREATE INDEX idx_agent_daily_stats_agent_date ON agent_daily_stats(agent_id, date);
+
+CREATE TABLE IF NOT EXISTS agent_hourly_stats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  hour_of_day INTEGER NOT NULL CHECK (hour_of_day BETWEEN 0 AND 23),
+  message_count INTEGER DEFAULT 0 NOT NULL,
+  activity_count INTEGER DEFAULT 0 NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  UNIQUE(agent_id, hour_of_day)
+);
+
+CREATE INDEX idx_agent_hourly_stats_agent_id ON agent_hourly_stats(agent_id);
+
+CREATE TABLE IF NOT EXISTS agent_activity_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  event_type VARCHAR(50) NOT NULL,
+  event_data JSONB DEFAULT '{}' NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX idx_agent_activity_events_agent_id ON agent_activity_events(agent_id);
+CREATE INDEX idx_agent_activity_events_created_at ON agent_activity_events(created_at DESC);
+
+COMMIT;
+```
+
+---
+
+*End of PRD*

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -1,0 +1,108 @@
+/**
+ * Date utility functions for shared usage across packages
+ */
+
+/**
+ * Get today's date as ISO string (YYYY-MM-DD)
+ */
+export function getTodayDateString(): string {
+  return new Date().toISOString().split('T')[0]
+}
+
+/**
+ * Get date string for a specific date
+ */
+export function getDateString(date: Date): string {
+  return date.toISOString().split('T')[0]
+}
+
+/**
+ * Get date N days ago as ISO string
+ */
+export function getDaysAgoDateString(days: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() - days)
+  return getDateString(date)
+}
+
+/**
+ * Format duration in seconds to human readable string
+ */
+export function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const remainingSeconds = seconds % 60
+
+  if (hours === 0 && minutes === 0) {
+    return `${remainingSeconds}s`
+  }
+  if (hours === 0) {
+    return `${minutes}m ${remainingSeconds}s`
+  }
+  if (hours < 24) {
+    return `${hours}h ${minutes}m`
+  }
+  const days = Math.floor(hours / 24)
+  const remainingHours = hours % 24
+  return `${days}d ${remainingHours}h`
+}
+
+/**
+ * Format duration in seconds to short string (for compact display)
+ */
+export function formatDurationShort(seconds: number): string {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+
+  if (hours === 0) {
+    return `${minutes}m`
+  }
+  if (hours < 24) {
+    return `${hours}h ${minutes}m`
+  }
+  const days = Math.floor(hours / 24)
+  const remainingHours = hours % 24
+  return `${days}d ${remainingHours}h`
+}
+
+/**
+ * Dashboard constants
+ */
+export const DASHBOARD_CONSTANTS = {
+  /** Number of days to show in activity heatmap */
+  HEATMAP_DAYS: 365,
+  /** Number of days for weekly activity chart */
+  WEEKLY_DAYS: 7,
+  /** Number of months for monthly trend */
+  MONTHLY_MONTHS: 12,
+  /** Number of days for active days calculation */
+  ACTIVE_DAYS_WINDOW: 30,
+  /** Number of days to keep activity events */
+  EVENT_RETENTION_DAYS: 90,
+  /** Cache TTL in seconds */
+  CACHE_TTL_SECONDS: 300,
+} as const
+
+/**
+ * Activity level thresholds and colors
+ */
+export const ACTIVITY_LEVELS = {
+  0: { min: 0, max: 0, color: 'bg-transparent', label: 'No activity' },
+  1: { min: 1, max: 10, color: 'bg-green-900/30', label: '1-10 messages' },
+  2: { min: 11, max: 50, color: 'bg-green-700/50', label: '11-50 messages' },
+  3: { min: 51, max: 100, color: 'bg-green-500/70', label: '51-100 messages' },
+  4: { min: 101, max: Infinity, color: 'bg-green-400', label: '100+ messages' },
+} as const
+
+export type ActivityLevel = 0 | 1 | 2 | 3 | 4
+
+/**
+ * Calculate activity level based on message count
+ */
+export function calculateActivityLevel(count: number): ActivityLevel {
+  if (count >= 100) return 4
+  if (count >= 51) return 3
+  if (count >= 11) return 2
+  if (count >= 1) return 1
+  return 0
+}

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -6,14 +6,14 @@
  * Get today's date as ISO string (YYYY-MM-DD)
  */
 export function getTodayDateString(): string {
-  return new Date().toISOString().split('T')[0]
+  return new Date().toISOString().slice(0, 10)
 }
 
 /**
  * Get date string for a specific date
  */
 export function getDateString(date: Date): string {
-  return date.toISOString().split('T')[0]
+  return date.toISOString().slice(0, 10)
 }
 
 /**

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -21,5 +21,4 @@ export function slugify(text: string): string {
 }
 
 export * from './avatar-generator'
-export * from './date'
 export * from './pixel-cats'

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -21,4 +21,5 @@ export function slugify(text: string): string {
 }
 
 export * from './avatar-generator'
+export * from './date'
 export * from './pixel-cats'


### PR DESCRIPTION
## Summary

This PR introduces the **Buddy Dashboard** feature - a GitHub-style activity tracking dashboard for Buddy owners to monitor their Buddy's performance and engagement metrics.

## Features

### 🗓️ Activity Heatmap
- 365-day contribution graph showing daily message activity
- 5-level color intensity scale
- Hover tooltips with exact counts

### 📊 Stats Cards
- Total Messages (lifetime count)
- Online Time (total duration)
- Active Days (last 30 days)
- Current Streak (consecutive active days)

### 📈 Analytics Charts
- Weekly activity bar chart (last 7 days)
- Hourly distribution heatmap
- Monthly trend line chart (12 months)

### 📋 Activity Feed
- Recent events (messages, status changes, rentals)
- Rental statistics (income, total rentals, current tenant)

## Technical Changes

### Database Schema
-  - Daily aggregated statistics
-  - Hourly activity distribution
-  - Activity event log

### API Endpoints
-  - Full dashboard data

### Frontend
- New dashboard page at 
- Integrated into existing Buddy profile page
- Mobile-responsive design

## PRD
See  for detailed specifications.

## Testing
- [ ] Unit tests for service layer
- [ ] Integration tests for API endpoints
- [ ] E2E tests for dashboard UI

## Checklist
- [x] PRD created
- [ ] Backend implementation
- [ ] Frontend implementation
- [ ] Tests added
- [ ] Documentation updated

---

**Note**: This PR currently contains only the PRD. Implementation will follow in subsequent commits.