### PR TITLE
feat(discover): add channels and rentals tabs to discover page

### DIFF
--- a/apps/mobile/app/(main)/discover.tsx
+++ b/apps/mobile/app/(main)/discover.tsx
@@ -1,15 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
-import { Search, Shield } from 'lucide-react-native'
+import { Globe, Hash, Search, Shield, Zap } from 'lucide-react-native'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FlatList, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
+import { FlatList, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native'
 import { EmptyState } from '../../src/components/common/empty-state'
 import { LoadingScreen } from '../../src/components/common/loading-screen'
 import { fetchApi, getImageUrl } from '../../src/lib/api'
 import { showToast } from '../../src/lib/toast'
 import { fontSize, radius, spacing, useColors } from '../../src/theme'
+
+type TabType = 'servers' | 'channels' | 'explore'
 
 interface DiscoverServer {
   id: string
@@ -21,6 +23,25 @@ interface DiscoverServer {
   isPublic: boolean
   inviteCode: string
   memberCount: number
+}
+
+interface DiscoverChannel {
+  id: string
+  name: string
+  type: 'text' | 'voice' | 'announcement'
+  topic: string | null
+  server: {
+    id: string
+    name: string
+    slug: string | null
+    iconUrl: string | null
+  }
+  memberCount: number
+  lastMessage: {
+    content: string
+    createdAt: string
+    authorId: string
+  } | null
 }
 
 interface ServerEntry {
@@ -43,11 +64,18 @@ export default function DiscoverScreen() {
   const colors = useColors()
   const router = useRouter()
   const queryClient = useQueryClient()
+  const [activeTab, setActiveTab] = useState<TabType>('servers')
   const [search, setSearch] = useState('')
 
-  const { data: servers = [], isLoading } = useQuery({
+  const { data: servers = [], isLoading: serversLoading } = useQuery({
     queryKey: ['discover-servers'],
     queryFn: () => fetchApi<DiscoverServer[]>('/api/servers/discover'),
+  })
+
+  const { data: channels = [], isLoading: channelsLoading } = useQuery({
+    queryKey: ['discover-channels'],
+    queryFn: () => fetchApi<DiscoverChannel[]>('/api/discover/channels'),
+    enabled: activeTab === 'channels',
   })
 
   const { data: myServers = [] } = useQuery({
@@ -78,23 +106,95 @@ export default function DiscoverScreen() {
     },
   })
 
-  const filtered = servers.filter(
+  const filteredServers = servers.filter(
     (s) =>
       s.name.toLowerCase().includes(search.toLowerCase()) ||
       s.description?.toLowerCase().includes(search.toLowerCase()),
+  )
+
+  const filteredChannels = channels.filter(
+    (c) =>
+      c.name.toLowerCase().includes(search.toLowerCase()) ||
+      c.topic?.toLowerCase().includes(search.toLowerCase()) ||
+      c.server.name.toLowerCase().includes(search.toLowerCase()),
+  )
+
+  const isLoading =
+    (activeTab === 'servers' && serversLoading) || (activeTab === 'channels' && channelsLoading)
+
+  const formatTimeAgo = (date: string) => {
+    const now = new Date()
+    const then = new Date(date)
+    const diff = now.getTime() - then.getTime()
+    const minutes = Math.floor(diff / 60000)
+    const hours = Math.floor(diff / 3600000)
+    const days = Math.floor(diff / 86400000)
+
+    if (minutes < 1) return t('discover.justNow')
+    if (minutes < 60) return t('discover.minutesAgo', { count: minutes })
+    if (hours < 24) return t('discover.hoursAgo', { count: hours })
+    return t('discover.daysAgo', { count: days })
+  }
+
+  const TabButton = ({
+    tab,
+    icon: Icon,
+    label,
+  }: {
+    tab: TabType
+    icon: typeof Globe
+    label: string
+  }) => (
+    <Pressable
+      style={[
+        styles.tabButton,
+        {
+          backgroundColor: activeTab === tab ? colors.primary : colors.surface,
+        },
+      ]}
+      onPress={() => setActiveTab(tab)}
+    >
+      <Icon size={16} color={activeTab === tab ? '#fff' : colors.textMuted} />
+      <Text style={[styles.tabText, { color: activeTab === tab ? '#fff' : colors.textSecondary }]}>
+        {label}
+      </Text>
+    </Pressable>
   )
 
   if (isLoading) return <LoadingScreen />
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      {/* Search */}
+      {/* Header */}
       <View
         style={[
-          styles.searchContainer,
+          styles.header,
           { backgroundColor: colors.surface, borderBottomColor: colors.border },
         ]}
       >
+        <View style={styles.headerContent}>
+          <View style={styles.titleRow}>
+            <Globe size={24} color={colors.primary} />
+            <Text style={[styles.title, { color: colors.text }]}>{t('discover.title')}</Text>
+          </View>
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+            {t('discover.subtitle')}
+          </Text>
+        </View>
+
+        {/* Tabs */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.tabsContainer}
+          contentContainerStyle={styles.tabsContent}
+        >
+          <TabButton tab="servers" icon={Globe} label={t('discover.tabs.servers')} />
+          <TabButton tab="channels" icon={Hash} label={t('discover.tabs.channels')} />
+          <TabButton tab="explore" icon={Zap} label={t('discover.tabs.explore')} />
+        </ScrollView>
+
+        {/* Search */}
         <View style={[styles.searchBox, { backgroundColor: colors.inputBackground }]}>
           <Search size={18} color={colors.textMuted} />
           <TextInput
@@ -107,106 +207,308 @@ export default function DiscoverScreen() {
         </View>
       </View>
 
-      {filtered.length === 0 ? (
-        <EmptyState icon="🔍" title={t('discover.noServers')} />
+      {/* Content */}
+      {activeTab === 'servers' ? (
+        <ServersTab
+          servers={filteredServers}
+          joinedServerIds={joinedServerIds}
+          joinMutation={joinMutation}
+          router={router}
+          colors={colors}
+          t={t}
+        />
+      ) : activeTab === 'channels' ? (
+        <ChannelsTab
+          channels={filteredChannels}
+          joinedServerIds={joinedServerIds}
+          router={router}
+          colors={colors}
+          t={t}
+          formatTimeAgo={formatTimeAgo}
+        />
       ) : (
-        <FlatList
-          data={filtered}
-          keyExtractor={(item) => item.id}
-          contentContainerStyle={styles.list}
-          renderItem={({ item }) => {
-            const isJoined = joinedServerIds.has(item.id)
-            return (
-              <Pressable
-                style={[styles.card, { backgroundColor: colors.surface }]}
-                onPress={() => {
-                  if (isJoined) {
-                    router.push(`/(main)/servers/${item.slug ?? item.id}`)
-                  }
-                }}
-              >
-                {/* Banner */}
-                <View style={[styles.banner, { backgroundColor: `${colors.primary}20` }]}>
-                  {item.bannerUrl && (
-                    <Image
-                      source={{ uri: getImageUrl(item.bannerUrl)! }}
-                      style={StyleSheet.absoluteFill}
-                      contentFit="cover"
-                    />
-                  )}
-                  {item.isPublic && (
-                    <View style={styles.publicBadge}>
-                      <Shield size={10} color="#fff" />
-                      <Text style={styles.publicText}>{t('discover.public')}</Text>
-                    </View>
-                  )}
+        <ExploreTab colors={colors} t={t} />
+      )}
+    </View>
+  )
+}
+
+// Servers Tab Component
+function ServersTab({
+  servers,
+  joinedServerIds,
+  joinMutation,
+  router,
+  colors,
+  t,
+}: {
+  servers: DiscoverServer[]
+  joinedServerIds: Set<string>
+  joinMutation: ReturnType<typeof useMutation>
+  router: ReturnType<typeof useRouter>
+  colors: ReturnType<typeof useColors>
+  t: (key: string, options?: Record<string, unknown>) => string
+}) {
+  if (servers.length === 0) {
+    return <EmptyState icon="🔍" title={t('discover.noServers')} />
+  }
+
+  return (
+    <FlatList
+      data={servers}
+      keyExtractor={(item) => item.id}
+      contentContainerStyle={styles.list}
+      renderItem={({ item }) => {
+        const isJoined = joinedServerIds.has(item.id)
+        return (
+          <Pressable
+            style={[styles.card, { backgroundColor: colors.surface }]}
+            onPress={() => {
+              if (isJoined) {
+                router.push(`/(main)/servers/${item.slug ?? item.id}`)
+              }
+            }}
+          >
+            <View style={[styles.banner, { backgroundColor: `${colors.primary}20` }]}>
+              {item.bannerUrl && (
+                <Image
+                  source={{ uri: getImageUrl(item.bannerUrl) || '' }}
+                  style={StyleSheet.absoluteFill}
+                  contentFit="cover"
+                />
+              )}
+              {item.isPublic && (
+                <View style={styles.publicBadge}>
+                  <Shield size={10} color="#fff" />
+                  <Text style={styles.publicText}>{t('discover.public')}</Text>
+                </View>
+              )}
+            </View>
+
+            <View style={[styles.iconWrap, { backgroundColor: colors.surface }]}>
+              {item.iconUrl ? (
+                <Image
+                  source={{ uri: getImageUrl(item.iconUrl) || '' }}
+                  style={styles.icon}
+                  contentFit="cover"
+                />
+              ) : (
+                <Text style={styles.iconFallback}>{item.name.charAt(0)}</Text>
+              )}
+            </View>
+
+            <View style={styles.cardBody}>
+              <Text style={[styles.serverName, { color: colors.text }]} numberOfLines={1}>
+                {item.name}
+              </Text>
+              <Text style={[styles.desc, { color: colors.textSecondary }]} numberOfLines={2}>
+                {item.description ?? t('discover.noDescription')}
+              </Text>
+
+              <View style={styles.cardFooter}>
+                <View style={styles.memberInfo}>
+                  <View style={[styles.onlineDot, { backgroundColor: '#23a559' }]} />
+                  <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                    {item.memberCount} {t('discover.members')}
+                  </Text>
                 </View>
 
-                {/* Icon overlay */}
-                <View style={[styles.iconWrap, { backgroundColor: colors.surface }]}>
-                  {item.iconUrl ? (
-                    <Image
-                      source={{ uri: getImageUrl(item.iconUrl)! }}
-                      style={styles.icon}
-                      contentFit="cover"
-                    />
-                  ) : (
-                    <Text style={styles.iconFallback}>{item.name.charAt(0)}</Text>
-                  )}
-                </View>
+                {isJoined ? (
+                  <Pressable
+                    style={[styles.joinBtn, { backgroundColor: '#23a559' }]}
+                    onPress={() => router.push(`/(main)/servers/${item.slug ?? item.id}`)}
+                  >
+                    <Text style={styles.joinBtnText}>{t('discover.enterButton')}</Text>
+                  </Pressable>
+                ) : (
+                  <Pressable
+                    style={[styles.joinBtn, { backgroundColor: colors.primary }]}
+                    onPress={() => {
+                      if (item.inviteCode) {
+                        joinMutation.mutate({ inviteCode: item.inviteCode, serverId: item.id })
+                      }
+                    }}
+                    disabled={joinMutation.isPending}
+                  >
+                    <Text style={styles.joinBtnText}>{t('discover.joinButton')}</Text>
+                  </Pressable>
+                )}
+              </View>
+            </View>
+          </Pressable>
+        )
+      }}
+    />
+  )
+}
 
-                <View style={styles.cardBody}>
-                  <Text style={[styles.serverName, { color: colors.text }]} numberOfLines={1}>
+// Channels Tab Component
+function ChannelsTab({
+  channels,
+  joinedServerIds,
+  router,
+  colors,
+  t,
+  formatTimeAgo,
+}: {
+  channels: DiscoverChannel[]
+  joinedServerIds: Set<string>
+  router: ReturnType<typeof useRouter>
+  colors: ReturnType<typeof useColors>
+  t: (key: string, options?: Record<string, unknown>) => string
+  formatTimeAgo: (date: string) => string
+}) {
+  if (channels.length === 0) {
+    return <EmptyState icon="#️⃣" title={t('discover.noChannels')} />
+  }
+
+  return (
+    <FlatList
+      data={channels}
+      keyExtractor={(item) => item.id}
+      contentContainerStyle={styles.list}
+      renderItem={({ item }) => {
+        const isJoined = joinedServerIds.has(item.server.id)
+        return (
+          <Pressable
+            style={[styles.channelCard, { backgroundColor: colors.surface }]}
+            onPress={() => {
+              if (isJoined) {
+                router.push(
+                  `/(main)/servers/${item.server.slug ?? item.server.id}/channels/${item.id}`,
+                )
+              } else {
+                router.push(`/(main)/servers/${item.server.slug ?? item.server.id}`)
+              }
+            }}
+          >
+            <View style={styles.channelHeader}>
+              <View style={styles.serverIcon}>
+                {item.server.iconUrl ? (
+                  <Image
+                    source={{ uri: getImageUrl(item.server.iconUrl) || '' }}
+                    style={styles.serverIconImage}
+                    contentFit="cover"
+                  />
+                ) : (
+                  <Text style={styles.serverIconFallback}>{item.server.name.charAt(0)}</Text>
+                )}
+              </View>
+              <View style={styles.channelInfo}>
+                <View style={styles.channelNameRow}>
+                  <Text style={{ color: colors.textMuted, fontSize: fontSize.sm }}>#</Text>
+                  <Text style={[styles.channelName, { color: colors.text }]} numberOfLines={1}>
                     {item.name}
                   </Text>
-                  <Text style={[styles.desc, { color: colors.textSecondary }]} numberOfLines={2}>
-                    {item.description ?? t('discover.noDescription')}
-                  </Text>
-
-                  <View style={styles.cardFooter}>
-                    <View style={styles.memberInfo}>
-                      <View style={[styles.onlineDot, { backgroundColor: '#23a559' }]} />
-                      <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
-                        {item.memberCount} {t('discover.members')}
-                      </Text>
-                    </View>
-
-                    {isJoined ? (
-                      <Pressable
-                        style={[styles.joinBtn, { backgroundColor: '#23a559' }]}
-                        onPress={() => router.push(`/(main)/servers/${item.slug ?? item.id}`)}
-                      >
-                        <Text style={styles.joinBtnText}>{t('discover.enterButton')}</Text>
-                      </Pressable>
-                    ) : (
-                      <Pressable
-                        style={[styles.joinBtn, { backgroundColor: colors.primary }]}
-                        onPress={() => {
-                          if (item.inviteCode) {
-                            joinMutation.mutate({ inviteCode: item.inviteCode, serverId: item.id })
-                          }
-                        }}
-                        disabled={joinMutation.isPending}
-                      >
-                        <Text style={styles.joinBtnText}>{t('discover.joinButton')}</Text>
-                      </Pressable>
-                    )}
-                  </View>
                 </View>
-              </Pressable>
-            )
-          }}
-        />
-      )}
+                <Text
+                  style={[styles.serverNameSmall, { color: colors.textSecondary }]}
+                  numberOfLines={1}
+                >
+                  {item.server.name}
+                </Text>
+              </View>
+            </View>
+
+            {item.topic && (
+              <Text
+                style={[styles.channelTopic, { color: colors.textSecondary }]}
+                numberOfLines={2}
+              >
+                {item.topic}
+              </Text>
+            )}
+
+            {item.lastMessage && (
+              <View style={[styles.lastMessageBox, { backgroundColor: colors.background }]}>
+                <Text
+                  style={[styles.lastMessageText, { color: colors.textSecondary }]}
+                  numberOfLines={2}
+                >
+                  {item.lastMessage.content}
+                </Text>
+                <Text style={[styles.lastMessageTime, { color: colors.textMuted }]}>
+                  {formatTimeAgo(item.lastMessage.createdAt)}
+                </Text>
+              </View>
+            )}
+
+            <View style={styles.channelFooter}>
+              <View style={styles.memberCount}>
+                <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                  {item.memberCount} {t('discover.members')}
+                </Text>
+              </View>
+              {!isJoined && (
+                <View style={[styles.joinBadge, { backgroundColor: colors.background }]}>
+                  <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                    {t('discover.joinToView')}
+                  </Text>
+                </View>
+              )}
+            </View>
+          </Pressable>
+        )
+      }}
+    />
+  )
+}
+
+// Explore Tab Component (placeholder)
+function ExploreTab({
+  colors,
+  t,
+}: {
+  colors: ReturnType<typeof useColors>
+  t: (key: string, options?: Record<string, unknown>) => string
+}) {
+  return (
+    <View style={[styles.exploreContainer, { backgroundColor: colors.background }]}>
+      <EmptyState icon="✨" title={t('discover.exploreComingSoon')} />
     </View>
   )
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  searchContainer: {
+  header: {
     padding: spacing.md,
     borderBottomWidth: 1,
+  },
+  headerContent: {
+    marginBottom: spacing.md,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  title: {
+    fontSize: fontSize.xl,
+    fontWeight: '800',
+  },
+  subtitle: {
+    fontSize: fontSize.sm,
+  },
+  tabsContainer: {
+    marginBottom: spacing.md,
+  },
+  tabsContent: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  tabButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.lg,
+  },
+  tabText: {
+    fontSize: fontSize.sm,
+    fontWeight: '600',
   },
   searchBox: {
     flexDirection: 'row',
@@ -223,6 +525,11 @@ const styles = StyleSheet.create({
   list: {
     padding: spacing.md,
     gap: spacing.md,
+  },
+  exploreContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   card: {
     borderRadius: radius.xl,
@@ -315,5 +622,82 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: fontSize.sm,
     fontWeight: '700',
+  },
+  // Channel styles
+  channelCard: {
+    borderRadius: radius.xl,
+    padding: spacing.md,
+  },
+  channelHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  serverIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: '#5865F220',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  serverIconImage: {
+    width: 48,
+    height: 48,
+  },
+  serverIconFallback: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#5865F2',
+  },
+  channelInfo: {
+    flex: 1,
+  },
+  channelNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  channelName: {
+    fontSize: fontSize.md,
+    fontWeight: '700',
+  },
+  serverNameSmall: {
+    fontSize: fontSize.sm,
+  },
+  channelTopic: {
+    fontSize: fontSize.sm,
+    marginBottom: spacing.sm,
+  },
+  lastMessageBox: {
+    borderRadius: radius.md,
+    padding: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  lastMessageText: {
+    fontSize: fontSize.sm,
+    marginBottom: 4,
+  },
+  lastMessageTime: {
+    fontSize: fontSize.xs,
+  },
+  channelFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingTop: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: '#00000010',
+  },
+  memberCount: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  joinBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: radius.sm,
   },
 })

--- a/apps/mobile/app/(main)/discover.tsx
+++ b/apps/mobile/app/(main)/discover.tsx
@@ -1,31 +1,48 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
-import { Globe, Hash, Search, Shield, Zap } from 'lucide-react-native'
-import { useMemo, useState } from 'react'
+import { Flame, Hash, MessageCircle, Search, Server, Users, Zap } from 'lucide-react-native'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FlatList, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
 import { EmptyState } from '../../src/components/common/empty-state'
-import { LoadingScreen } from '../../src/components/common/loading-screen'
 import { fetchApi, getImageUrl } from '../../src/lib/api'
 import { showToast } from '../../src/lib/toast'
 import { fontSize, radius, spacing, useColors } from '../../src/theme'
 
-type TabType = 'servers' | 'channels' | 'explore'
+type FeedItemType = 'server' | 'channel' | 'rental'
+type FilterType = 'all' | 'servers' | 'channels' | 'rentals'
 
-interface DiscoverServer {
+interface FeedItem {
+  id: string
+  type: FeedItemType
+  heatScore: number
+  data: ServerData | ChannelData | RentalData
+}
+
+interface ServerData {
   id: string
   name: string
   slug: string | null
   description: string | null
   iconUrl: string | null
-  bannerUrl?: string | null
+  bannerUrl: string | null
+  memberCount: number
   isPublic: boolean
   inviteCode: string
-  memberCount: number
+  createdAt: string
 }
 
-interface DiscoverChannel {
+interface ChannelData {
   id: string
   name: string
   type: 'text' | 'voice' | 'announcement'
@@ -40,8 +57,41 @@ interface DiscoverChannel {
   lastMessage: {
     content: string
     createdAt: string
-    authorId: string
   } | null
+}
+
+interface RentalData {
+  contractId: string
+  contractNo: string
+  startedAt: string
+  expiresAt: string | null
+  listing: {
+    id: string
+    title: string
+    description: string | null
+    deviceTier: string | null
+    osType: string | null
+    hourlyRate: number
+    tags: string[] | null
+  } | null
+  tenant: {
+    id: string
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+  } | null
+  agent: {
+    id: string
+    name: string
+    status: string
+    lastHeartbeat: string | null
+  } | null
+}
+
+interface FeedResponse {
+  items: FeedItem[]
+  total: number
+  hasMore: boolean
 }
 
 interface ServerEntry {
@@ -49,34 +99,14 @@ interface ServerEntry {
   member: { role: string }
 }
 
-interface JoinServerResponse {
-  id: string
-  slug?: string | null
-}
-
-interface ApiError {
-  status?: number
-  message?: string
-}
-
 export default function DiscoverScreen() {
   const { t } = useTranslation()
   const colors = useColors()
   const router = useRouter()
   const queryClient = useQueryClient()
-  const [activeTab, setActiveTab] = useState<TabType>('servers')
-  const [search, setSearch] = useState('')
-
-  const { data: servers = [], isLoading: serversLoading } = useQuery({
-    queryKey: ['discover-servers'],
-    queryFn: () => fetchApi<DiscoverServer[]>('/api/servers/discover'),
-  })
-
-  const { data: channels = [], isLoading: channelsLoading } = useQuery({
-    queryKey: ['discover-channels'],
-    queryFn: () => fetchApi<DiscoverChannel[]>('/api/discover/channels'),
-    enabled: activeTab === 'channels',
-  })
+  const [searchQuery, setSearchQuery] = useState('')
+  const [activeFilter, setActiveFilter] = useState<FilterType>('all')
+  const [isSearching, setIsSearching] = useState(false)
 
   const { data: myServers = [] } = useQuery({
     queryKey: ['servers'],
@@ -85,9 +115,45 @@ export default function DiscoverScreen() {
 
   const joinedServerIds = useMemo(() => new Set(myServers.map((s) => s.server.id)), [myServers])
 
+  // 无限滚动加载
+  const {
+    data: feedData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: ['discover-feed', activeFilter],
+    queryFn: async ({ pageParam = 0 }) => {
+      const res = await fetchApi<FeedResponse>(
+        `/api/discover/feed?type=${activeFilter}&limit=15&offset=${pageParam}`,
+      )
+      return res
+    },
+    getNextPageParam: (lastPage, pages) => {
+      if (!lastPage.hasMore) return undefined
+      return pages.length * 15
+    },
+    initialPageParam: 0,
+  })
+
+  // 搜索
+  const { data: searchResults, isLoading: searchLoading } = useQuery({
+    queryKey: ['discover-search', searchQuery, activeFilter],
+    queryFn: async () => {
+      if (!searchQuery || searchQuery.length < 2) return { items: [] }
+      const res = await fetchApi<{ items: FeedItem[] }>(
+        `/api/discover/search?q=${encodeURIComponent(searchQuery)}&type=${activeFilter}`,
+      )
+      return res
+    },
+    enabled: isSearching && searchQuery.length >= 2,
+  })
+
   const joinMutation = useMutation({
-    mutationFn: ({ inviteCode }: { inviteCode: string; serverId: string }) =>
-      fetchApi<JoinServerResponse>('/api/servers/_/join', {
+    mutationFn: ({ inviteCode }: { inviteCode: string }) =>
+      fetchApi<{ id: string; slug?: string | null }>('/api/servers/_/join', {
         method: 'POST',
         body: JSON.stringify({ inviteCode }),
       }),
@@ -95,32 +161,26 @@ export default function DiscoverScreen() {
       queryClient.invalidateQueries({ queryKey: ['servers'] })
       router.push(`/(main)/servers/${data.slug ?? data.id}`)
     },
-    onError: (err: ApiError, variables) => {
-      if (err?.status === 409) {
-        queryClient.invalidateQueries({ queryKey: ['servers'] })
-        const srv = servers.find((s) => s.id === variables.serverId)
-        router.push(`/(main)/servers/${srv?.slug ?? variables.serverId}`)
-      } else {
-        showToast(err?.message || t('common.error'), 'error')
-      }
+    onError: (err: { message?: string }) => {
+      showToast(err?.message || t('common.error'), 'error')
     },
   })
 
-  const filteredServers = servers.filter(
-    (s) =>
-      s.name.toLowerCase().includes(search.toLowerCase()) ||
-      s.description?.toLowerCase().includes(search.toLowerCase()),
-  )
+  const allItems = useMemo(() => {
+    if (isSearching) return searchResults?.items || []
+    return feedData?.pages.flatMap((page) => page.items) || []
+  }, [feedData, searchResults, isSearching])
 
-  const filteredChannels = channels.filter(
-    (c) =>
-      c.name.toLowerCase().includes(search.toLowerCase()) ||
-      c.topic?.toLowerCase().includes(search.toLowerCase()) ||
-      c.server.name.toLowerCase().includes(search.toLowerCase()),
-  )
+  const handleSearch = () => {
+    if (searchQuery.length >= 2) {
+      setIsSearching(true)
+    }
+  }
 
-  const isLoading =
-    (activeTab === 'servers' && serversLoading) || (activeTab === 'channels' && channelsLoading)
+  const clearSearch = () => {
+    setSearchQuery('')
+    setIsSearching(false)
+  }
 
   const formatTimeAgo = (date: string) => {
     const now = new Date()
@@ -133,35 +193,51 @@ export default function DiscoverScreen() {
     if (minutes < 1) return t('discover.justNow')
     if (minutes < 60) return t('discover.minutesAgo', { count: minutes })
     if (hours < 24) return t('discover.hoursAgo', { count: hours })
-    return t('discover.daysAgo', { count: days })
+    if (days < 7) return t('discover.daysAgo', { count: days })
+    return then.toLocaleDateString()
   }
 
-  const TabButton = ({
-    tab,
-    icon: Icon,
-    label,
-  }: {
-    tab: TabType
-    icon: typeof Globe
-    label: string
-  }) => (
-    <Pressable
-      style={[
-        styles.tabButton,
-        {
-          backgroundColor: activeTab === tab ? colors.primary : colors.surface,
-        },
-      ]}
-      onPress={() => setActiveTab(tab)}
-    >
-      <Icon size={16} color={activeTab === tab ? '#fff' : colors.textMuted} />
-      <Text style={[styles.tabText, { color: activeTab === tab ? '#fff' : colors.textSecondary }]}>
-        {label}
-      </Text>
-    </Pressable>
-  )
+  const getHeatIcon = (score: number) => {
+    if (score >= 100) return { icon: Flame, color: '#ef4444' }
+    if (score >= 50) return { icon: Zap, color: '#f97316' }
+    return null
+  }
 
-  if (isLoading) return <LoadingScreen />
+  const renderItem = ({ item }: { item: FeedItem }) => {
+    return (
+      <FeedCard
+        item={item}
+        joinedServerIds={joinedServerIds}
+        joinMutation={joinMutation}
+        router={router}
+        colors={colors}
+        t={t}
+        formatTimeAgo={formatTimeAgo}
+        getHeatIcon={getHeatIcon}
+      />
+    )
+  }
+
+  const renderFooter = () => {
+    if (!hasNextPage || isSearching) return null
+    return (
+      <View style={styles.loadMore}>
+        {isFetchingNextPage ? (
+          <ActivityIndicator size="small" color={colors.primary} />
+        ) : (
+          <Text style={{ color: colors.textMuted, fontSize: fontSize.sm }}>
+            {t('discover.loadMore')}
+          </Text>
+        )}
+      </View>
+    )
+  }
+
+  const onEndReached = () => {
+    if (!isSearching && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -172,271 +248,282 @@ export default function DiscoverScreen() {
           { backgroundColor: colors.surface, borderBottomColor: colors.border },
         ]}
       >
-        <View style={styles.headerContent}>
-          <View style={styles.titleRow}>
-            <Globe size={24} color={colors.primary} />
-            <Text style={[styles.title, { color: colors.text }]}>{t('discover.title')}</Text>
+        {/* Title */}
+        <View style={styles.titleRow}>
+          <View style={[styles.iconContainer, { backgroundColor: colors.primary }]}>
+            <Flame size={20} color="#fff" />
           </View>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-            {t('discover.subtitle')}
-          </Text>
+          <View>
+            <Text style={[styles.title, { color: colors.text }]}>{t('discover.title')}</Text>
+            <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+              {t('discover.subtitle')}
+            </Text>
+          </View>
         </View>
-
-        {/* Tabs */}
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          style={styles.tabsContainer}
-          contentContainerStyle={styles.tabsContent}
-        >
-          <TabButton tab="servers" icon={Globe} label={t('discover.tabs.servers')} />
-          <TabButton tab="channels" icon={Hash} label={t('discover.tabs.channels')} />
-          <TabButton tab="explore" icon={Zap} label={t('discover.tabs.explore')} />
-        </ScrollView>
 
         {/* Search */}
         <View style={[styles.searchBox, { backgroundColor: colors.inputBackground }]}>
           <Search size={18} color={colors.textMuted} />
           <TextInput
             style={[styles.searchInput, { color: colors.text }]}
-            value={search}
-            onChangeText={setSearch}
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+            onSubmitEditing={handleSearch}
             placeholder={t('discover.searchPlaceholder')}
             placeholderTextColor={colors.textMuted}
+            returnKeyType="search"
           />
+          {searchQuery.length > 0 && (
+            <Pressable onPress={clearSearch}>
+              <Text style={{ color: colors.textMuted, fontSize: 18 }}>×</Text>
+            </Pressable>
+          )}
+        </View>
+
+        {/* Filter Tabs */}
+        <View style={styles.filterContainer}>
+          {[
+            { key: 'all', label: t('discover.filters.all'), icon: Flame },
+            { key: 'servers', label: t('discover.filters.servers'), icon: Server },
+            { key: 'channels', label: t('discover.filters.channels'), icon: Hash },
+            { key: 'rentals', label: t('discover.filters.rentals'), icon: Zap },
+          ].map(({ key, label, icon: Icon }) => (
+            <Pressable
+              key={key}
+              style={[
+                styles.filterButton,
+                {
+                  backgroundColor: activeFilter === key ? colors.primary : colors.background,
+                },
+              ]}
+              onPress={() => {
+                setActiveFilter(key as FilterType)
+                setIsSearching(false)
+              }}
+            >
+              <Icon size={12} color={activeFilter === key ? '#fff' : colors.textMuted} />
+              <Text
+                style={{
+                  color: activeFilter === key ? '#fff' : colors.textSecondary,
+                  fontSize: fontSize.xs,
+                  fontWeight: '600',
+                  marginLeft: 4,
+                }}
+              >
+                {label}
+              </Text>
+            </Pressable>
+          ))}
         </View>
       </View>
 
       {/* Content */}
-      {activeTab === 'servers' ? (
-        <ServersTab
-          servers={filteredServers}
-          joinedServerIds={joinedServerIds}
-          joinMutation={joinMutation}
-          router={router}
-          colors={colors}
-          t={t}
-        />
-      ) : activeTab === 'channels' ? (
-        <ChannelsTab
-          channels={filteredChannels}
-          joinedServerIds={joinedServerIds}
-          router={router}
-          colors={colors}
-          t={t}
-          formatTimeAgo={formatTimeAgo}
+      {isLoading ? (
+        <View style={styles.centerContainer}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : allItems.length === 0 ? (
+        <EmptyState
+          icon={isSearching ? '🔍' : '✨'}
+          title={isSearching ? t('discover.noSearchResults') : t('discover.emptyTitle')}
         />
       ) : (
-        <ExploreTab colors={colors} t={t} />
+        <FlatList
+          data={allItems}
+          keyExtractor={(item, index) => `${item.type}-${item.id}-${index}`}
+          renderItem={renderItem}
+          contentContainerStyle={styles.list}
+          refreshControl={
+            <RefreshControl refreshing={isLoading} onRefresh={refetch} tintColor={colors.primary} />
+          }
+          onEndReached={onEndReached}
+          onEndReachedThreshold={0.5}
+          ListFooterComponent={renderFooter}
+        />
       )}
     </View>
   )
 }
 
-// Servers Tab Component
-function ServersTab({
-  servers,
+// Feed Card Component
+function FeedCard({
+  item,
   joinedServerIds,
   joinMutation,
   router,
   colors,
   t,
+  formatTimeAgo,
+  getHeatIcon,
 }: {
-  servers: DiscoverServer[]
+  item: FeedItem
   joinedServerIds: Set<string>
   joinMutation: ReturnType<typeof useMutation>
   router: ReturnType<typeof useRouter>
   colors: ReturnType<typeof useColors>
   t: (key: string, options?: Record<string, unknown>) => string
-}) {
-  if (servers.length === 0) {
-    return <EmptyState icon="🔍" title={t('discover.noServers')} />
-  }
-
-  return (
-    <FlatList
-      data={servers}
-      keyExtractor={(item) => item.id}
-      contentContainerStyle={styles.list}
-      renderItem={({ item }) => {
-        const isJoined = joinedServerIds.has(item.id)
-        return (
-          <Pressable
-            style={[styles.card, { backgroundColor: colors.surface }]}
-            onPress={() => {
-              if (isJoined) {
-                router.push(`/(main)/servers/${item.slug ?? item.id}`)
-              }
-            }}
-          >
-            <View style={[styles.banner, { backgroundColor: `${colors.primary}20` }]}>
-              {item.bannerUrl && (
-                <Image
-                  source={{ uri: getImageUrl(item.bannerUrl) || '' }}
-                  style={StyleSheet.absoluteFill}
-                  contentFit="cover"
-                />
-              )}
-              {item.isPublic && (
-                <View style={styles.publicBadge}>
-                  <Shield size={10} color="#fff" />
-                  <Text style={styles.publicText}>{t('discover.public')}</Text>
-                </View>
-              )}
-            </View>
-
-            <View style={[styles.iconWrap, { backgroundColor: colors.surface }]}>
-              {item.iconUrl ? (
-                <Image
-                  source={{ uri: getImageUrl(item.iconUrl) || '' }}
-                  style={styles.icon}
-                  contentFit="cover"
-                />
-              ) : (
-                <Text style={styles.iconFallback}>{item.name.charAt(0)}</Text>
-              )}
-            </View>
-
-            <View style={styles.cardBody}>
-              <Text style={[styles.serverName, { color: colors.text }]} numberOfLines={1}>
-                {item.name}
-              </Text>
-              <Text style={[styles.desc, { color: colors.textSecondary }]} numberOfLines={2}>
-                {item.description ?? t('discover.noDescription')}
-              </Text>
-
-              <View style={styles.cardFooter}>
-                <View style={styles.memberInfo}>
-                  <View style={[styles.onlineDot, { backgroundColor: '#23a559' }]} />
-                  <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
-                    {item.memberCount} {t('discover.members')}
-                  </Text>
-                </View>
-
-                {isJoined ? (
-                  <Pressable
-                    style={[styles.joinBtn, { backgroundColor: '#23a559' }]}
-                    onPress={() => router.push(`/(main)/servers/${item.slug ?? item.id}`)}
-                  >
-                    <Text style={styles.joinBtnText}>{t('discover.enterButton')}</Text>
-                  </Pressable>
-                ) : (
-                  <Pressable
-                    style={[styles.joinBtn, { backgroundColor: colors.primary }]}
-                    onPress={() => {
-                      if (item.inviteCode) {
-                        joinMutation.mutate({ inviteCode: item.inviteCode, serverId: item.id })
-                      }
-                    }}
-                    disabled={joinMutation.isPending}
-                  >
-                    <Text style={styles.joinBtnText}>{t('discover.joinButton')}</Text>
-                  </Pressable>
-                )}
-              </View>
-            </View>
-          </Pressable>
-        )
-      }}
-    />
-  )
-}
-
-// Channels Tab Component
-function ChannelsTab({
-  channels,
-  joinedServerIds,
-  router,
-  colors,
-  t,
-  formatTimeAgo,
-}: {
-  channels: DiscoverChannel[]
-  joinedServerIds: Set<string>
-  router: ReturnType<typeof useRouter>
-  colors: ReturnType<typeof useColors>
-  t: (key: string, options?: Record<string, unknown>) => string
   formatTimeAgo: (date: string) => string
+  getHeatIcon: (score: number) => { icon: typeof Flame; color: string } | null
 }) {
-  if (channels.length === 0) {
-    return <EmptyState icon="#️⃣" title={t('discover.noChannels')} />
-  }
+  const heat = getHeatIcon(item.heatScore)
 
-  return (
-    <FlatList
-      data={channels}
-      keyExtractor={(item) => item.id}
-      contentContainerStyle={styles.list}
-      renderItem={({ item }) => {
-        const isJoined = joinedServerIds.has(item.server.id)
-        return (
-          <Pressable
-            style={[styles.channelCard, { backgroundColor: colors.surface }]}
-            onPress={() => {
-              if (isJoined) {
-                router.push(
-                  `/(main)/servers/${item.server.slug ?? item.server.id}/channels/${item.id}`,
-                )
-              } else {
-                router.push(`/(main)/servers/${item.server.slug ?? item.server.id}`)
-              }
-            }}
-          >
-            <View style={styles.channelHeader}>
-              <View style={styles.serverIcon}>
-                {item.server.iconUrl ? (
-                  <Image
-                    source={{ uri: getImageUrl(item.server.iconUrl) || '' }}
-                    style={styles.serverIconImage}
-                    contentFit="cover"
-                  />
-                ) : (
-                  <Text style={styles.serverIconFallback}>{item.server.name.charAt(0)}</Text>
-                )}
-              </View>
-              <View style={styles.channelInfo}>
-                <View style={styles.channelNameRow}>
-                  <Text style={{ color: colors.textMuted, fontSize: fontSize.sm }}>#</Text>
-                  <Text style={[styles.channelName, { color: colors.text }]} numberOfLines={1}>
-                    {item.name}
-                  </Text>
-                </View>
-                <Text
-                  style={[styles.serverNameSmall, { color: colors.textSecondary }]}
-                  numberOfLines={1}
-                >
-                  {item.server.name}
+  if (item.type === 'server') {
+    const server = item.data as ServerData
+    const isJoined = joinedServerIds.has(server.id)
+
+    return (
+      <Pressable
+        style={[styles.card, { backgroundColor: colors.surface }]}
+        onPress={() => {
+          if (isJoined) {
+            router.push(`/(main)/servers/${server.slug ?? server.id}`)
+          }
+        }}
+      >
+        <View style={styles.cardHeader}>
+          <View style={styles.serverIconContainer}>
+            {server.iconUrl ? (
+              <Image
+                source={{ uri: getImageUrl(server.iconUrl) || '' }}
+                style={styles.serverIcon}
+              />
+            ) : (
+              <View style={[styles.serverIconFallback, { backgroundColor: colors.primary + '20' }]}>
+                <Text style={{ fontSize: 20, fontWeight: '700', color: colors.primary }}>
+                  {server.name.charAt(0)}
                 </Text>
               </View>
+            )}
+            {server.isPublic && (
+              <View style={styles.publicBadge}>
+                <Flame size={10} color="#fff" />
+              </View>
+            )}
+          </View>
+
+          <View style={styles.cardContent}>
+            <View style={styles.cardTitleRow}>
+              <Text style={[styles.cardTitle, { color: colors.text }]} numberOfLines={1}>
+                {server.name}
+              </Text>
+              {isJoined ? (
+                <Pressable
+                  style={[styles.actionButton, { backgroundColor: '#22c55e' }]}
+                  onPress={() => router.push(`/(main)/servers/${server.slug ?? server.id}`)}
+                >
+                  <Text style={styles.actionButtonText}>{t('discover.enterButton')}</Text>
+                </Pressable>
+              ) : (
+                <Pressable
+                  style={[styles.actionButton, { backgroundColor: colors.primary }]}
+                  onPress={() => joinMutation.mutate({ inviteCode: server.inviteCode })}
+                  disabled={joinMutation.isPending}
+                >
+                  <Text style={styles.actionButtonText}>{t('discover.joinButton')}</Text>
+                </Pressable>
+              )}
             </View>
 
-            {item.topic && (
-              <Text
-                style={[styles.channelTopic, { color: colors.textSecondary }]}
-                numberOfLines={2}
+            <View style={styles.metaRow}>
+              <View style={styles.metaItem}>
+                <Users size={12} color={colors.textMuted} />
+                <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                  {server.memberCount}
+                </Text>
+              </View>
+              {heat && (
+                <View style={styles.metaItem}>
+                  <heat.icon size={12} color={heat.color} />
+                  <Text style={{ color: heat.color, fontSize: fontSize.xs }}>
+                    {t('discover.heat.hot')}
+                  </Text>
+                </View>
+              )}
+            </View>
+
+            {server.description && (
+              <Text style={[styles.description, { color: colors.textSecondary }]} numberOfLines={2}>
+                {server.description}
+              </Text>
+            )}
+          </View>
+        </View>
+      </Pressable>
+    )
+  }
+
+  if (item.type === 'channel') {
+    const channel = item.data as ChannelData
+    const isJoined = joinedServerIds.has(channel.server.id)
+
+    return (
+      <Pressable
+        style={[styles.card, { backgroundColor: colors.surface }]}
+        onPress={() => {
+          if (isJoined) {
+            router.push(
+              `/(main)/servers/${channel.server.slug ?? channel.server.id}/channels/${channel.id}`,
+            )
+          } else {
+            router.push(`/(main)/servers/${channel.server.slug ?? channel.server.id}`)
+          }
+        }}
+      >
+        <View style={styles.cardHeader}>
+          <View style={styles.channelIconContainer}>
+            {channel.server.iconUrl ? (
+              <Image
+                source={{ uri: getImageUrl(channel.server.iconUrl) || '' }}
+                style={styles.channelIcon}
+              />
+            ) : (
+              <View
+                style={[styles.channelIconFallback, { backgroundColor: colors.primary + '20' }]}
               >
-                {item.topic}
+                <Text style={{ fontSize: 16, fontWeight: '700', color: colors.primary }}>
+                  {channel.server.name.charAt(0)}
+                </Text>
+              </View>
+            )}
+          </View>
+
+          <View style={styles.cardContent}>
+            <View style={styles.channelTitleRow}>
+              <Text style={{ color: colors.textMuted, fontSize: fontSize.sm }}>
+                {channel.server.name}
+              </Text>
+              <Text style={{ color: colors.textMuted }}>/</Text>
+              <Hash size={14} color={colors.textMuted} />
+              <Text style={[styles.channelName, { color: colors.text }]} numberOfLines={1}>
+                {channel.name}
+              </Text>
+            </View>
+
+            {channel.topic && (
+              <Text style={[styles.topic, { color: colors.textSecondary }]} numberOfLines={1}>
+                {channel.topic}
               </Text>
             )}
 
-            {item.lastMessage && (
+            {channel.lastMessage && (
               <View style={[styles.lastMessageBox, { backgroundColor: colors.background }]}>
                 <Text
                   style={[styles.lastMessageText, { color: colors.textSecondary }]}
                   numberOfLines={2}
                 >
-                  {item.lastMessage.content}
+                  {channel.lastMessage.content}
                 </Text>
                 <Text style={[styles.lastMessageTime, { color: colors.textMuted }]}>
-                  {formatTimeAgo(item.lastMessage.createdAt)}
+                  {formatTimeAgo(channel.lastMessage.createdAt)}
                 </Text>
               </View>
             )}
 
             <View style={styles.channelFooter}>
-              <View style={styles.memberCount}>
+              <View style={styles.metaItem}>
+                <MessageCircle size={12} color={colors.textMuted} />
                 <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
-                  {item.memberCount} {t('discover.members')}
+                  {channel.memberCount}
                 </Text>
               </View>
               {!isJoined && (
@@ -447,26 +534,117 @@ function ChannelsTab({
                 </View>
               )}
             </View>
-          </Pressable>
-        )
-      }}
-    />
-  )
-}
+          </View>
+        </View>
+      </Pressable>
+    )
+  }
 
-// Explore Tab Component (placeholder)
-function ExploreTab({
-  colors,
-  t,
-}: {
-  colors: ReturnType<typeof useColors>
-  t: (key: string, options?: Record<string, unknown>) => string
-}) {
-  return (
-    <View style={[styles.exploreContainer, { backgroundColor: colors.background }]}>
-      <EmptyState icon="✨" title={t('discover.exploreComingSoon')} />
-    </View>
-  )
+  if (item.type === 'rental') {
+    const rental = item.data as RentalData
+
+    return (
+      <View style={[styles.card, { backgroundColor: colors.surface }]}>
+        <View style={styles.cardHeader}>
+          <View style={[styles.rentalIconContainer, { backgroundColor: colors.primary + '20' }]}>
+            <Text style={{ fontSize: 24 }}>🤖</Text>
+          </View>
+
+          <View style={styles.cardContent}>
+            <View style={styles.cardTitleRow}>
+              <Text style={[styles.cardTitle, { color: colors.text }]} numberOfLines={1}>
+                {rental.listing?.title || t('discover.unknownListing')}
+              </Text>
+              <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                {formatTimeAgo(rental.startedAt)}
+              </Text>
+            </View>
+
+            <Text style={[styles.agentName, { color: colors.textSecondary }]}>
+              {rental.agent?.name || t('discover.unknownAgent')}
+            </Text>
+
+            {rental.listing?.description && (
+              <Text style={[styles.description, { color: colors.textSecondary }]} numberOfLines={2}>
+                {rental.listing.description}
+              </Text>
+            )}
+
+            <View style={styles.tagsRow}>
+              {rental.listing?.deviceTier && (
+                <View style={[styles.tag, { backgroundColor: colors.background }]}>
+                  <Text style={{ color: colors.textSecondary, fontSize: fontSize.xs }}>
+                    {rental.listing.deviceTier}
+                  </Text>
+                </View>
+              )}
+              {rental.listing?.osType && (
+                <View style={[styles.tag, { backgroundColor: colors.background }]}>
+                  <Text style={{ color: colors.textSecondary, fontSize: fontSize.xs }}>
+                    {rental.listing.osType}
+                  </Text>
+                </View>
+              )}
+              {rental.agent?.status && (
+                <View
+                  style={[
+                    styles.tag,
+                    {
+                      backgroundColor:
+                        rental.agent.status === 'online'
+                          ? '#22c55e20'
+                          : rental.agent.status === 'error'
+                            ? '#ef444420'
+                            : colors.background,
+                    },
+                  ]}
+                >
+                  <Text
+                    style={{
+                      color:
+                        rental.agent.status === 'online'
+                          ? '#22c55e'
+                          : rental.agent.status === 'error'
+                            ? '#ef4444'
+                            : colors.textSecondary,
+                      fontSize: fontSize.xs,
+                    }}
+                  >
+                    {rental.agent.status}
+                  </Text>
+                </View>
+              )}
+            </View>
+
+            <View style={styles.rentalFooter}>
+              <View style={styles.tenantInfo}>
+                <View style={[styles.tenantAvatar, { backgroundColor: colors.background }]}>
+                  {rental.tenant?.avatarUrl ? (
+                    <Image
+                      source={{ uri: getImageUrl(rental.tenant.avatarUrl) || '' }}
+                      style={{ width: 20, height: 20 }}
+                    />
+                  ) : (
+                    <Text style={{ fontSize: 10 }}>👤</Text>
+                  )}
+                </View>
+                <Text style={{ color: colors.textSecondary, fontSize: fontSize.xs }}>
+                  {rental.tenant?.displayName ||
+                    rental.tenant?.username ||
+                    t('discover.unknownUser')}
+                </Text>
+              </View>
+              <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                {rental.listing?.hourlyRate}虾币/h
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    )
+  }
+
+  return null
 }
 
 const styles = StyleSheet.create({
@@ -475,14 +653,18 @@ const styles = StyleSheet.create({
     padding: spacing.md,
     borderBottomWidth: 1,
   },
-  headerContent: {
-    marginBottom: spacing.md,
-  },
   titleRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,
-    marginBottom: spacing.xs,
+    marginBottom: spacing.md,
+  },
+  iconContainer: {
+    width: 40,
+    height: 40,
+    borderRadius: radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   title: {
     fontSize: fontSize.xl,
@@ -491,25 +673,6 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: fontSize.sm,
   },
-  tabsContainer: {
-    marginBottom: spacing.md,
-  },
-  tabsContent: {
-    flexDirection: 'row',
-    gap: spacing.sm,
-  },
-  tabButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm,
-    borderRadius: radius.lg,
-  },
-  tabText: {
-    fontSize: fontSize.sm,
-    fontWeight: '600',
-  },
   searchBox: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -517,145 +680,130 @@ const styles = StyleSheet.create({
     borderRadius: radius.lg,
     height: 44,
     gap: spacing.sm,
+    marginBottom: spacing.md,
   },
   searchInput: {
     flex: 1,
     fontSize: fontSize.md,
   },
+  filterContainer: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  filterButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   list: {
     padding: spacing.md,
     gap: spacing.md,
   },
-  exploreContainer: {
-    flex: 1,
-    justifyContent: 'center',
+  loadMore: {
+    paddingVertical: spacing.lg,
     alignItems: 'center',
   },
+  // Card styles
   card: {
-    borderRadius: radius.xl,
-    overflow: 'hidden',
-  },
-  banner: {
-    height: 100,
-  },
-  publicBadge: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 99,
-  },
-  publicText: {
-    color: '#fff',
-    fontSize: 10,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-  },
-  iconWrap: {
-    position: 'absolute',
-    top: 74,
-    left: 12,
-    width: 52,
-    height: 52,
-    borderRadius: 14,
-    padding: 3,
-    zIndex: 10,
-  },
-  icon: {
-    width: 46,
-    height: 46,
-    borderRadius: 11,
-  },
-  iconFallback: {
-    width: 46,
-    height: 46,
-    borderRadius: 11,
-    textAlign: 'center',
-    lineHeight: 46,
-    fontSize: 20,
-    fontWeight: '700',
-    color: '#fff',
-    backgroundColor: '#5865F2',
-    overflow: 'hidden',
-  },
-  cardBody: {
-    paddingTop: 32,
-    paddingHorizontal: spacing.lg,
-    paddingBottom: spacing.lg,
-  },
-  serverName: {
-    fontSize: fontSize.lg,
-    fontWeight: '800',
-    marginBottom: 4,
-  },
-  desc: {
-    fontSize: fontSize.sm,
-    marginBottom: spacing.md,
-    minHeight: 36,
-  },
-  cardFooter: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  memberInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  onlineDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-  },
-  joinBtn: {
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: radius.md,
-  },
-  joinBtnText: {
-    color: '#fff',
-    fontSize: fontSize.sm,
-    fontWeight: '700',
-  },
-  // Channel styles
-  channelCard: {
     borderRadius: radius.xl,
     padding: spacing.md,
   },
-  channelHeader: {
+  cardHeader: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  cardContent: {
+    flex: 1,
+  },
+  cardTitleRow: {
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'space-between',
     gap: spacing.sm,
-    marginBottom: spacing.sm,
+  },
+  cardTitle: {
+    fontSize: fontSize.md,
+    fontWeight: '700',
+    flex: 1,
+  },
+  actionButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: radius.md,
+  },
+  actionButtonText: {
+    color: '#fff',
+    fontSize: fontSize.xs,
+    fontWeight: '700',
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    marginTop: spacing.xs,
+  },
+  metaItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  description: {
+    fontSize: fontSize.sm,
+    marginTop: spacing.sm,
+  },
+  // Server styles
+  serverIconContainer: {
+    position: 'relative',
   },
   serverIcon: {
-    width: 48,
-    height: 48,
-    borderRadius: 12,
-    overflow: 'hidden',
-    backgroundColor: '#5865F220',
+    width: 56,
+    height: 56,
+    borderRadius: radius.lg,
+  },
+  serverIconFallback: {
+    width: 56,
+    height: 56,
+    borderRadius: radius.lg,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  serverIconImage: {
+  publicBadge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: '#22c55e',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // Channel styles
+  channelIconContainer: {
+    width: 48,
+    height: 48,
+    borderRadius: radius.md,
+    overflow: 'hidden',
+  },
+  channelIcon: {
     width: 48,
     height: 48,
   },
-  serverIconFallback: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: '#5865F2',
+  channelIconFallback: {
+    width: 48,
+    height: 48,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  channelInfo: {
-    flex: 1,
-  },
-  channelNameRow: {
+  channelTitleRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
@@ -664,40 +812,76 @@ const styles = StyleSheet.create({
     fontSize: fontSize.md,
     fontWeight: '700',
   },
-  serverNameSmall: {
+  topic: {
     fontSize: fontSize.sm,
-  },
-  channelTopic: {
-    fontSize: fontSize.sm,
-    marginBottom: spacing.sm,
+    marginTop: 2,
   },
   lastMessageBox: {
     borderRadius: radius.md,
     padding: spacing.sm,
-    marginBottom: spacing.sm,
+    marginTop: spacing.sm,
   },
   lastMessageText: {
     fontSize: fontSize.sm,
-    marginBottom: 4,
   },
   lastMessageTime: {
     fontSize: fontSize.xs,
+    marginTop: 4,
   },
   channelFooter: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingTop: spacing.sm,
-    borderTopWidth: 1,
-    borderTopColor: '#00000010',
-  },
-  memberCount: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    marginTop: spacing.sm,
   },
   joinBadge: {
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: radius.sm,
   },
+  // Rental styles
+  rentalIconContainer: {
+    width: 56,
+    height: 56,
+    borderRadius: radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  agentName: {
+    fontSize: fontSize.sm,
+    marginTop: 2,
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginTop: spacing.sm,
+  },
+  tag: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: radius.sm,
+  },
+  rentalFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: spacing.sm,
+    paddingTop: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: '#00000010',
+  },
+  tenantInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  tenantAvatar: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
 })
+ENDOFFILE

--- a/apps/mobile/src/components/discover/ChannelFilter.tsx
+++ b/apps/mobile/src/components/discover/ChannelFilter.tsx
@@ -1,0 +1,458 @@
+import {
+  Check,
+  ChevronDown,
+  Clock,
+  Filter,
+  MessageSquare,
+  Search,
+  X,
+  Zap,
+} from 'lucide-react-native'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Animated,
+  Dimensions,
+  Modal,
+  PanResponder,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+import { fontSize, radius, spacing, useColors } from '../../theme'
+
+const { height: SCREEN_HEIGHT } = Dimensions.get('window')
+
+export interface ChannelFilterState {
+  search: string
+  sortBy: 'default' | 'lastMessage' | 'activity' | 'created' | 'updated'
+  sortOrder: 'asc' | 'desc'
+  showArchived: boolean
+}
+
+interface ChannelFilterProps {
+  filters: ChannelFilterState
+  onChange: (filters: ChannelFilterState) => void
+  onClear: () => void
+}
+
+const sortOptions = [
+  { key: 'default', label: 'discover.filter.sort.default', icon: Zap },
+  { key: 'lastMessage', label: 'discover.filter.sort.lastMessage', icon: MessageSquare },
+  { key: 'activity', label: 'discover.filter.sort.activity', icon: Clock },
+  { key: 'created', label: 'discover.filter.sort.created', icon: Clock },
+  { key: 'updated', label: 'discover.filter.sort.updated', icon: Clock },
+] as const
+
+export function ChannelFilter({ filters, onChange, onClear }: ChannelFilterProps) {
+  const { t } = useTranslation()
+  const colors = useColors()
+  const [isOpen, setIsOpen] = useState(false)
+  const [tempFilters, setTempFilters] = useState(filters)
+  const translateY = useState(new Animated.Value(SCREEN_HEIGHT))[0]
+
+  const hasActiveFilters =
+    filters.search ||
+    filters.sortBy !== 'default' ||
+    filters.sortOrder !== 'desc' ||
+    filters.showArchived
+
+  const openModal = () => {
+    setIsOpen(true)
+    setTempFilters(filters)
+    Animated.spring(translateY, {
+      toValue: 0,
+      useNativeDriver: true,
+      friction: 8,
+      tension: 40,
+    }).start()
+  }
+
+  const closeModal = () => {
+    Animated.spring(translateY, {
+      toValue: SCREEN_HEIGHT,
+      useNativeDriver: true,
+      friction: 8,
+      tension: 40,
+    }).start(() => {
+      setIsOpen(false)
+    })
+  }
+
+  const handleApply = () => {
+    onChange(tempFilters)
+    closeModal()
+  }
+
+  const handleClear = () => {
+    const cleared = {
+      search: '',
+      sortBy: 'default' as const,
+      sortOrder: 'desc' as const,
+      showArchived: false,
+    }
+    setTempFilters(cleared)
+    onClear()
+    closeModal()
+  }
+
+  const toggleSortOrder = () => {
+    setTempFilters((prev) => ({
+      ...prev,
+      sortOrder: prev.sortOrder === 'asc' ? 'desc' : 'asc',
+    }))
+  }
+
+  const panResponder = PanResponder.create({
+    onMoveShouldSetPanResponder: (_, gestureState) =>
+      gestureState.dy > 0 && Math.abs(gestureState.dy) > 10,
+    onPanResponderMove: (_, gestureState) => {
+      if (gestureState.dy > 0) {
+        translateY.setValue(gestureState.dy)
+      }
+    },
+    onPanResponderRelease: (_, gestureState) => {
+      if (gestureState.dy > 100) {
+        closeModal()
+      } else {
+        Animated.spring(translateY, {
+          toValue: 0,
+          useNativeDriver: true,
+          friction: 8,
+        }).start()
+      }
+    },
+  })
+
+  return (
+    <>
+      {/* Trigger Button */}
+      <TouchableOpacity
+        onPress={openModal}
+        style={[
+          styles.trigger,
+          {
+            backgroundColor: hasActiveFilters || isOpen ? `${colors.primary}20` : colors.surface,
+            borderColor: hasActiveFilters || isOpen ? colors.primary : 'transparent',
+          },
+        ]}
+      >
+        <Filter size={14} color={hasActiveFilters || isOpen ? colors.primary : colors.textMuted} />
+        <Text
+          style={{
+            color: hasActiveFilters || isOpen ? colors.primary : colors.textSecondary,
+            fontSize: fontSize.sm,
+            fontWeight: '500',
+          }}
+        >
+          {t('discover.filter.title')}
+        </Text>
+        <ChevronDown
+          size={14}
+          color={hasActiveFilters || isOpen ? colors.primary : colors.textMuted}
+        />
+        {hasActiveFilters && (
+          <View style={[styles.badge, { backgroundColor: colors.primary }]}>
+            <Text style={{ color: '#fff', fontSize: 10, fontWeight: '700' }}>!</Text>
+          </View>
+        )}
+      </TouchableOpacity>
+
+      {/* Modal */}
+      <Modal visible={isOpen} transparent animationType="none" onRequestClose={closeModal}>
+        <View style={styles.overlay}>
+          {/* Backdrop */}
+          <Pressable style={styles.backdrop} onPress={closeModal} />
+
+          {/* Bottom Sheet */}
+          <Animated.View
+            style={[
+              styles.sheet,
+              { backgroundColor: colors.surface },
+              { transform: [{ translateY }] },
+            ]}
+            {...panResponder.panHandlers}
+          >
+            {/* Drag Handle */}
+            <View style={styles.dragHandle}>
+              <View style={[styles.dragIndicator, { backgroundColor: colors.textMuted }]} />
+            </View>
+
+            {/* Header */}
+            <View style={[styles.header, { borderBottomColor: colors.border }]}>
+              <Text style={[styles.headerTitle, { color: colors.text }]}>
+                {t('discover.filter.title')}
+              </Text>
+              <TouchableOpacity onPress={closeModal} style={styles.closeButton}>
+                <X size={20} color={colors.textMuted} />
+              </TouchableOpacity>
+            </View>
+
+            {/* Content */}
+            <View style={styles.content}>
+              {/* Search */}
+              <View style={[styles.searchBox, { backgroundColor: colors.inputBackground }]}>
+                <Search size={14} color={colors.textMuted} />
+                <TextInput
+                  style={[styles.searchInput, { color: colors.text }]}
+                  value={tempFilters.search}
+                  onChangeText={(text) => setTempFilters((prev) => ({ ...prev, search: text }))}
+                  placeholder={t('discover.filter.searchPlaceholder')}
+                  placeholderTextColor={colors.textMuted}
+                />
+                {tempFilters.search && (
+                  <TouchableOpacity
+                    onPress={() => setTempFilters((prev) => ({ ...prev, search: '' }))}
+                  >
+                    <X size={14} color={colors.textMuted} />
+                  </TouchableOpacity>
+                )}
+              </View>
+
+              {/* Sort Options */}
+              <View style={styles.section}>
+                <View style={styles.sectionHeader}>
+                  <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
+                    {t('discover.filter.sortBy')}
+                  </Text>
+                  <TouchableOpacity onPress={toggleSortOrder} style={styles.sortOrderButton}>
+                    <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                      {tempFilters.sortOrder === 'asc' ? '↑' : '↓'}
+                    </Text>
+                    <Text style={{ color: colors.textMuted, fontSize: fontSize.xs }}>
+                      {tempFilters.sortOrder === 'asc'
+                        ? t('discover.filter.ascending')
+                        : t('discover.filter.descending')}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+
+                {sortOptions.map(({ key, label, icon: Icon }) => (
+                  <TouchableOpacity
+                    key={key}
+                    onPress={() => setTempFilters((prev) => ({ ...prev, sortBy: key }))}
+                    style={[
+                      styles.sortOption,
+                      {
+                        backgroundColor:
+                          tempFilters.sortBy === key ? `${colors.primary}20` : 'transparent',
+                      },
+                    ]}
+                  >
+                    <Icon
+                      size={14}
+                      color={tempFilters.sortBy === key ? colors.primary : colors.textMuted}
+                    />
+                    <Text
+                      style={{
+                        flex: 1,
+                        color: tempFilters.sortBy === key ? colors.primary : colors.text,
+                        fontSize: fontSize.sm,
+                      }}
+                    >
+                      {t(label)}
+                    </Text>
+                    {tempFilters.sortBy === key && <Check size={14} color={colors.primary} />}
+                  </TouchableOpacity>
+                ))}
+              </View>
+
+              {/* Toggle Options */}
+              <View style={styles.section}>
+                <TouchableOpacity
+                  onPress={() =>
+                    setTempFilters((prev) => ({
+                      ...prev,
+                      showArchived: !prev.showArchived,
+                    }))
+                  }
+                  style={styles.toggleOption}
+                >
+                  <View style={styles.toggleLeft}>
+                    <View
+                      style={[
+                        styles.checkbox,
+                        {
+                          borderColor: tempFilters.showArchived ? colors.primary : colors.textMuted,
+                          backgroundColor: tempFilters.showArchived
+                            ? colors.primary
+                            : 'transparent',
+                        },
+                      ]}
+                    >
+                      {tempFilters.showArchived && <Check size={10} color="#fff" />}
+                    </View>
+                    <Text style={{ color: colors.text, fontSize: fontSize.sm }}>
+                      {t('discover.filter.showArchived')}
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            {/* Footer */}
+            <View style={[styles.footer, { borderTopColor: colors.border }]}>
+              <TouchableOpacity
+                onPress={handleClear}
+                style={[styles.footerButton, { backgroundColor: colors.background }]}
+              >
+                <Text style={{ color: colors.textSecondary, fontSize: fontSize.sm }}>
+                  {t('discover.filter.clear')}
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={handleApply}
+                style={[styles.footerButton, { backgroundColor: colors.primary }]}
+              >
+                <Text style={{ color: '#fff', fontSize: fontSize.sm, fontWeight: '600' }}>
+                  {t('discover.filter.apply')}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </Animated.View>
+        </View>
+      </Modal>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  trigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+  },
+  badge: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  backdrop: {
+    flex: 1,
+  },
+  sheet: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    maxHeight: SCREEN_HEIGHT * 0.85,
+  },
+  dragHandle: {
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+  },
+  dragIndicator: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+    borderBottomWidth: 1,
+  },
+  headerTitle: {
+    fontSize: fontSize.lg,
+    fontWeight: '700',
+  },
+  closeButton: {
+    padding: spacing.xs,
+  },
+  content: {
+    padding: spacing.lg,
+    gap: spacing.lg,
+  },
+  searchBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: radius.lg,
+    height: 44,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: fontSize.sm,
+  },
+  section: {
+    gap: spacing.xs,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.xs,
+  },
+  sectionTitle: {
+    fontSize: fontSize.xs,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  sortOrderButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.sm,
+  },
+  sortOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+  },
+  toggleOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.sm,
+  },
+  toggleLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  checkbox: {
+    width: 20,
+    height: 20,
+    borderRadius: 4,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  footer: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    padding: spacing.lg,
+    borderTopWidth: 1,
+  },
+  footerButton: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+  },
+})

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -759,6 +759,23 @@
     "heat": {
       "hot": "Hot"
     },
+    "filter": {
+      "title": "Filter",
+      "searchPlaceholder": "Search channels...",
+      "sortBy": "Sort by",
+      "ascending": "Ascending",
+      "descending": "Descending",
+      "showArchived": "Show archived",
+      "clear": "Clear",
+      "apply": "Apply",
+      "sort": {
+        "default": "Default",
+        "lastMessage": "Last message",
+        "activity": "Activity",
+        "created": "Created",
+        "updated": "Updated"
+      }
+    },
     "loadMore": "Loading more...",
     "noMore": "No more",
     "emptyTitle": "Nothing here",

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -753,8 +753,9 @@
     "tabs": {
       "servers": "Servers",
       "channels": "Channels",
-      "rentals": "Rentals"
+      "explore": "Explore"
     },
+    "exploreComingSoon": "More features coming soon",
     "deviceTier": {
       "highEnd": "High-end",
       "midRange": "Mid-range",

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -730,15 +730,37 @@
     "joining": "Joining..."
   },
   "discover": {
-    "title": "Discover Servers",
-    "subtitle": "Find and join communities you're interested in",
-    "searchPlaceholder": "Search servers...",
+    "title": "Discover",
+    "subtitle": "Find servers, channels, and active rentals",
+    "searchPlaceholder": "Search...",
     "noServers": "No public servers available",
+    "noChannels": "No active channels available",
+    "noRentals": "No active rentals",
     "noDescription": "No description",
     "members": "members",
     "joinButton": "Join",
     "enterButton": "Enter",
-    "public": "Public"
+    "public": "Public",
+    "joinToView": "Join to view",
+    "rentedSince": "Rented",
+    "unknownListing": "Unknown Listing",
+    "unknownAgent": "Unknown Buddy",
+    "unknownUser": "Unknown User",
+    "justNow": "Just now",
+    "minutesAgo": "{{count}}m ago",
+    "hoursAgo": "{{count}}h ago",
+    "daysAgo": "{{count}}d ago",
+    "tabs": {
+      "servers": "Servers",
+      "channels": "Channels",
+      "rentals": "Rentals"
+    },
+    "deviceTier": {
+      "highEnd": "High-end",
+      "midRange": "Mid-range",
+      "lowEnd": "Low-end",
+      "unknown": "Unknown"
+    }
   },
   "notification": {
     "title": "Notifications",

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -750,12 +750,21 @@
     "minutesAgo": "{{count}}m ago",
     "hoursAgo": "{{count}}h ago",
     "daysAgo": "{{count}}d ago",
-    "tabs": {
+    "filters": {
+      "all": "All",
       "servers": "Servers",
       "channels": "Channels",
-      "explore": "Explore"
+      "rentals": "Rentals"
     },
-    "exploreComingSoon": "More features coming soon",
+    "heat": {
+      "hot": "Hot"
+    },
+    "loadMore": "Loading more...",
+    "noMore": "No more",
+    "emptyTitle": "Nothing here",
+    "emptyDesc": "Be the first to create a community!",
+    "noSearchResults": "No results",
+    "noSearchResultsDesc": "Try different keywords",
     "deviceTier": {
       "highEnd": "High-end",
       "midRange": "Mid-range",

--- a/apps/mobile/src/i18n/locales/zh-CN.json
+++ b/apps/mobile/src/i18n/locales/zh-CN.json
@@ -753,8 +753,9 @@
     "tabs": {
       "servers": "服务器",
       "channels": "频道",
-      "rentals": "租赁"
+      "explore": "发现"
     },
+    "exploreComingSoon": "更多功能即将推出",
     "deviceTier": {
       "highEnd": "高端",
       "midRange": "中端",

--- a/apps/mobile/src/i18n/locales/zh-CN.json
+++ b/apps/mobile/src/i18n/locales/zh-CN.json
@@ -750,12 +750,21 @@
     "minutesAgo": "{{count}} 分钟前",
     "hoursAgo": "{{count}} 小时前",
     "daysAgo": "{{count}} 天前",
-    "tabs": {
+    "filters": {
+      "all": "全部",
       "servers": "服务器",
       "channels": "频道",
-      "explore": "发现"
+      "rentals": "租赁"
     },
-    "exploreComingSoon": "更多功能即将推出",
+    "heat": {
+      "hot": "热门"
+    },
+    "loadMore": "加载更多...",
+    "noMore": "没有更多了",
+    "emptyTitle": "这里还没有内容",
+    "emptyDesc": "成为第一个创建社区的人吧！",
+    "noSearchResults": "未找到结果",
+    "noSearchResultsDesc": "尝试不同的关键词",
     "deviceTier": {
       "highEnd": "高端",
       "midRange": "中端",

--- a/apps/mobile/src/i18n/locales/zh-CN.json
+++ b/apps/mobile/src/i18n/locales/zh-CN.json
@@ -730,15 +730,37 @@
     "joining": "加入中..."
   },
   "discover": {
-    "title": "探索服务器",
-    "subtitle": "发现并加入感兴趣的社区",
-    "searchPlaceholder": "搜索服务器...",
+    "title": "发现",
+    "subtitle": "发现服务器、频道和正在租赁的 Buddy",
+    "searchPlaceholder": "搜索...",
     "noServers": "暂无公开的服务器",
+    "noChannels": "暂无活跃的频道",
+    "noRentals": "暂无正在租赁的 Buddy",
     "noDescription": "暂无描述",
     "members": "成员",
     "joinButton": "加入",
     "enterButton": "进入",
-    "public": "公开"
+    "public": "公开",
+    "joinToView": "加入后查看",
+    "rentedSince": "租赁于",
+    "unknownListing": "未知租赁",
+    "unknownAgent": "未知 Buddy",
+    "unknownUser": "未知用户",
+    "justNow": "刚刚",
+    "minutesAgo": "{{count}} 分钟前",
+    "hoursAgo": "{{count}} 小时前",
+    "daysAgo": "{{count}} 天前",
+    "tabs": {
+      "servers": "服务器",
+      "channels": "频道",
+      "rentals": "租赁"
+    },
+    "deviceTier": {
+      "highEnd": "高端",
+      "midRange": "中端",
+      "lowEnd": "低端",
+      "unknown": "未知"
+    }
   },
   "notification": {
     "title": "通知",

--- a/apps/mobile/src/i18n/locales/zh-CN.json
+++ b/apps/mobile/src/i18n/locales/zh-CN.json
@@ -759,6 +759,23 @@
     "heat": {
       "hot": "热门"
     },
+    "filter": {
+      "title": "筛选",
+      "searchPlaceholder": "搜索频道...",
+      "sortBy": "排序方式",
+      "ascending": "升序",
+      "descending": "降序",
+      "showArchived": "显示已归档",
+      "clear": "清除",
+      "apply": "应用",
+      "sort": {
+        "default": "默认",
+        "lastMessage": "最新消息",
+        "activity": "活跃度",
+        "created": "创建时间",
+        "updated": "更新时间"
+      }
+    },
     "loadMore": "加载更多...",
     "noMore": "没有更多了",
     "emptyTitle": "这里还没有内容",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -43,6 +43,7 @@
     "@types/bcryptjs": "^3.0.0",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/mime-types": "^2.1.4",
+    "@types/node": "^25.5.0",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.1.0",
     "drizzle-kit": "^0.31.10",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -7,6 +7,7 @@ import { createAgentHandler } from './handlers/agent.handler'
 import { createAppHandler } from './handlers/app.handler'
 import { createAuthHandler } from './handlers/auth.handler'
 import { createChannelHandler } from './handlers/channel.handler'
+import { createDiscoverHandler } from './handlers/discover.handler'
 import { createDmHandler } from './handlers/dm.handler'
 import { createFriendshipHandler } from './handlers/friendship.handler'
 import { createInviteHandler } from './handlers/invite.handler'
@@ -99,6 +100,9 @@ export function createApp(container: AppContainer) {
   app.route('/api', createShopHandler(container))
   app.route('/api', createRentalHandler(container))
   app.route('/api/voice', voiceEnhanceHandler)
+
+  // Discover endpoints (public)
+  app.route('/api/discover', createDiscoverHandler(container))
 
   // 404 handler
   app.notFound((c) => c.json({ error: 'Not Found' }, 404))

--- a/apps/server/src/handlers/discover.handler.ts
+++ b/apps/server/src/handlers/discover.handler.ts
@@ -3,177 +3,363 @@ import { Hono } from 'hono'
 import type { AppContainer } from '../container'
 import * as schema from '../db/schema'
 
+/**
+ * 计算热度分数
+ * 基于：成员数、消息活跃度、最近活动
+ */
+function calculateHeatScore(params: {
+  memberCount: number
+  messageCount?: number
+  lastActivityAt?: Date | null
+  createdAt: Date
+}): number {
+  const { memberCount, messageCount = 0, lastActivityAt, createdAt } = params
+
+  // 基础分数：成员数权重 1，消息数权重 0.5
+  let score = memberCount * 1 + messageCount * 0.5
+
+  // 时间衰减：越活跃越靠前
+  const now = Date.now()
+  const lastActivity = lastActivityAt?.getTime() || createdAt.getTime()
+  const hoursSinceLastActivity = (now - lastActivity) / (1000 * 60 * 60)
+
+  // 24小时内活跃度最高，之后逐渐衰减
+  const timeDecay = Math.max(0, 1 - hoursSinceLastActivity / 168) // 7天衰减到0
+  score = score * (1 + timeDecay)
+
+  return Math.round(score)
+}
+
 export function createDiscoverHandler(container: AppContainer) {
   const handler = new Hono()
 
   /**
-   * GET /api/discover/channels
-   * Returns public channels from public servers with latest messages
-   * Public endpoint - no auth required
+   * GET /api/discover/feed
+   * 综合推荐流 - 按热度+时间排序
+   * 返回混合内容：服务器、频道、活跃租赁
    */
-  handler.get('/channels', async (c) => {
+  handler.get('/feed', async (c) => {
     const db = container.resolve('db')
     const limit = Math.min(Number(c.req.query('limit') ?? '20'), 50)
     const offset = Number(c.req.query('offset') ?? '0')
+    const type = c.req.query('type') as 'all' | 'servers' | 'channels' | 'rentals' | undefined
 
-    // Get public channels from public servers with latest activity
-    const channelRows = await db
-      .select({
-        channel: schema.channels,
-        server: schema.servers,
-      })
-      .from(schema.channels)
-      .innerJoin(schema.servers, eq(schema.channels.serverId, schema.servers.id))
-      .where(
-        and(
-          eq(schema.channels.isPrivate, false),
-          not(sql`${schema.channels.name} LIKE 'app:%'`),
-          eq(schema.servers.isPublic, true),
-        ),
-      )
-      .orderBy(desc(schema.channels.lastMessageAt))
-      .limit(limit)
-      .offset(offset)
+    const result: Array<{
+      id: string
+      type: 'server' | 'channel' | 'rental'
+      heatScore: number
+      data: unknown
+    }> = []
 
-    if (channelRows.length === 0) {
-      return c.json([])
-    }
+    // 1. 获取热门服务器
+    if (!type || type === 'all' || type === 'servers') {
+      const servers = await db
+        .select({
+          server: schema.servers,
+          memberCount: sql<number>`count(${schema.members.userId})::int`,
+        })
+        .from(schema.servers)
+        .leftJoin(schema.members, eq(schema.servers.id, schema.members.serverId))
+        .where(eq(schema.servers.isPublic, true))
+        .groupBy(schema.servers.id)
+        .orderBy(desc(sql`count(${schema.members.userId})`))
+        .limit(limit)
 
-    const channelIds = channelRows.map((row) => row.channel.id)
-
-    // Get latest message for each channel
-    const latestMessages = await db
-      .select({
-        channelId: schema.messages.channelId,
-        content: schema.messages.content,
-        createdAt: schema.messages.createdAt,
-        authorId: schema.messages.authorId,
-      })
-      .from(schema.messages)
-      .where(inArray(schema.messages.channelId, channelIds))
-      .orderBy(desc(schema.messages.createdAt))
-
-    // Get the latest message per channel
-    const latestMessageByChannel = new Map<string, (typeof latestMessages)[0]>()
-    for (const msg of latestMessages) {
-      if (!latestMessageByChannel.has(msg.channelId)) {
-        latestMessageByChannel.set(msg.channelId, msg)
+      for (const { server, memberCount } of servers) {
+        result.push({
+          id: server.id,
+          type: 'server',
+          heatScore: calculateHeatScore({
+            memberCount,
+            createdAt: server.createdAt,
+          }),
+          data: {
+            id: server.id,
+            name: server.name,
+            slug: server.slug,
+            description: server.description,
+            iconUrl: server.iconUrl,
+            bannerUrl: server.bannerUrl,
+            memberCount,
+            isPublic: server.isPublic,
+            inviteCode: server.inviteCode,
+            createdAt: server.createdAt,
+          },
+        })
       }
     }
 
-    // Get member counts for each channel
-    const memberCounts = await db
-      .select({
-        channelId: schema.channelMembers.channelId,
-        count: sql<number>`count(*)::int`.as('count'),
-      })
-      .from(schema.channelMembers)
-      .where(inArray(schema.channelMembers.channelId, channelIds))
-      .groupBy(schema.channelMembers.channelId)
+    // 2. 获取活跃频道
+    if (!type || type === 'all' || type === 'channels') {
+      const channelRows = await db
+        .select({
+          channel: schema.channels,
+          server: schema.servers,
+          memberCount: sql<number>`count(${schema.channelMembers.userId})::int`,
+          messageCount: sql<number>`count(${schema.messages.id})::int`,
+        })
+        .from(schema.channels)
+        .innerJoin(schema.servers, eq(schema.channels.serverId, schema.servers.id))
+        .leftJoin(schema.channelMembers, eq(schema.channels.id, schema.channelMembers.channelId))
+        .leftJoin(schema.messages, eq(schema.channels.id, schema.messages.channelId))
+        .where(
+          and(
+            eq(schema.channels.isPrivate, false),
+            not(sql`${schema.channels.name} LIKE 'app:%'`),
+            eq(schema.servers.isPublic, true),
+          ),
+        )
+        .groupBy(schema.channels.id, schema.servers.id)
+        .orderBy(desc(schema.channels.lastMessageAt))
+        .limit(limit)
 
-    const memberCountMap = new Map(memberCounts.map((m) => [m.channelId, m.count]))
+      // 获取最新消息
+      const channelIds = channelRows.map((r) => r.channel.id)
+      const latestMessages =
+        channelIds.length > 0
+          ? await db
+              .select({
+                channelId: schema.messages.channelId,
+                content: schema.messages.content,
+                createdAt: schema.messages.createdAt,
+                authorId: schema.messages.authorId,
+              })
+              .from(schema.messages)
+              .where(inArray(schema.messages.channelId, channelIds))
+              .orderBy(desc(schema.messages.createdAt))
+          : []
 
-    const result = channelRows.map((row) => ({
-      id: row.channel.id,
-      name: row.channel.name,
-      type: row.channel.type,
-      topic: row.channel.topic,
-      server: {
-        id: row.server.id,
-        name: row.server.name,
-        slug: row.server.slug,
-        iconUrl: row.server.iconUrl,
-      },
-      memberCount: memberCountMap.get(row.channel.id) ?? 0,
-      lastMessage: latestMessageByChannel.get(row.channel.id)
-        ? {
-            content: latestMessageByChannel.get(row.channel.id)!.content.slice(0, 200),
-            createdAt: latestMessageByChannel.get(row.channel.id)!.createdAt,
-            authorId: latestMessageByChannel.get(row.channel.id)!.authorId,
-          }
-        : null,
-    }))
+      const latestMessageByChannel = new Map<string, (typeof latestMessages)[0]>()
+      for (const msg of latestMessages) {
+        if (!latestMessageByChannel.has(msg.channelId)) {
+          latestMessageByChannel.set(msg.channelId, msg)
+        }
+      }
 
-    return c.json(result)
+      for (const { channel, server, memberCount, messageCount } of channelRows) {
+        const lastMessage = latestMessageByChannel.get(channel.id)
+        result.push({
+          id: channel.id,
+          type: 'channel',
+          heatScore: calculateHeatScore({
+            memberCount,
+            messageCount,
+            lastActivityAt: channel.lastMessageAt || channel.createdAt,
+            createdAt: channel.createdAt,
+          }),
+          data: {
+            id: channel.id,
+            name: channel.name,
+            type: channel.type,
+            topic: channel.topic,
+            server: {
+              id: server.id,
+              name: server.name,
+              slug: server.slug,
+              iconUrl: server.iconUrl,
+            },
+            memberCount,
+            lastMessage: lastMessage
+              ? {
+                  content: lastMessage.content.slice(0, 150),
+                  createdAt: lastMessage.createdAt,
+                }
+              : null,
+          },
+        })
+      }
+    }
+
+    // 3. 获取活跃租赁
+    if (!type || type === 'all' || type === 'rentals') {
+      const clawListingDao = container.resolve('clawListingDao')
+      const userDao = container.resolve('userDao')
+      const agentDao = container.resolve('agentDao')
+
+      const activeContracts = await db
+        .select()
+        .from(schema.rentalContracts)
+        .where(eq(schema.rentalContracts.status, 'active'))
+        .orderBy(desc(schema.rentalContracts.createdAt))
+        .limit(limit)
+
+      for (const contract of activeContracts) {
+        const listing = await clawListingDao.findById(contract.listingId)
+        if (!listing) continue
+
+        const tenant = await userDao.findById(contract.tenantId)
+        const owner = await userDao.findById(listing.ownerId)
+        const agent = listing.agentId ? await agentDao.findById(listing.agentId) : null
+        const agentUser = agent?.userId ? await userDao.findById(agent.userId) : null
+
+        result.push({
+          id: contract.id,
+          type: 'rental',
+          heatScore: calculateHeatScore({
+            memberCount: 2, // 租赁双方
+            lastActivityAt: agent?.lastHeartbeat,
+            createdAt: new Date(contract.startsAt),
+          }),
+          data: {
+            contractId: contract.id,
+            contractNo: contract.contractNo,
+            startedAt: contract.startsAt,
+            expiresAt: contract.expiresAt,
+            listing: {
+              id: listing.id,
+              title: listing.title,
+              description: listing.description,
+              deviceTier: listing.deviceTier,
+              osType: listing.osType,
+              hourlyRate: listing.hourlyRate,
+              tags: listing.tags,
+            },
+            tenant: tenant
+              ? {
+                  id: tenant.id,
+                  username: tenant.username,
+                  displayName: tenant.displayName,
+                  avatarUrl: tenant.avatarUrl,
+                }
+              : null,
+            owner: owner
+              ? {
+                  id: owner.id,
+                  username: owner.username,
+                  displayName: owner.displayName,
+                  avatarUrl: owner.avatarUrl,
+                }
+              : null,
+            agent: agent
+              ? {
+                  id: agent.id,
+                  name: agentUser?.displayName || agentUser?.username || 'Unknown',
+                  status: agent.status,
+                  lastHeartbeat: agent.lastHeartbeat,
+                }
+              : null,
+          },
+        })
+      }
+    }
+
+    // 按热度分数排序
+    result.sort((a, b) => b.heatScore - a.heatScore)
+
+    // 分页
+    const paginatedResult = result.slice(offset, offset + limit)
+
+    return c.json({
+      items: paginatedResult,
+      total: result.length,
+      hasMore: result.length > offset + limit,
+    })
   })
 
   /**
-   * GET /api/discover/rentals
-   * Returns currently active buddy rentals
-   * Public endpoint - no auth required
+   * GET /api/discover/search
+   * 统一搜索接口
    */
-  handler.get('/rentals', async (c) => {
+  handler.get('/search', async (c) => {
     const db = container.resolve('db')
-    const clawListingDao = container.resolve('clawListingDao')
-    const userDao = container.resolve('userDao')
-    const agentDao = container.resolve('agentDao')
+    const query = c.req.query('q')?.toLowerCase()
+    const type = c.req.query('type') as 'all' | 'servers' | 'channels' | 'rentals' | undefined
     const limit = Math.min(Number(c.req.query('limit') ?? '20'), 50)
-    const offset = Number(c.req.query('offset') ?? '0')
 
-    // Get active rental contracts with pagination
-    const activeContracts = await db
-      .select()
-      .from(schema.rentalContracts)
-      .where(eq(schema.rentalContracts.status, 'active'))
-      .orderBy(desc(schema.rentalContracts.createdAt))
-      .limit(limit)
-      .offset(offset)
+    if (!query || query.length < 2) {
+      return c.json({ items: [], total: 0 })
+    }
 
-    // Enrich with listing and user info
-    const enriched = await Promise.all(
-      activeContracts.map(async (contract) => {
-        const listing = await clawListingDao.findById(contract.listingId)
-        const tenant = await userDao.findById(contract.tenantId)
-        const owner = listing ? await userDao.findById(listing.ownerId) : null
-        const agent = listing?.agentId ? await agentDao.findById(listing.agentId) : null
-        const agentUser = agent?.userId ? await userDao.findById(agent.userId) : null
+    const result: Array<{
+      id: string
+      type: 'server' | 'channel' | 'rental'
+      data: unknown
+    }> = []
 
-        return {
-          contractId: contract.id,
-          contractNo: contract.contractNo,
-          startedAt: contract.startsAt,
-          expiresAt: contract.expiresAt,
-          listing: listing
-            ? {
-                id: listing.id,
-                title: listing.title,
-                description: listing.description,
-                deviceTier: listing.deviceTier,
-                osType: listing.osType,
-                hourlyRate: listing.hourlyRate,
-                dailyRate: listing.dailyRate,
-                tags: listing.tags,
-              }
-            : null,
-          tenant: tenant
-            ? {
-                id: tenant.id,
-                username: tenant.username,
-                displayName: tenant.displayName,
-                avatarUrl: tenant.avatarUrl,
-              }
-            : null,
-          owner: owner
-            ? {
-                id: owner.id,
-                username: owner.username,
-                displayName: owner.displayName,
-                avatarUrl: owner.avatarUrl,
-              }
-            : null,
-          agent: agent
-            ? {
-                id: agent.id,
-                name: agentUser?.displayName || agentUser?.username || 'Unknown',
-                status: agent.status,
-                lastHeartbeat: agent.lastHeartbeat,
-              }
-            : null,
-        }
-      }),
-    )
+    // 搜索服务器
+    if (!type || type === 'all' || type === 'servers') {
+      const servers = await db
+        .select({
+          server: schema.servers,
+          memberCount: sql<number>`count(${schema.members.userId})::int`,
+        })
+        .from(schema.servers)
+        .leftJoin(schema.members, eq(schema.servers.id, schema.members.serverId))
+        .where(
+          and(
+            eq(schema.servers.isPublic, true),
+            sql`lower(${schema.servers.name}) LIKE ${`%${query}%`}`,
+          ),
+        )
+        .groupBy(schema.servers.id)
+        .limit(limit)
 
-    return c.json(enriched)
+      for (const { server, memberCount } of servers) {
+        result.push({
+          id: server.id,
+          type: 'server',
+          data: {
+            id: server.id,
+            name: server.name,
+            slug: server.slug,
+            description: server.description,
+            iconUrl: server.iconUrl,
+            bannerUrl: server.bannerUrl,
+            memberCount,
+            isPublic: server.isPublic,
+            inviteCode: server.inviteCode,
+          },
+        })
+      }
+    }
+
+    // 搜索频道
+    if (!type || type === 'all' || type === 'channels') {
+      const channels = await db
+        .select({
+          channel: schema.channels,
+          server: schema.servers,
+          memberCount: sql<number>`count(${schema.channelMembers.userId})::int`,
+        })
+        .from(schema.channels)
+        .innerJoin(schema.servers, eq(schema.channels.serverId, schema.servers.id))
+        .leftJoin(schema.channelMembers, eq(schema.channels.id, schema.channelMembers.channelId))
+        .where(
+          and(
+            eq(schema.channels.isPrivate, false),
+            not(sql`${schema.channels.name} LIKE 'app:%'`),
+            eq(schema.servers.isPublic, true),
+            sql`lower(${schema.channels.name}) LIKE ${`%${query}%`}`,
+          ),
+        )
+        .groupBy(schema.channels.id, schema.servers.id)
+        .limit(limit)
+
+      for (const { channel, server, memberCount } of channels) {
+        result.push({
+          id: channel.id,
+          type: 'channel',
+          data: {
+            id: channel.id,
+            name: channel.name,
+            type: channel.type,
+            topic: channel.topic,
+            server: {
+              id: server.id,
+              name: server.name,
+              slug: server.slug,
+              iconUrl: server.iconUrl,
+            },
+            memberCount,
+          },
+        })
+      }
+    }
+
+    return c.json({
+      items: result,
+      total: result.length,
+    })
   })
 
   return handler

--- a/apps/server/src/handlers/discover.handler.ts
+++ b/apps/server/src/handlers/discover.handler.ts
@@ -1,0 +1,180 @@
+import { and, desc, eq, inArray, not, sql } from 'drizzle-orm'
+import { Hono } from 'hono'
+import type { AppContainer } from '../container'
+import * as schema from '../db/schema'
+
+export function createDiscoverHandler(container: AppContainer) {
+  const handler = new Hono()
+
+  /**
+   * GET /api/discover/channels
+   * Returns public channels from public servers with latest messages
+   * Public endpoint - no auth required
+   */
+  handler.get('/channels', async (c) => {
+    const db = container.resolve('db')
+    const limit = Math.min(Number(c.req.query('limit') ?? '20'), 50)
+    const offset = Number(c.req.query('offset') ?? '0')
+
+    // Get public channels from public servers with latest activity
+    const channelRows = await db
+      .select({
+        channel: schema.channels,
+        server: schema.servers,
+      })
+      .from(schema.channels)
+      .innerJoin(schema.servers, eq(schema.channels.serverId, schema.servers.id))
+      .where(
+        and(
+          eq(schema.channels.isPrivate, false),
+          not(sql`${schema.channels.name} LIKE 'app:%'`),
+          eq(schema.servers.isPublic, true),
+        ),
+      )
+      .orderBy(desc(schema.channels.lastMessageAt))
+      .limit(limit)
+      .offset(offset)
+
+    if (channelRows.length === 0) {
+      return c.json([])
+    }
+
+    const channelIds = channelRows.map((row) => row.channel.id)
+
+    // Get latest message for each channel
+    const latestMessages = await db
+      .select({
+        channelId: schema.messages.channelId,
+        content: schema.messages.content,
+        createdAt: schema.messages.createdAt,
+        authorId: schema.messages.authorId,
+      })
+      .from(schema.messages)
+      .where(inArray(schema.messages.channelId, channelIds))
+      .orderBy(desc(schema.messages.createdAt))
+
+    // Get the latest message per channel
+    const latestMessageByChannel = new Map<string, (typeof latestMessages)[0]>()
+    for (const msg of latestMessages) {
+      if (!latestMessageByChannel.has(msg.channelId)) {
+        latestMessageByChannel.set(msg.channelId, msg)
+      }
+    }
+
+    // Get member counts for each channel
+    const memberCounts = await db
+      .select({
+        channelId: schema.channelMembers.channelId,
+        count: sql<number>`count(*)::int`.as('count'),
+      })
+      .from(schema.channelMembers)
+      .where(inArray(schema.channelMembers.channelId, channelIds))
+      .groupBy(schema.channelMembers.channelId)
+
+    const memberCountMap = new Map(memberCounts.map((m) => [m.channelId, m.count]))
+
+    const result = channelRows.map((row) => ({
+      id: row.channel.id,
+      name: row.channel.name,
+      type: row.channel.type,
+      topic: row.channel.topic,
+      server: {
+        id: row.server.id,
+        name: row.server.name,
+        slug: row.server.slug,
+        iconUrl: row.server.iconUrl,
+      },
+      memberCount: memberCountMap.get(row.channel.id) ?? 0,
+      lastMessage: latestMessageByChannel.get(row.channel.id)
+        ? {
+            content: latestMessageByChannel.get(row.channel.id)!.content.slice(0, 200),
+            createdAt: latestMessageByChannel.get(row.channel.id)!.createdAt,
+            authorId: latestMessageByChannel.get(row.channel.id)!.authorId,
+          }
+        : null,
+    }))
+
+    return c.json(result)
+  })
+
+  /**
+   * GET /api/discover/rentals
+   * Returns currently active buddy rentals
+   * Public endpoint - no auth required
+   */
+  handler.get('/rentals', async (c) => {
+    const db = container.resolve('db')
+    const clawListingDao = container.resolve('clawListingDao')
+    const userDao = container.resolve('userDao')
+    const agentDao = container.resolve('agentDao')
+    const limit = Math.min(Number(c.req.query('limit') ?? '20'), 50)
+    const offset = Number(c.req.query('offset') ?? '0')
+
+    // Get active rental contracts with pagination
+    const activeContracts = await db
+      .select()
+      .from(schema.rentalContracts)
+      .where(eq(schema.rentalContracts.status, 'active'))
+      .orderBy(desc(schema.rentalContracts.createdAt))
+      .limit(limit)
+      .offset(offset)
+
+    // Enrich with listing and user info
+    const enriched = await Promise.all(
+      activeContracts.map(async (contract) => {
+        const listing = await clawListingDao.findById(contract.listingId)
+        const tenant = await userDao.findById(contract.tenantId)
+        const owner = listing ? await userDao.findById(listing.ownerId) : null
+        const agent = listing?.agentId ? await agentDao.findById(listing.agentId) : null
+        const agentUser = agent?.userId ? await userDao.findById(agent.userId) : null
+
+        return {
+          contractId: contract.id,
+          contractNo: contract.contractNo,
+          startedAt: contract.startsAt,
+          expiresAt: contract.expiresAt,
+          listing: listing
+            ? {
+                id: listing.id,
+                title: listing.title,
+                description: listing.description,
+                deviceTier: listing.deviceTier,
+                osType: listing.osType,
+                hourlyRate: listing.hourlyRate,
+                dailyRate: listing.dailyRate,
+                tags: listing.tags,
+              }
+            : null,
+          tenant: tenant
+            ? {
+                id: tenant.id,
+                username: tenant.username,
+                displayName: tenant.displayName,
+                avatarUrl: tenant.avatarUrl,
+              }
+            : null,
+          owner: owner
+            ? {
+                id: owner.id,
+                username: owner.username,
+                displayName: owner.displayName,
+                avatarUrl: owner.avatarUrl,
+              }
+            : null,
+          agent: agent
+            ? {
+                id: agent.id,
+                name: agentUser?.displayName || agentUser?.username || 'Unknown',
+                status: agent.status,
+                lastHeartbeat: agent.lastHeartbeat,
+              }
+            : null,
+        }
+      }),
+    )
+
+    return c.json(enriched)
+  })
+
+  return handler
+}

--- a/apps/web/src/components/discover/ChannelFilter.tsx
+++ b/apps/web/src/components/discover/ChannelFilter.tsx
@@ -1,0 +1,230 @@
+import { Check, ChevronDown, Clock, Filter, MessageSquare, Search, X, Zap } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export interface ChannelFilterState {
+  search: string
+  sortBy: 'default' | 'lastMessage' | 'activity' | 'created' | 'updated'
+  sortOrder: 'asc' | 'desc'
+  showArchived: boolean
+}
+
+interface ChannelFilterProps {
+  filters: ChannelFilterState
+  onChange: (filters: ChannelFilterState) => void
+  onClear: () => void
+}
+
+const sortOptions = [
+  { key: 'default', label: 'discover.filter.sort.default', icon: Zap },
+  { key: 'lastMessage', label: 'discover.filter.sort.lastMessage', icon: MessageSquare },
+  { key: 'activity', label: 'discover.filter.sort.activity', icon: Clock },
+  { key: 'created', label: 'discover.filter.sort.created', icon: Clock },
+  { key: 'updated', label: 'discover.filter.sort.updated', icon: Clock },
+] as const
+
+export function ChannelFilter({ filters, onChange, onClear }: ChannelFilterProps) {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const [tempFilters, setTempFilters] = useState(filters)
+
+  const hasActiveFilters =
+    filters.search ||
+    filters.sortBy !== 'default' ||
+    filters.sortOrder !== 'desc' ||
+    filters.showArchived
+
+  const handleApply = () => {
+    onChange(tempFilters)
+    setIsOpen(false)
+  }
+
+  const handleClear = () => {
+    const cleared = {
+      search: '',
+      sortBy: 'default' as const,
+      sortOrder: 'desc' as const,
+      showArchived: false,
+    }
+    setTempFilters(cleared)
+    onClear()
+    setIsOpen(false)
+  }
+
+  const toggleSortOrder = () => {
+    setTempFilters((prev) => ({
+      ...prev,
+      sortOrder: prev.sortOrder === 'asc' ? 'desc' : 'asc',
+    }))
+  }
+
+  return (
+    <div className="relative">
+      {/* Trigger Button */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className={[
+          'flex items-center gap-2 px-3 py-2 rounded-lg text-[13px] font-medium transition',
+          'border',
+          hasActiveFilters || isOpen
+            ? 'bg-primary/10 border-primary text-primary'
+            : 'bg-bg-tertiary border-transparent text-text-secondary hover:bg-bg-secondary',
+        ].join(' ')}
+      >
+        <Filter size={14} />
+        <span>{t('discover.filter.title')}</span>
+        <ChevronDown
+          size={14}
+          className={['transition-transform', isOpen ? 'rotate-180' : ''].join(' ')}
+        />
+        {hasActiveFilters && (
+          <span className="ml-1 w-4 h-4 rounded-full bg-primary text-white text-[10px] flex items-center justify-center">
+            !
+          </span>
+        )}
+      </button>
+
+      {/* Dropdown Panel */}
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
+
+          {/* Panel */}
+          <div className="absolute top-full right-0 mt-2 w-80 bg-bg-secondary rounded-xl border border-bg-tertiary shadow-xl z-50 overflow-hidden">
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-bg-tertiary">
+              <h3 className="font-semibold text-text-primary text-[14px]">
+                {t('discover.filter.title')}
+              </h3>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="p-1 rounded-lg text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition"
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            {/* Search */}
+            <div className="p-4 border-b border-bg-tertiary">
+              <div className="relative">
+                <Search
+                  size={14}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted"
+                />
+                <input
+                  type="text"
+                  value={tempFilters.search}
+                  onChange={(e) => setTempFilters((prev) => ({ ...prev, search: e.target.value }))}
+                  placeholder={t('discover.filter.searchPlaceholder')}
+                  className="w-full bg-bg-tertiary text-text-primary rounded-lg pl-9 pr-8 py-2 text-[13px] outline-none focus:ring-1 focus:ring-primary/50"
+                />
+                {tempFilters.search && (
+                  <button
+                    type="button"
+                    onClick={() => setTempFilters((prev) => ({ ...prev, search: '' }))}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded-full text-text-muted hover:text-text-primary hover:bg-bg-secondary transition"
+                  >
+                    <X size={12} />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Sort Options */}
+            <div className="p-4 border-b border-bg-tertiary">
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-text-secondary text-[12px] font-medium uppercase tracking-wider">
+                  {t('discover.filter.sortBy')}
+                </span>
+                {/* Sort Order Toggle */}
+                <button
+                  type="button"
+                  onClick={toggleSortOrder}
+                  className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition"
+                >
+                  <span>{tempFilters.sortOrder === 'asc' ? '↑' : '↓'}</span>
+                  <span>
+                    {tempFilters.sortOrder === 'asc'
+                      ? t('discover.filter.ascending')
+                      : t('discover.filter.descending')}
+                  </span>
+                </button>
+              </div>
+              <div className="space-y-1">
+                {sortOptions.map(({ key, label, icon: Icon }) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setTempFilters((prev) => ({ ...prev, sortBy: key }))}
+                    className={[
+                      'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] transition',
+                      tempFilters.sortBy === key
+                        ? 'bg-primary/10 text-primary'
+                        : 'text-text-secondary hover:bg-bg-tertiary',
+                    ].join(' ')}
+                  >
+                    <Icon size={14} />
+                    <span className="flex-1 text-left">{t(label)}</span>
+                    {tempFilters.sortBy === key && <Check size={14} className="text-primary" />}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Toggle Options */}
+            <div className="p-4">
+              <button
+                type="button"
+                onClick={() =>
+                  setTempFilters((prev) => ({
+                    ...prev,
+                    showArchived: !prev.showArchived,
+                  }))
+                }
+                className={[
+                  'w-full flex items-center justify-between px-3 py-2 rounded-lg text-[13px] transition',
+                  tempFilters.showArchived
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-text-secondary hover:bg-bg-tertiary',
+                ].join(' ')}
+              >
+                <span className="flex items-center gap-3">
+                  <span
+                    className={[
+                      'w-4 h-4 rounded flex items-center justify-center border-2 transition',
+                      tempFilters.showArchived ? 'border-primary bg-primary' : 'border-text-muted',
+                    ].join(' ')}
+                  >
+                    {tempFilters.showArchived && <Check size={10} className="text-white" />}
+                  </span>
+                  <span>{t('discover.filter.showArchived')}</span>
+                </span>
+              </button>
+            </div>
+
+            {/* Footer Actions */}
+            <div className="flex items-center gap-2 p-4 border-t border-bg-tertiary bg-bg-tertiary/50">
+              <button
+                type="button"
+                onClick={handleClear}
+                className="flex-1 px-4 py-2 rounded-lg text-[13px] font-medium text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition"
+              >
+                {t('discover.filter.clear')}
+              </button>
+              <button
+                type="button"
+                onClick={handleApply}
+                className="flex-1 px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white hover:bg-primary/90 transition"
+              >
+                {t('discover.filter.apply')}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -644,8 +644,8 @@
   },
   "discover": {
     "title": "Discover",
-    "subtitle": "Find servers, channels, and active rentals",
-    "searchPlaceholder": "Search...",
+    "subtitle": "Explore communities, channels, and active rentals",
+    "searchPlaceholder": "Search servers, channels...",
     "noServers": "No public servers available",
     "noChannels": "No active channels available",
     "noRentals": "No active rentals",
@@ -663,10 +663,21 @@
     "minutesAgo": "{{count}}m ago",
     "hoursAgo": "{{count}}h ago",
     "daysAgo": "{{count}}d ago",
-    "tabs": {
+    "loadMore": "Loading more...",
+    "noMore": "No more content",
+    "emptyTitle": "Nothing here yet",
+    "emptyDesc": "Be the first to create or join a community!",
+    "noSearchResults": "No results found",
+    "noSearchResultsDesc": "Try different keywords or filters",
+    "filters": {
+      "all": "All",
       "servers": "Servers",
       "channels": "Channels",
       "rentals": "Rentals"
+    },
+    "heat": {
+      "hot": "Hot",
+      "trending": "Trending"
     },
     "deviceTier": {
       "highEnd": "High-end",

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -679,6 +679,23 @@
       "hot": "Hot",
       "trending": "Trending"
     },
+    "filter": {
+      "title": "Filter",
+      "searchPlaceholder": "Search channels...",
+      "sortBy": "Sort by",
+      "ascending": "Ascending",
+      "descending": "Descending",
+      "showArchived": "Show archived",
+      "clear": "Clear",
+      "apply": "Apply",
+      "sort": {
+        "default": "Default",
+        "lastMessage": "Last message",
+        "activity": "Activity",
+        "created": "Created",
+        "updated": "Updated"
+      }
+    },
     "deviceTier": {
       "highEnd": "High-end",
       "midRange": "Mid-range",

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -679,6 +679,7 @@
       "hot": "Hot",
       "trending": "Trending"
     },
+    "channelBadge": "Channel",
     "filter": {
       "title": "Filter",
       "searchPlaceholder": "Search channels...",

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -643,15 +643,37 @@
     "acceptInvite": "Accept Invitation"
   },
   "discover": {
-    "title": "Discover Servers",
-    "subtitle": "Find and join communities you're interested in",
-    "searchPlaceholder": "Search servers...",
+    "title": "Discover",
+    "subtitle": "Find servers, channels, and active rentals",
+    "searchPlaceholder": "Search...",
     "noServers": "No public servers available",
+    "noChannels": "No active channels available",
+    "noRentals": "No active rentals",
     "noDescription": "No description",
     "members": "members",
     "joinButton": "Join",
     "enterButton": "Enter",
-    "public": "Public"
+    "public": "Public",
+    "joinToView": "Join to view",
+    "rentedSince": "Rented",
+    "unknownListing": "Unknown Listing",
+    "unknownAgent": "Unknown Buddy",
+    "unknownUser": "Unknown User",
+    "justNow": "Just now",
+    "minutesAgo": "{{count}}m ago",
+    "hoursAgo": "{{count}}h ago",
+    "daysAgo": "{{count}}d ago",
+    "tabs": {
+      "servers": "Servers",
+      "channels": "Channels",
+      "rentals": "Rentals"
+    },
+    "deviceTier": {
+      "highEnd": "High-end",
+      "midRange": "Mid-range",
+      "lowEnd": "Low-end",
+      "unknown": "Unknown"
+    }
   },
   "notification": {
     "title": "Notifications",

--- a/apps/web/src/lib/locales/ja.json
+++ b/apps/web/src/lib/locales/ja.json
@@ -642,15 +642,66 @@
     "acceptInvite": "招待を受ける"
   },
   "discover": {
-    "title": "サーバーを探す",
-    "subtitle": "興味のあるコミュニティを見つけて参加",
-    "searchPlaceholder": "サーバーを検索...",
+    "title": "発見",
+    "subtitle": "コミュニティ、チャンネル、レンタル中のBuddyを探索",
+    "searchPlaceholder": "サーバー、チャンネルを検索...",
     "noServers": "公開サーバーはありません",
+    "noChannels": "アクティブなチャンネルはありません",
+    "noRentals": "レンタル中のBuddyはありません",
     "noDescription": "説明なし",
     "members": "メンバー",
     "joinButton": "参加",
     "enterButton": "入る",
-    "public": "公開"
+    "public": "公開",
+    "joinToView": "参加して表示",
+    "rentedSince": "レンタル開始",
+    "unknownListing": "不明なリスト",
+    "unknownAgent": "不明なBuddy",
+    "unknownUser": "不明なユーザー",
+    "justNow": "たった今",
+    "minutesAgo": "{{count}}分前",
+    "hoursAgo": "{{count}}時間前",
+    "daysAgo": "{{count}}日前",
+    "loadMore": "さらに読み込む...",
+    "noMore": "これ以上ありません",
+    "emptyTitle": "まだ何もありません",
+    "emptyDesc": "最初のコミュニティを作成または参加しましょう！",
+    "noSearchResults": "結果が見つかりません",
+    "noSearchResultsDesc": "別のキーワードやフィルターを試してください",
+    "channelBadge": "チャンネル",
+    "filters": {
+      "all": "すべて",
+      "servers": "サーバー",
+      "channels": "チャンネル",
+      "rentals": "レンタル"
+    },
+    "heat": {
+      "hot": "人気",
+      "trending": "トレンド"
+    },
+    "filter": {
+      "title": "フィルター",
+      "searchPlaceholder": "チャンネルを検索...",
+      "sortBy": "並び替え",
+      "ascending": "昇順",
+      "descending": "降順",
+      "showArchived": "アーカイブを表示",
+      "clear": "クリア",
+      "apply": "適用",
+      "sort": {
+        "default": "デフォルト",
+        "lastMessage": "最新メッセージ",
+        "activity": "アクティビティ",
+        "created": "作成日",
+        "updated": "更新日"
+      }
+    },
+    "deviceTier": {
+      "highEnd": "高スペック",
+      "midRange": "中スペック",
+      "lowEnd": "低スペック",
+      "unknown": "不明"
+    }
   },
   "notification": {
     "title": "通知",

--- a/apps/web/src/lib/locales/ko.json
+++ b/apps/web/src/lib/locales/ko.json
@@ -642,15 +642,66 @@
     "acceptInvite": "초대 수락"
   },
   "discover": {
-    "title": "서버 탐색",
-    "subtitle": "관심 있는 커뮤니티를 찾아 참가하세요",
-    "searchPlaceholder": "서버 검색...",
+    "title": "발견",
+    "subtitle": "커뮤니티, 채널, 대여 중인 Buddy 탐색",
+    "searchPlaceholder": "서버, 채널 검색...",
     "noServers": "공개 서버가 없습니다",
+    "noChannels": "활성 채널이 없습니다",
+    "noRentals": "대여 중인 Buddy가 없습니다",
     "noDescription": "설명 없음",
     "members": "멤버",
     "joinButton": "참가",
     "enterButton": "입장",
-    "public": "공개"
+    "public": "공개",
+    "joinToView": "참가하여 보기",
+    "rentedSince": "대여 시작",
+    "unknownListing": "알 수 없는 목록",
+    "unknownAgent": "알 수 없는 Buddy",
+    "unknownUser": "알 수 없는 사용자",
+    "justNow": "방금",
+    "minutesAgo": "{{count}}분 전",
+    "hoursAgo": "{{count}}시간 전",
+    "daysAgo": "{{count}}일 전",
+    "loadMore": "더 불러오기...",
+    "noMore": "더 이상 없음",
+    "emptyTitle": "아직 내용이 없습니다",
+    "emptyDesc": "첫 번째로 커뮤니티를 만들거나 참가하세요!",
+    "noSearchResults": "결과를 찾을 수 없습니다",
+    "noSearchResultsDesc": "다른 키워드나 필터를 시도해 보세요",
+    "channelBadge": "채널",
+    "filters": {
+      "all": "전체",
+      "servers": "서버",
+      "channels": "채널",
+      "rentals": "대여"
+    },
+    "heat": {
+      "hot": "인기",
+      "trending": "트렌드"
+    },
+    "filter": {
+      "title": "필터",
+      "searchPlaceholder": "채널 검색...",
+      "sortBy": "정렬 기준",
+      "ascending": "오름차순",
+      "descending": "내림차순",
+      "showArchived": "보관함 표시",
+      "clear": "지우기",
+      "apply": "적용",
+      "sort": {
+        "default": "기본",
+        "lastMessage": "최근 메시지",
+        "activity": "활동",
+        "created": "생성일",
+        "updated": "업데이트일"
+      }
+    },
+    "deviceTier": {
+      "highEnd": "고사양",
+      "midRange": "중사양",
+      "lowEnd": "저사양",
+      "unknown": "알 수 없음"
+    }
   },
   "notification": {
     "title": "알림",

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -643,15 +643,37 @@
     "acceptInvite": "接受邀请"
   },
   "discover": {
-    "title": "探索服务器",
-    "subtitle": "发现并加入感兴趣的社区",
-    "searchPlaceholder": "搜索服务器...",
+    "title": "发现",
+    "subtitle": "发现服务器、频道和正在租赁的 Buddy",
+    "searchPlaceholder": "搜索...",
     "noServers": "暂无公开的服务器",
+    "noChannels": "暂无活跃的频道",
+    "noRentals": "暂无正在租赁的 Buddy",
     "noDescription": "暂无描述",
     "members": "成员",
     "joinButton": "加入",
     "enterButton": "进入",
-    "public": "公开"
+    "public": "公开",
+    "joinToView": "加入后查看",
+    "rentedSince": "租赁于",
+    "unknownListing": "未知租赁",
+    "unknownAgent": "未知 Buddy",
+    "unknownUser": "未知用户",
+    "justNow": "刚刚",
+    "minutesAgo": "{{count}} 分钟前",
+    "hoursAgo": "{{count}} 小时前",
+    "daysAgo": "{{count}} 天前",
+    "tabs": {
+      "servers": "服务器",
+      "channels": "频道",
+      "rentals": "租赁"
+    },
+    "deviceTier": {
+      "highEnd": "高端",
+      "midRange": "中端",
+      "lowEnd": "低端",
+      "unknown": "未知"
+    }
   },
   "notification": {
     "title": "通知",

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -679,6 +679,7 @@
       "hot": "热门",
       "trending": " trending"
     },
+    "channelBadge": "频道",
     "filter": {
       "title": "筛选",
       "searchPlaceholder": "搜索频道...",

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -644,8 +644,8 @@
   },
   "discover": {
     "title": "发现",
-    "subtitle": "发现服务器、频道和正在租赁的 Buddy",
-    "searchPlaceholder": "搜索...",
+    "subtitle": "探索社区、频道和正在租赁的 Buddy",
+    "searchPlaceholder": "搜索服务器、频道...",
     "noServers": "暂无公开的服务器",
     "noChannels": "暂无活跃的频道",
     "noRentals": "暂无正在租赁的 Buddy",
@@ -663,10 +663,21 @@
     "minutesAgo": "{{count}} 分钟前",
     "hoursAgo": "{{count}} 小时前",
     "daysAgo": "{{count}} 天前",
-    "tabs": {
+    "loadMore": "加载更多...",
+    "noMore": "没有更多内容了",
+    "emptyTitle": "这里还没有内容",
+    "emptyDesc": "成为第一个创建或加入社区的人吧！",
+    "noSearchResults": "未找到结果",
+    "noSearchResultsDesc": "尝试不同的关键词或筛选条件",
+    "filters": {
+      "all": "全部",
       "servers": "服务器",
       "channels": "频道",
       "rentals": "租赁"
+    },
+    "heat": {
+      "hot": "热门",
+      "trending": " trending"
     },
     "deviceTier": {
       "highEnd": "高端",

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -679,6 +679,23 @@
       "hot": "热门",
       "trending": " trending"
     },
+    "filter": {
+      "title": "筛选",
+      "searchPlaceholder": "搜索频道...",
+      "sortBy": "排序方式",
+      "ascending": "升序",
+      "descending": "降序",
+      "showArchived": "显示已归档",
+      "clear": "清除",
+      "apply": "应用",
+      "sort": {
+        "default": "默认",
+        "lastMessage": "最新消息",
+        "activity": "活跃度",
+        "created": "创建时间",
+        "updated": "更新时间"
+      }
+    },
     "deviceTier": {
       "highEnd": "高端",
       "midRange": "中端",

--- a/apps/web/src/lib/locales/zh-TW.json
+++ b/apps/web/src/lib/locales/zh-TW.json
@@ -642,15 +642,66 @@
     "acceptInvite": "接受邀請"
   },
   "discover": {
-    "title": "探索伺服器",
-    "subtitle": "發現並加入感興趣的社群",
-    "searchPlaceholder": "搜尋伺服器...",
+    "title": "發現",
+    "subtitle": "探索社群、頻道和正在租賃的 Buddy",
+    "searchPlaceholder": "搜尋伺服器、頻道...",
     "noServers": "暫無公開的伺服器",
+    "noChannels": "暫無活躍的頻道",
+    "noRentals": "暫無正在租賃的 Buddy",
     "noDescription": "暫無描述",
     "members": "成員",
     "joinButton": "加入",
     "enterButton": "進入",
-    "public": "公開"
+    "public": "公開",
+    "joinToView": "加入後查看",
+    "rentedSince": "租賃於",
+    "unknownListing": "未知租賃",
+    "unknownAgent": "未知 Buddy",
+    "unknownUser": "未知用戶",
+    "justNow": "剛剛",
+    "minutesAgo": "{{count}} 分鐘前",
+    "hoursAgo": "{{count}} 小時前",
+    "daysAgo": "{{count}} 天前",
+    "loadMore": "加載更多...",
+    "noMore": "沒有更多內容了",
+    "emptyTitle": "這裡還沒有內容",
+    "emptyDesc": "成為第一個創建或加入社群的人吧！",
+    "noSearchResults": "未找到結果",
+    "noSearchResultsDesc": "嘗試不同的關鍵詞或篩選條件",
+    "channelBadge": "頻道",
+    "filters": {
+      "all": "全部",
+      "servers": "伺服器",
+      "channels": "頻道",
+      "rentals": "租賃"
+    },
+    "heat": {
+      "hot": "熱門",
+      "trending": "趨勢"
+    },
+    "filter": {
+      "title": "篩選",
+      "searchPlaceholder": "搜尋頻道...",
+      "sortBy": "排序方式",
+      "ascending": "升序",
+      "descending": "降序",
+      "showArchived": "顯示已歸檔",
+      "clear": "清除",
+      "apply": "應用",
+      "sort": {
+        "default": "默認",
+        "lastMessage": "最新消息",
+        "activity": "活躍度",
+        "created": "創建時間",
+        "updated": "更新時間"
+      }
+    },
+    "deviceTier": {
+      "highEnd": "高端",
+      "midRange": "中端",
+      "lowEnd": "低端",
+      "unknown": "未知"
+    }
   },
   "notification": {
     "title": "通知",

--- a/apps/web/src/pages/discover.tsx
+++ b/apps/web/src/pages/discover.tsx
@@ -520,57 +520,70 @@ function FeedCard({
             })
           }
         }}
-        className="bg-bg-secondary rounded-2xl p-4 hover:bg-[#383a40] transition cursor-pointer border border-[#1e1f22]"
+        className="bg-bg-secondary rounded-2xl overflow-hidden hover:bg-[#383a40] hover:-translate-y-0.5 hover:shadow-xl transition-all duration-200 cursor-pointer border border-[#1e1f22] group relative"
       >
-        <div className="flex gap-4">
-          {/* Server Icon */}
-          <div className="w-12 h-12 rounded-xl overflow-hidden bg-bg-tertiary shrink-0">
-            {channel.server.iconUrl ? (
-              <img src={channel.server.iconUrl} alt="" className="w-full h-full object-cover" />
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-lg font-bold text-primary/60">
-                {channel.server.name.charAt(0)}
-              </div>
-            )}
-          </div>
+        {/* Header with server icon and channel badge */}
+        <div className="h-[80px] bg-gradient-to-br from-[#5865F2]/20 to-[#5865F2]/5 relative p-4">
+          {/* Channel Badge */}
+          <span className="absolute top-3 right-3 flex items-center gap-1 px-2.5 py-1 bg-primary/80 backdrop-blur-md text-white text-[11px] font-bold rounded-full z-10 uppercase tracking-widest">
+            <Hash size={10} />
+            {t('discover.channelBadge')}
+          </span>
 
-          {/* Content */}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <span className="text-text-muted text-[13px]">{channel.server.name}</span>
-              <span className="text-text-muted">/</span>
-              <div className="flex items-center gap-1">
-                <Hash size={14} className="text-text-muted" />
-                <span className="font-semibold text-text-primary">{channel.name}</span>
-              </div>
-            </div>
-
-            {channel.topic && (
-              <p className="text-text-secondary text-[13px] mb-2">{channel.topic}</p>
-            )}
-
-            {channel.lastMessage && (
-              <div className="bg-bg-tertiary/50 rounded-lg p-3 mt-2">
-                <p className="text-text-secondary text-[13px] line-clamp-2">
-                  {channel.lastMessage.content}
-                </p>
-                <p className="text-text-muted text-[11px] mt-1">
-                  {formatTimeAgo(channel.lastMessage.createdAt)}
-                </p>
-              </div>
-            )}
-
-            <div className="flex items-center gap-3 mt-3">
-              <span className="flex items-center gap-1 text-[12px] text-text-muted">
-                <MessageCircle size={12} />
-                {channel.memberCount} {t('discover.members')}
-              </span>
-              {!isJoined && (
-                <span className="text-[11px] text-text-muted bg-bg-tertiary px-2 py-0.5 rounded">
-                  {t('discover.joinToView')}
-                </span>
+          {/* Server Info */}
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-xl overflow-hidden bg-bg-tertiary shrink-0 border-2 border-bg-secondary">
+              {channel.server.iconUrl ? (
+                <img src={channel.server.iconUrl} alt="" className="w-full h-full object-cover" />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-lg font-bold text-primary/60 bg-bg-tertiary">
+                  {channel.server.name.charAt(0)}
+                </div>
               )}
             </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-text-muted text-[12px] truncate">{channel.server.name}</p>
+              <div className="flex items-center gap-1">
+                <Hash size={14} className="text-primary" />
+                <span className="font-bold text-text-primary text-[15px] truncate">
+                  {channel.name}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="p-4 flex flex-col flex-1">
+          {channel.topic && (
+            <p className="text-text-secondary text-[14px] mb-3 line-clamp-2">{channel.topic}</p>
+          )}
+
+          {channel.lastMessage && (
+            <div className="bg-bg-tertiary/50 rounded-lg p-3 mb-3">
+              <p className="text-text-secondary text-[13px] line-clamp-2">
+                {channel.lastMessage.content}
+              </p>
+              <p className="text-text-muted text-[11px] mt-1">
+                {formatTimeAgo(channel.lastMessage.createdAt)}
+              </p>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between mt-auto pt-3 border-t border-bg-tertiary">
+            <span className="flex items-center gap-1.5 text-[12px] font-medium text-text-muted">
+              <div className="w-2 h-2 rounded-full bg-[#23a559]"></div>
+              {channel.memberCount} {t('discover.members')}
+            </span>
+            {!isJoined ? (
+              <span className="text-[11px] text-text-muted bg-bg-tertiary px-2 py-1 rounded">
+                {t('discover.joinToView')}
+              </span>
+            ) : (
+              <span className="text-[11px] text-green-400 bg-green-500/10 px-2 py-1 rounded">
+                {t('discover.enterButton')}
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/pages/discover.tsx
+++ b/apps/web/src/pages/discover.tsx
@@ -1,12 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { Globe, Search, Shield } from 'lucide-react'
+import { Globe, Hash, Search, Shield, Zap } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppStatus } from '../hooks/use-app-status'
 import { useUnreadCount } from '../hooks/use-unread-count'
 import { fetchApi } from '../lib/api'
 import { getCatAvatar } from '../lib/pixel-cats'
+
+type TabType = 'servers' | 'channels' | 'rentals'
 
 interface DiscoverServer {
   id: string
@@ -21,6 +23,60 @@ interface DiscoverServer {
   memberAvatars?: { id: string; avatarUrl: string | null }[]
 }
 
+interface DiscoverChannel {
+  id: string
+  name: string
+  type: 'text' | 'voice' | 'announcement'
+  topic: string | null
+  server: {
+    id: string
+    name: string
+    slug: string | null
+    iconUrl: string | null
+  }
+  memberCount: number
+  lastMessage: {
+    content: string
+    createdAt: string
+    authorId: string
+  } | null
+}
+
+interface DiscoverRental {
+  contractId: string
+  contractNo: string
+  startedAt: string
+  expiresAt: string | null
+  listing: {
+    id: string
+    title: string
+    description: string | null
+    deviceTier: string | null
+    osType: string | null
+    hourlyRate: number
+    dailyRate: number | null
+    tags: string[] | null
+  } | null
+  tenant: {
+    id: string
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+  } | null
+  owner: {
+    id: string
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+  } | null
+  agent: {
+    id: string
+    name: string
+    status: string
+    lastHeartbeat: string | null
+  } | null
+}
+
 interface ServerEntry {
   server: { id: string; name: string; slug: string | null; iconUrl: string | null }
   member: { role: string }
@@ -29,6 +85,8 @@ interface ServerEntry {
 export function DiscoverPage() {
   const { t } = useTranslation()
   const unreadCount = useUnreadCount()
+  const [activeTab, setActiveTab] = useState<TabType>('servers')
+  const [search, setSearch] = useState('')
   useAppStatus({
     title: t('discover.title'),
     unreadCount,
@@ -37,14 +95,24 @@ export function DiscoverPage() {
   })
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const [search, setSearch] = useState('')
 
-  const { data: servers = [], isLoading } = useQuery({
+  const { data: servers = [], isLoading: serversLoading } = useQuery({
     queryKey: ['discover-servers'],
     queryFn: () => fetchApi<DiscoverServer[]>('/api/servers/discover'),
   })
 
-  // Fetch user's joined servers to determine joined status
+  const { data: channels = [], isLoading: channelsLoading } = useQuery({
+    queryKey: ['discover-channels'],
+    queryFn: () => fetchApi<DiscoverChannel[]>('/api/discover/channels'),
+    enabled: activeTab === 'channels',
+  })
+
+  const { data: rentals = [], isLoading: rentalsLoading } = useQuery({
+    queryKey: ['discover-rentals'],
+    queryFn: () => fetchApi<DiscoverRental[]>('/api/discover/rentals'),
+    enabled: activeTab === 'rentals',
+  })
+
   const { data: myServers = [] } = useQuery({
     queryKey: ['servers'],
     queryFn: () => fetchApi<ServerEntry[]>('/api/servers'),
@@ -68,7 +136,6 @@ export function DiscoverPage() {
     onError: (err: unknown, variables) => {
       const status = (err as { status?: number })?.status
       if (status === 409) {
-        // Already a member — navigate to the server (find slug from discover list)
         queryClient.invalidateQueries({ queryKey: ['servers'] })
         const srv = servers.find((s) => s.id === variables.serverId)
         navigate({
@@ -79,11 +146,44 @@ export function DiscoverPage() {
     },
   })
 
-  const filtered = servers.filter(
+  const filteredServers = servers.filter(
     (s) =>
       s.name.toLowerCase().includes(search.toLowerCase()) ||
       s.description?.toLowerCase().includes(search.toLowerCase()),
   )
+
+  const filteredChannels = channels.filter(
+    (c) =>
+      c.name.toLowerCase().includes(search.toLowerCase()) ||
+      c.topic?.toLowerCase().includes(search.toLowerCase()) ||
+      c.server.name.toLowerCase().includes(search.toLowerCase()),
+  )
+
+  const filteredRentals = rentals.filter(
+    (r) =>
+      r.listing?.title?.toLowerCase().includes(search.toLowerCase()) ||
+      r.listing?.description?.toLowerCase().includes(search.toLowerCase()) ||
+      r.agent?.name?.toLowerCase().includes(search.toLowerCase()),
+  )
+
+  const isLoading =
+    (activeTab === 'servers' && serversLoading) ||
+    (activeTab === 'channels' && channelsLoading) ||
+    (activeTab === 'rentals' && rentalsLoading)
+
+  const formatTimeAgo = (date: string) => {
+    const now = new Date()
+    const then = new Date(date)
+    const diff = now.getTime() - then.getTime()
+    const minutes = Math.floor(diff / 60000)
+    const hours = Math.floor(diff / 3600000)
+    const days = Math.floor(diff / 86400000)
+
+    if (minutes < 1) return t('discover.justNow')
+    if (minutes < 60) return t('discover.minutesAgo', { count: minutes })
+    if (hours < 24) return t('discover.hoursAgo', { count: hours })
+    return t('discover.daysAgo', { count: days })
+  }
 
   return (
     <div className="flex-1 flex flex-col bg-bg-primary overflow-y-auto">
@@ -95,6 +195,49 @@ export function DiscoverPage() {
             <h1 className="text-2xl font-bold text-text-primary">{t('discover.title')}</h1>
           </div>
           <p className="text-text-primary mb-6 text-[15px]">{t('discover.subtitle')}</p>
+
+          {/* Tabs */}
+          <div className="flex gap-2 mb-6">
+            <button
+              type="button"
+              onClick={() => setActiveTab('servers')}
+              className={[
+                'flex items-center gap-2 px-4 py-2 rounded-lg text-[14px] font-medium transition',
+                activeTab === 'servers'
+                  ? 'bg-primary text-white'
+                  : 'bg-bg-tertiary text-text-secondary hover:bg-bg-secondary',
+              ].join(' ')}
+            >
+              <Globe size={16} />
+              {t('discover.tabs.servers')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('channels')}
+              className={[
+                'flex items-center gap-2 px-4 py-2 rounded-lg text-[14px] font-medium transition',
+                activeTab === 'channels'
+                  ? 'bg-primary text-white'
+                  : 'bg-bg-tertiary text-text-secondary hover:bg-bg-secondary',
+              ].join(' ')}
+            >
+              <Hash size={16} />
+              {t('discover.tabs.channels')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('rentals')}
+              className={[
+                'flex items-center gap-2 px-4 py-2 rounded-lg text-[14px] font-medium transition',
+                activeTab === 'rentals'
+                  ? 'bg-primary text-white'
+                  : 'bg-bg-tertiary text-text-secondary hover:bg-bg-secondary',
+              ].join(' ')}
+            >
+              <Zap size={16} />
+              {t('discover.tabs.rentals')}
+            </button>
+          </div>
 
           {/* Search */}
           <div className="relative max-w-md">
@@ -113,131 +256,385 @@ export function DiscoverPage() {
         </div>
       </div>
 
-      {/* Server grid */}
+      {/* Content */}
       <div className="max-w-4xl mx-auto w-full px-6 py-6">
         {isLoading ? (
           <div className="text-center text-text-muted py-12">{t('common.loading')}</div>
-        ) : filtered.length === 0 ? (
-          <div className="text-center text-text-muted py-12">{t('discover.noServers')}</div>
+        ) : activeTab === 'servers' ? (
+          <ServersTab
+            servers={filteredServers}
+            joinedServerIds={joinedServerIds}
+            joinMutation={joinMutation}
+            navigate={navigate}
+            t={t}
+          />
+        ) : activeTab === 'channels' ? (
+          <ChannelsTab
+            channels={filteredChannels}
+            joinedServerIds={joinedServerIds}
+            navigate={navigate}
+            t={t}
+            formatTimeAgo={formatTimeAgo}
+          />
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {filtered.map((server, i) => {
-              const isJoined = joinedServerIds.has(server.id)
-              return (
-                <div
-                  key={server.id}
-                  onClick={() => {
-                    if (isJoined) {
+          <RentalsTab rentals={filteredRentals} t={t} formatTimeAgo={formatTimeAgo} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+// Server Tab Component
+function ServersTab({
+  servers,
+  joinedServerIds,
+  joinMutation,
+  navigate,
+  t,
+}: {
+  servers: DiscoverServer[]
+  joinedServerIds: Set<string>
+  joinMutation: ReturnType<typeof useMutation>
+  navigate: ReturnType<typeof useNavigate>
+  t: (key: string, options?: Record<string, unknown>) => string
+}) {
+  if (servers.length === 0) {
+    return <div className="text-center text-text-muted py-12">{t('discover.noServers')}</div>
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {servers.map((server, i) => {
+        const isJoined = joinedServerIds.has(server.id)
+        return (
+          <div
+            key={server.id}
+            onClick={() => {
+              if (isJoined) {
+                navigate({
+                  to: '/servers/$serverSlug',
+                  params: { serverSlug: server.slug ?? server.id },
+                })
+              }
+            }}
+            className="bg-bg-secondary rounded-[16px] overflow-hidden hover:bg-[#383a40] hover:-translate-y-0.5 hover:shadow-xl transition-all duration-200 group flex flex-col cursor-pointer border border-[#1e1f22] relative"
+          >
+            <div className="h-[120px] bg-gradient-to-br from-[#5865F2]/20 to-[#5865F2]/5 relative">
+              {server.bannerUrl && (
+                <img
+                  src={server.bannerUrl}
+                  alt=""
+                  className="w-full h-full object-cover absolute inset-0"
+                />
+              )}
+              {server.isPublic && (
+                <span className="absolute top-3 right-3 flex items-center gap-1 px-2.5 py-1 bg-black/50 backdrop-blur-md text-white text-[11px] font-bold rounded-full z-10 uppercase tracking-widest">
+                  <Shield size={12} />
+                  {t('discover.public')}
+                </span>
+              )}
+            </div>
+
+            <div className="absolute top-[92px] left-4 p-1.5 bg-bg-secondary group-hover:bg-[#383a40] rounded-[18px] transition-colors duration-200 z-20">
+              <div className="w-[48px] h-[48px] rounded-[12px] overflow-hidden bg-bg-tertiary flex items-center justify-center">
+                {server.iconUrl ? (
+                  <img src={server.iconUrl} alt="" className="w-full h-full object-cover" />
+                ) : (
+                  <img src={getCatAvatar(i)} alt={server.name} className="w-9 h-9" />
+                )}
+              </div>
+            </div>
+
+            <div className="pt-10 p-4 flex flex-col flex-1">
+              <h3 className="font-bold text-[#f2f3f5] text-[16px] mb-1 truncate">{server.name}</h3>
+              <p className="text-text-primary text-[14px] mb-4 line-clamp-2 min-h-[2.5rem] flex-1">
+                {server.description ?? t('discover.noDescription')}
+              </p>
+              <div className="flex items-center justify-between mt-auto">
+                <div className="flex items-center gap-2">
+                  <div className="flex -space-x-2">
+                    {(server.memberAvatars ?? []).slice(0, 5).map((m) => (
+                      <div
+                        key={m.id}
+                        className="w-6 h-6 rounded-full border-2 border-[#2b2d31] group-hover:border-[#383a40] overflow-hidden bg-bg-tertiary transition-colors duration-200"
+                      >
+                        {m.avatarUrl ? (
+                          <img src={m.avatarUrl} alt="" className="w-full h-full object-cover" />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-[10px] text-text-primary">
+                            👤
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                  <span className="flex items-center gap-1.5 text-[12px] font-medium text-text-muted">
+                    <div className="w-2 h-2 rounded-full bg-[#23a559]"></div>
+                    {server.memberCount} {t('discover.members')}
+                  </span>
+                </div>
+                {isJoined ? (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
                       navigate({
                         to: '/servers/$serverSlug',
                         params: { serverSlug: server.slug ?? server.id },
                       })
-                    }
-                  }}
-                  className="bg-bg-secondary rounded-[16px] overflow-hidden hover:bg-[#383a40] hover:-translate-y-0.5 hover:shadow-xl transition-all duration-200 group flex flex-col cursor-pointer border border-[#1e1f22] relative"
-                >
-                  {/* Server banner */}
-                  <div className="h-[120px] bg-gradient-to-br from-[#5865F2]/20 to-[#5865F2]/5 relative">
-                    {server.bannerUrl && (
-                      <img
-                        src={server.bannerUrl}
-                        alt=""
-                        className="w-full h-full object-cover absolute inset-0"
-                      />
-                    )}
-                    {server.isPublic && (
-                      <span className="absolute top-3 right-3 flex items-center gap-1 px-2.5 py-1 bg-black/50 backdrop-blur-md text-white text-[11px] font-bold rounded-full z-10 uppercase tracking-widest">
-                        <Shield size={12} />
-                        {t('discover.public')}
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Avatar overlapping banner */}
-                  <div className="absolute top-[92px] left-4 p-1.5 bg-bg-secondary group-hover:bg-[#383a40] rounded-[18px] transition-colors duration-200 z-20">
-                    <div className="w-[48px] h-[48px] rounded-[12px] overflow-hidden bg-bg-tertiary flex items-center justify-center">
-                      {server.iconUrl ? (
-                        <img src={server.iconUrl} alt="" className="w-full h-full object-cover" />
-                      ) : (
-                        <img src={getCatAvatar(i)} alt={server.name} className="w-9 h-9" />
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="pt-10 p-4 flex flex-col flex-1">
-                    <h3 className="font-bold text-[#f2f3f5] text-[16px] mb-1 truncate">
-                      {server.name}
-                    </h3>
-                    <p className="text-text-primary text-[14px] mb-4 line-clamp-2 min-h-[2.5rem] flex-1">
-                      {server.description ?? t('discover.noDescription')}
-                    </p>
-                    <div className="flex items-center justify-between mt-auto">
-                      <div className="flex items-center gap-2">
-                        <div className="flex -space-x-2">
-                          {(server.memberAvatars ?? []).slice(0, 5).map((m) => (
-                            <div
-                              key={m.id}
-                              className="w-6 h-6 rounded-full border-2 border-[#2b2d31] group-hover:border-[#383a40] overflow-hidden bg-bg-tertiary transition-colors duration-200"
-                            >
-                              {m.avatarUrl ? (
-                                <img
-                                  src={m.avatarUrl}
-                                  alt=""
-                                  className="w-full h-full object-cover"
-                                />
-                              ) : (
-                                <div className="w-full h-full flex items-center justify-center text-[10px] text-text-primary">
-                                  👤
-                                </div>
-                              )}
-                            </div>
-                          ))}
-                        </div>
-                        <span className="flex items-center gap-1.5 text-[12px] font-medium text-text-muted">
-                          <div className="w-2 h-2 rounded-full bg-[#23a559]"></div>
-                          {server.memberCount} {t('discover.members')}
-                        </span>
-                      </div>
-                      {isJoined ? (
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            navigate({
-                              to: '/servers/$serverSlug',
-                              params: { serverSlug: server.slug ?? server.id },
-                            })
-                          }}
-                          className="flex items-center gap-1.5 px-4 py-1.5 bg-[#23a559] hover:bg-[#1d8749] text-white rounded-[3px] text-[14px] font-medium transition"
-                        >
-                          {t('discover.enterButton')}
-                        </button>
-                      ) : (
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            if (server.inviteCode) {
-                              joinMutation.mutate({
-                                inviteCode: server.inviteCode,
-                                serverId: server.id,
-                              })
-                            }
-                          }}
-                          disabled={joinMutation.isPending}
-                          className="flex items-center gap-1.5 px-4 py-1.5 bg-[#5865F2] hover:bg-[#4752C4] text-white rounded-[3px] text-[14px] font-medium transition disabled:opacity-50"
-                        >
-                          {t('discover.joinButton')}
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              )
-            })}
+                    }}
+                    className="flex items-center gap-1.5 px-4 py-1.5 bg-[#23a559] hover:bg-[#1d8749] text-white rounded-[3px] text-[14px] font-medium transition"
+                  >
+                    {t('discover.enterButton')}
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      if (server.inviteCode) {
+                        joinMutation.mutate({
+                          inviteCode: server.inviteCode,
+                          serverId: server.id,
+                        })
+                      }
+                    }}
+                    disabled={joinMutation.isPending}
+                    className="flex items-center gap-1.5 px-4 py-1.5 bg-[#5865F2] hover:bg-[#4752C4] text-white rounded-[3px] text-[14px] font-medium transition disabled:opacity-50"
+                  >
+                    {t('discover.joinButton')}
+                  </button>
+                )}
+              </div>
+            </div>
           </div>
-        )}
-      </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// Channels Tab Component
+function ChannelsTab({
+  channels,
+  joinedServerIds,
+  navigate,
+  t,
+  formatTimeAgo,
+}: {
+  channels: DiscoverChannel[]
+  joinedServerIds: Set<string>
+  navigate: ReturnType<typeof useNavigate>
+  t: (key: string, options?: Record<string, unknown>) => string
+  formatTimeAgo: (date: string) => string
+}) {
+  if (channels.length === 0) {
+    return <div className="text-center text-text-muted py-12">{t('discover.noChannels')}</div>
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {channels.map((channel) => {
+        const isJoined = joinedServerIds.has(channel.server.id)
+        return (
+          <div
+            key={channel.id}
+            onClick={() => {
+              if (isJoined) {
+                navigate({
+                  to: '/servers/$serverSlug/channels/$channelId',
+                  params: {
+                    serverSlug: channel.server.slug ?? channel.server.id,
+                    channelId: channel.id,
+                  },
+                })
+              } else {
+                navigate({
+                  to: '/servers/$serverSlug',
+                  params: { serverSlug: channel.server.slug ?? channel.server.id },
+                })
+              }
+            }}
+            className="bg-bg-secondary rounded-[16px] overflow-hidden hover:bg-[#383a40] hover:-translate-y-0.5 hover:shadow-xl transition-all duration-200 group flex flex-col cursor-pointer border border-[#1e1f22] relative p-4"
+          >
+            <div className="flex items-start gap-3 mb-3">
+              <div className="w-12 h-12 rounded-[12px] overflow-hidden bg-bg-tertiary flex items-center justify-center shrink-0">
+                {channel.server.iconUrl ? (
+                  <img src={channel.server.iconUrl} alt="" className="w-full h-full object-cover" />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-[18px] font-bold text-text-primary bg-primary/20">
+                    {channel.server.name.charAt(0)}
+                  </div>
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <Hash size={14} className="text-text-muted" />
+                  <h3 className="font-bold text-[#f2f3f5] text-[15px] truncate">{channel.name}</h3>
+                </div>
+                <p className="text-text-secondary text-[13px] truncate">{channel.server.name}</p>
+              </div>
+            </div>
+
+            {channel.topic && (
+              <p className="text-text-secondary text-[13px] mb-3 line-clamp-2">{channel.topic}</p>
+            )}
+
+            {channel.lastMessage && (
+              <div className="bg-bg-tertiary rounded-lg p-3 mb-3">
+                <p className="text-text-primary text-[13px] line-clamp-2 mb-1">
+                  {channel.lastMessage.content}
+                </p>
+                <p className="text-text-muted text-[11px]">
+                  {formatTimeAgo(channel.lastMessage.createdAt)}
+                </p>
+              </div>
+            )}
+
+            <div className="flex items-center justify-between mt-auto pt-2 border-t border-bg-tertiary">
+              <div className="flex items-center gap-2">
+                <span className="text-[12px] font-medium text-text-muted">
+                  {channel.memberCount} {t('discover.members')}
+                </span>
+              </div>
+              {!isJoined && (
+                <span className="text-[11px] text-text-muted bg-bg-tertiary px-2 py-1 rounded">
+                  {t('discover.joinToView')}
+                </span>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// Rentals Tab Component
+function RentalsTab({
+  rentals,
+  t,
+  formatTimeAgo,
+}: {
+  rentals: DiscoverRental[]
+  t: (key: string, options?: Record<string, unknown>) => string
+  formatTimeAgo: (date: string) => string
+}) {
+  if (rentals.length === 0) {
+    return <div className="text-center text-text-muted py-12">{t('discover.noRentals')}</div>
+  }
+
+  const getDeviceTierLabel = (tier: string | null) => {
+    switch (tier) {
+      case 'high_end':
+        return t('discover.deviceTier.highEnd')
+      case 'mid_range':
+        return t('discover.deviceTier.midRange')
+      case 'low_end':
+        return t('discover.deviceTier.lowEnd')
+      default:
+        return t('discover.deviceTier.unknown')
+    }
+  }
+
+  const getOsTypeLabel = (os: string | null) => {
+    switch (os) {
+      case 'macos':
+        return 'macOS'
+      case 'windows':
+        return 'Windows'
+      case 'linux':
+        return 'Linux'
+      default:
+        return os ?? 'Unknown'
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {rentals.map((rental) => (
+        <div
+          key={rental.contractId}
+          className="bg-bg-secondary rounded-[16px] overflow-hidden border border-[#1e1f22] relative p-4"
+        >
+          <div className="flex items-start gap-3 mb-3">
+            <div className="w-12 h-12 rounded-[12px] overflow-hidden bg-bg-tertiary flex items-center justify-center shrink-0">
+              {rental.agent ? (
+                <div className="w-full h-full flex items-center justify-center text-[20px]">🤖</div>
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-[18px] font-bold text-text-primary bg-primary/20">
+                  {rental.listing?.title?.charAt(0) ?? '?'}
+                </div>
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="font-bold text-[#f2f3f5] text-[15px] truncate">
+                {rental.listing?.title ?? t('discover.unknownListing')}
+              </h3>
+              <p className="text-text-secondary text-[13px]">
+                {rental.agent?.name ?? t('discover.unknownAgent')}
+              </p>
+            </div>
+          </div>
+
+          {rental.listing?.description && (
+            <p className="text-text-secondary text-[13px] mb-3 line-clamp-2">
+              {rental.listing.description}
+            </p>
+          )}
+
+          <div className="flex flex-wrap gap-2 mb-3">
+            {rental.listing?.deviceTier && (
+              <span className="text-[11px] px-2 py-1 bg-bg-tertiary rounded-full text-text-secondary">
+                {getDeviceTierLabel(rental.listing.deviceTier)}
+              </span>
+            )}
+            {rental.listing?.osType && (
+              <span className="text-[11px] px-2 py-1 bg-bg-tertiary rounded-full text-text-secondary">
+                {getOsTypeLabel(rental.listing.osType)}
+              </span>
+            )}
+            {rental.agent?.status && (
+              <span
+                className={[
+                  'text-[11px] px-2 py-1 rounded-full',
+                  rental.agent.status === 'online'
+                    ? 'bg-green-500/20 text-green-400'
+                    : rental.agent.status === 'error'
+                      ? 'bg-red-500/20 text-red-400'
+                      : 'bg-bg-tertiary text-text-secondary',
+                ].join(' ')}
+              >
+                {rental.agent.status}
+              </span>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between pt-3 border-t border-bg-tertiary">
+            <div className="flex items-center gap-2">
+              <div className="w-6 h-6 rounded-full overflow-hidden bg-bg-tertiary">
+                {rental.tenant?.avatarUrl ? (
+                  <img
+                    src={rental.tenant.avatarUrl}
+                    alt=""
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-[10px] text-text-primary">
+                    👤
+                  </div>
+                )}
+              </div>
+              <span className="text-text-secondary text-[12px]">
+                {rental.tenant?.displayName ?? rental.tenant?.username ?? t('discover.unknownUser')}
+              </span>
+            </div>
+            <div className="text-text-muted text-[12px]">
+              {t('discover.rentedSince')} {formatTimeAgo(rental.startedAt)}
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   )
 }

--- a/apps/web/src/pages/discover.tsx
+++ b/apps/web/src/pages/discover.tsx
@@ -1,29 +1,47 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { Globe, Hash, Search, Shield, Zap } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import {
+  Flame,
+  Hash,
+  MessageCircle,
+  MoreHorizontal,
+  Search,
+  Server,
+  Shield,
+  Users,
+  Zap,
+} from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppStatus } from '../hooks/use-app-status'
 import { useUnreadCount } from '../hooks/use-unread-count'
 import { fetchApi } from '../lib/api'
 import { getCatAvatar } from '../lib/pixel-cats'
 
-type TabType = 'servers' | 'channels' | 'rentals'
+type FeedItemType = 'server' | 'channel' | 'rental'
+type FilterType = 'all' | 'servers' | 'channels' | 'rentals'
 
-interface DiscoverServer {
+interface FeedItem {
+  id: string
+  type: FeedItemType
+  heatScore: number
+  data: ServerData | ChannelData | RentalData
+}
+
+interface ServerData {
   id: string
   name: string
   slug: string | null
   description: string | null
   iconUrl: string | null
-  bannerUrl?: string | null
+  bannerUrl: string | null
+  memberCount: number
   isPublic: boolean
   inviteCode: string
-  memberCount: number
-  memberAvatars?: { id: string; avatarUrl: string | null }[]
+  createdAt: string
 }
 
-interface DiscoverChannel {
+interface ChannelData {
   id: string
   name: string
   type: 'text' | 'voice' | 'announcement'
@@ -38,11 +56,10 @@ interface DiscoverChannel {
   lastMessage: {
     content: string
     createdAt: string
-    authorId: string
   } | null
 }
 
-interface DiscoverRental {
+interface RentalData {
   contractId: string
   contractNo: string
   startedAt: string
@@ -54,7 +71,6 @@ interface DiscoverRental {
     deviceTier: string | null
     osType: string | null
     hourlyRate: number
-    dailyRate: number | null
     tags: string[] | null
   } | null
   tenant: {
@@ -82,35 +98,27 @@ interface ServerEntry {
   member: { role: string }
 }
 
+interface FeedResponse {
+  items: FeedItem[]
+  total: number
+  hasMore: boolean
+}
+
 export function DiscoverPage() {
   const { t } = useTranslation()
   const unreadCount = useUnreadCount()
-  const [activeTab, setActiveTab] = useState<TabType>('servers')
-  const [search, setSearch] = useState('')
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [searchQuery, setSearchQuery] = useState('')
+  const [activeFilter, setActiveFilter] = useState<FilterType>('all')
+  const [isSearching, setIsSearching] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
   useAppStatus({
     title: t('discover.title'),
     unreadCount,
     hasNotification: unreadCount > 0,
     variant: 'workspace',
-  })
-  const navigate = useNavigate()
-  const queryClient = useQueryClient()
-
-  const { data: servers = [], isLoading: serversLoading } = useQuery({
-    queryKey: ['discover-servers'],
-    queryFn: () => fetchApi<DiscoverServer[]>('/api/servers/discover'),
-  })
-
-  const { data: channels = [], isLoading: channelsLoading } = useQuery({
-    queryKey: ['discover-channels'],
-    queryFn: () => fetchApi<DiscoverChannel[]>('/api/discover/channels'),
-    enabled: activeTab === 'channels',
-  })
-
-  const { data: rentals = [], isLoading: rentalsLoading } = useQuery({
-    queryKey: ['discover-rentals'],
-    queryFn: () => fetchApi<DiscoverRental[]>('/api/discover/rentals'),
-    enabled: activeTab === 'rentals',
   })
 
   const { data: myServers = [] } = useQuery({
@@ -120,9 +128,44 @@ export function DiscoverPage() {
 
   const joinedServerIds = useMemo(() => new Set(myServers.map((s) => s.server.id)), [myServers])
 
+  // 无限滚动加载推荐流
+  const {
+    data: feedData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: feedLoading,
+  } = useInfiniteQuery({
+    queryKey: ['discover-feed', activeFilter],
+    queryFn: async ({ pageParam = 0 }) => {
+      const res = await fetchApi<FeedResponse>(
+        `/api/discover/feed?type=${activeFilter}&limit=20&offset=${pageParam}`,
+      )
+      return res
+    },
+    getNextPageParam: (lastPage, pages) => {
+      if (!lastPage.hasMore) return undefined
+      return pages.length * 20
+    },
+    initialPageParam: 0,
+  })
+
+  // 搜索
+  const { data: searchResults, isLoading: searchLoading } = useQuery({
+    queryKey: ['discover-search', searchQuery, activeFilter],
+    queryFn: async () => {
+      if (!searchQuery || searchQuery.length < 2) return { items: [] }
+      const res = await fetchApi<{ items: FeedItem[] }>(
+        `/api/discover/search?q=${encodeURIComponent(searchQuery)}&type=${activeFilter}`,
+      )
+      return res
+    },
+    enabled: isSearching && searchQuery.length >= 2,
+  })
+
   const joinMutation = useMutation({
-    mutationFn: ({ inviteCode }: { inviteCode: string; serverId: string }) =>
-      fetchApi<{ id: string }>('/api/servers/_/join', {
+    mutationFn: ({ inviteCode }: { inviteCode: string }) =>
+      fetchApi<{ id: string; slug?: string | null }>('/api/servers/_/join', {
         method: 'POST',
         body: JSON.stringify({ inviteCode }),
       }),
@@ -130,46 +173,50 @@ export function DiscoverPage() {
       queryClient.invalidateQueries({ queryKey: ['servers'] })
       navigate({
         to: '/servers/$serverSlug',
-        params: { serverSlug: (data as { slug?: string; id: string }).slug ?? data.id },
+        params: { serverSlug: data.slug ?? data.id },
       })
-    },
-    onError: (err: unknown, variables) => {
-      const status = (err as { status?: number })?.status
-      if (status === 409) {
-        queryClient.invalidateQueries({ queryKey: ['servers'] })
-        const srv = servers.find((s) => s.id === variables.serverId)
-        navigate({
-          to: '/servers/$serverSlug',
-          params: { serverSlug: srv?.slug ?? variables.serverId },
-        })
-      }
     },
   })
 
-  const filteredServers = servers.filter(
-    (s) =>
-      s.name.toLowerCase().includes(search.toLowerCase()) ||
-      s.description?.toLowerCase().includes(search.toLowerCase()),
-  )
+  // 合并所有页面数据
+  const allItems = useMemo(() => {
+    if (isSearching) return searchResults?.items || []
+    return feedData?.pages.flatMap((page) => page.items) || []
+  }, [feedData, searchResults, isSearching])
 
-  const filteredChannels = channels.filter(
-    (c) =>
-      c.name.toLowerCase().includes(search.toLowerCase()) ||
-      c.topic?.toLowerCase().includes(search.toLowerCase()) ||
-      c.server.name.toLowerCase().includes(search.toLowerCase()),
-  )
+  // 监听滚动加载更多
+  const observerRef = useRef<IntersectionObserver>()
+  const loadMoreRef = useRef<HTMLDivElement>(null)
 
-  const filteredRentals = rentals.filter(
-    (r) =>
-      r.listing?.title?.toLowerCase().includes(search.toLowerCase()) ||
-      r.listing?.description?.toLowerCase().includes(search.toLowerCase()) ||
-      r.agent?.name?.toLowerCase().includes(search.toLowerCase()),
-  )
+  useEffect(() => {
+    if (isSearching) return
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage()
+        }
+      },
+      { threshold: 0.1 },
+    )
 
-  const isLoading =
-    (activeTab === 'servers' && serversLoading) ||
-    (activeTab === 'channels' && channelsLoading) ||
-    (activeTab === 'rentals' && rentalsLoading)
+    if (loadMoreRef.current) {
+      observerRef.current.observe(loadMoreRef.current)
+    }
+
+    return () => observerRef.current?.disconnect()
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, isSearching])
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (searchQuery.length >= 2) {
+      setIsSearching(true)
+    }
+  }
+
+  const clearSearch = () => {
+    setSearchQuery('')
+    setIsSearching(false)
+  }
 
   const formatTimeAgo = (date: string) => {
     const now = new Date()
@@ -182,437 +229,411 @@ export function DiscoverPage() {
     if (minutes < 1) return t('discover.justNow')
     if (minutes < 60) return t('discover.minutesAgo', { count: minutes })
     if (hours < 24) return t('discover.hoursAgo', { count: hours })
-    return t('discover.daysAgo', { count: days })
+    if (days < 7) return t('discover.daysAgo', { count: days })
+    return then.toLocaleDateString()
+  }
+
+  const getHeatLevel = (score: number) => {
+    if (score >= 100) return { level: 'hot', color: 'text-red-400', icon: Flame }
+    if (score >= 50) return { level: 'warm', color: 'text-orange-400', icon: Zap }
+    return { level: 'normal', color: 'text-text-muted', icon: null }
   }
 
   return (
     <div className="flex-1 flex flex-col bg-bg-primary overflow-y-auto">
       {/* Header */}
-      <div className="desktop-drag-titlebar border-b-2 border-bg-tertiary px-6 py-8 bg-bg-primary">
-        <div className="max-w-4xl mx-auto">
-          <div className="flex items-center gap-3 mb-4">
-            <Globe size={28} className="text-primary" />
-            <h1 className="text-2xl font-bold text-text-primary">{t('discover.title')}</h1>
-          </div>
-          <p className="text-text-primary mb-6 text-[15px]">{t('discover.subtitle')}</p>
-
-          {/* Tabs */}
-          <div className="flex gap-2 mb-6">
-            <button
-              type="button"
-              onClick={() => setActiveTab('servers')}
-              className={[
-                'flex items-center gap-2 px-4 py-2 rounded-lg text-[14px] font-medium transition',
-                activeTab === 'servers'
-                  ? 'bg-primary text-white'
-                  : 'bg-bg-tertiary text-text-secondary hover:bg-bg-secondary',
-              ].join(' ')}
-            >
-              <Globe size={16} />
-              {t('discover.tabs.servers')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setActiveTab('channels')}
-              className={[
-                'flex items-center gap-2 px-4 py-2 rounded-lg text-[14px] font-medium transition',
-                activeTab === 'channels'
-                  ? 'bg-primary text-white'
-                  : 'bg-bg-tertiary text-text-secondary hover:bg-bg-secondary',
-              ].join(' ')}
-            >
-              <Hash size={16} />
-              {t('discover.tabs.channels')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setActiveTab('rentals')}
-              className={[
-                'flex items-center gap-2 px-4 py-2 rounded-lg text-[14px] font-medium transition',
-                activeTab === 'rentals'
-                  ? 'bg-primary text-white'
-                  : 'bg-bg-tertiary text-text-secondary hover:bg-bg-secondary',
-              ].join(' ')}
-            >
-              <Zap size={16} />
-              {t('discover.tabs.rentals')}
-            </button>
+      <div className="desktop-drag-titlebar border-b border-bg-tertiary bg-bg-primary">
+        <div className="max-w-5xl mx-auto px-6 py-6">
+          {/* Title */}
+          <div className="flex items-center gap-3 mb-6">
+            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-primary to-primary/60 flex items-center justify-center">
+              <Flame size={20} className="text-white" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-text-primary">{t('discover.title')}</h1>
+              <p className="text-text-secondary text-sm">{t('discover.subtitle')}</p>
+            </div>
           </div>
 
-          {/* Search */}
-          <div className="relative max-w-md">
-            <Search
-              size={18}
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted"
-            />
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder={t('discover.searchPlaceholder')}
-              className="w-full bg-bg-tertiary text-text-primary rounded-lg pl-10 pr-4 py-2.5 outline-none focus:ring-1 focus:ring-primary text-[15px] shadow-sm"
-            />
+          {/* Search Bar */}
+          <form onSubmit={handleSearch} className="relative mb-4">
+            <div className="relative">
+              <Search
+                size={18}
+                className="absolute left-4 top-1/2 -translate-y-1/2 text-text-muted"
+              />
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onFocus={() => searchQuery.length >= 2 && setIsSearching(true)}
+                placeholder={t('discover.searchPlaceholder')}
+                className="w-full bg-bg-tertiary text-text-primary rounded-xl pl-12 pr-10 py-3 outline-none focus:ring-2 focus:ring-primary/50 text-[15px] transition-shadow"
+              />
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={clearSearch}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          </form>
+
+          {/* Filter Tabs */}
+          <div className="flex gap-2">
+            {[
+              { key: 'all', label: t('discover.filters.all'), icon: Flame },
+              { key: 'servers', label: t('discover.filters.servers'), icon: Server },
+              { key: 'channels', label: t('discover.filters.channels'), icon: Hash },
+              { key: 'rentals', label: t('discover.filters.rentals'), icon: Zap },
+            ].map(({ key, label, icon: Icon }) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => {
+                  setActiveFilter(key as FilterType)
+                  setIsSearching(false)
+                }}
+                className={[
+                  'flex items-center gap-1.5 px-4 py-2 rounded-lg text-[13px] font-medium transition',
+                  activeFilter === key
+                    ? 'bg-primary text-white'
+                    : 'bg-bg-tertiary text-text-secondary hover:bg-bg-secondary',
+                ].join(' ')}
+              >
+                <Icon size={14} />
+                {label}
+              </button>
+            ))}
           </div>
         </div>
       </div>
 
-      {/* Content */}
-      <div className="max-w-4xl mx-auto w-full px-6 py-6">
-        {isLoading ? (
-          <div className="text-center text-text-muted py-12">{t('common.loading')}</div>
-        ) : activeTab === 'servers' ? (
-          <ServersTab
-            servers={filteredServers}
-            joinedServerIds={joinedServerIds}
-            joinMutation={joinMutation}
-            navigate={navigate}
-            t={t}
-          />
-        ) : activeTab === 'channels' ? (
-          <ChannelsTab
-            channels={filteredChannels}
-            joinedServerIds={joinedServerIds}
-            navigate={navigate}
-            t={t}
-            formatTimeAgo={formatTimeAgo}
-          />
-        ) : (
-          <RentalsTab rentals={filteredRentals} t={t} formatTimeAgo={formatTimeAgo} />
-        )}
+      {/* Content Feed */}
+      <div className="flex-1">
+        <div className="max-w-5xl mx-auto px-6 py-6">
+          {isSearching && searchLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="animate-spin w-8 h-8 border-2 border-primary border-t-transparent rounded-full" />
+            </div>
+          ) : allItems.length === 0 ? (
+            <EmptyState isSearching={isSearching} t={t} />
+          ) : (
+            <div className="space-y-4">
+              {allItems.map((item, index) => (
+                <FeedCard
+                  key={`${item.type}-${item.id}-${index}`}
+                  item={item}
+                  joinedServerIds={joinedServerIds}
+                  joinMutation={joinMutation}
+                  navigate={navigate}
+                  t={t}
+                  formatTimeAgo={formatTimeAgo}
+                  getHeatLevel={getHeatLevel}
+                />
+              ))}
+
+              {/* Load More Trigger */}
+              {!isSearching && (
+                <div ref={loadMoreRef} className="py-4 text-center">
+                  {isFetchingNextPage ? (
+                    <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full mx-auto" />
+                  ) : hasNextPage ? (
+                    <span className="text-text-muted text-sm">{t('discover.loadMore')}</span>
+                  ) : (
+                    <span className="text-text-muted text-sm">{t('discover.noMore')}</span>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )
 }
 
-// Server Tab Component
-function ServersTab({
-  servers,
-  joinedServerIds,
-  joinMutation,
-  navigate,
+// Empty State Component
+function EmptyState({
+  isSearching,
   t,
 }: {
-  servers: DiscoverServer[]
-  joinedServerIds: Set<string>
-  joinMutation: ReturnType<typeof useMutation>
-  navigate: ReturnType<typeof useNavigate>
+  isSearching: boolean
   t: (key: string, options?: Record<string, unknown>) => string
 }) {
-  if (servers.length === 0) {
-    return <div className="text-center text-text-muted py-12">{t('discover.noServers')}</div>
-  }
-
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {servers.map((server, i) => {
-        const isJoined = joinedServerIds.has(server.id)
-        return (
-          <div
-            key={server.id}
-            onClick={() => {
-              if (isJoined) {
-                navigate({
-                  to: '/servers/$serverSlug',
-                  params: { serverSlug: server.slug ?? server.id },
-                })
-              }
-            }}
-            className="bg-bg-secondary rounded-[16px] overflow-hidden hover:bg-[#383a40] hover:-translate-y-0.5 hover:shadow-xl transition-all duration-200 group flex flex-col cursor-pointer border border-[#1e1f22] relative"
-          >
-            <div className="h-[120px] bg-gradient-to-br from-[#5865F2]/20 to-[#5865F2]/5 relative">
-              {server.bannerUrl && (
-                <img
-                  src={server.bannerUrl}
-                  alt=""
-                  className="w-full h-full object-cover absolute inset-0"
-                />
-              )}
-              {server.isPublic && (
-                <span className="absolute top-3 right-3 flex items-center gap-1 px-2.5 py-1 bg-black/50 backdrop-blur-md text-white text-[11px] font-bold rounded-full z-10 uppercase tracking-widest">
-                  <Shield size={12} />
-                  {t('discover.public')}
-                </span>
-              )}
-            </div>
-
-            <div className="absolute top-[92px] left-4 p-1.5 bg-bg-secondary group-hover:bg-[#383a40] rounded-[18px] transition-colors duration-200 z-20">
-              <div className="w-[48px] h-[48px] rounded-[12px] overflow-hidden bg-bg-tertiary flex items-center justify-center">
-                {server.iconUrl ? (
-                  <img src={server.iconUrl} alt="" className="w-full h-full object-cover" />
-                ) : (
-                  <img src={getCatAvatar(i)} alt={server.name} className="w-9 h-9" />
-                )}
-              </div>
-            </div>
-
-            <div className="pt-10 p-4 flex flex-col flex-1">
-              <h3 className="font-bold text-[#f2f3f5] text-[16px] mb-1 truncate">{server.name}</h3>
-              <p className="text-text-primary text-[14px] mb-4 line-clamp-2 min-h-[2.5rem] flex-1">
-                {server.description ?? t('discover.noDescription')}
-              </p>
-              <div className="flex items-center justify-between mt-auto">
-                <div className="flex items-center gap-2">
-                  <div className="flex -space-x-2">
-                    {(server.memberAvatars ?? []).slice(0, 5).map((m) => (
-                      <div
-                        key={m.id}
-                        className="w-6 h-6 rounded-full border-2 border-[#2b2d31] group-hover:border-[#383a40] overflow-hidden bg-bg-tertiary transition-colors duration-200"
-                      >
-                        {m.avatarUrl ? (
-                          <img src={m.avatarUrl} alt="" className="w-full h-full object-cover" />
-                        ) : (
-                          <div className="w-full h-full flex items-center justify-center text-[10px] text-text-primary">
-                            👤
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                  <span className="flex items-center gap-1.5 text-[12px] font-medium text-text-muted">
-                    <div className="w-2 h-2 rounded-full bg-[#23a559]"></div>
-                    {server.memberCount} {t('discover.members')}
-                  </span>
-                </div>
-                {isJoined ? (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      navigate({
-                        to: '/servers/$serverSlug',
-                        params: { serverSlug: server.slug ?? server.id },
-                      })
-                    }}
-                    className="flex items-center gap-1.5 px-4 py-1.5 bg-[#23a559] hover:bg-[#1d8749] text-white rounded-[3px] text-[14px] font-medium transition"
-                  >
-                    {t('discover.enterButton')}
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      if (server.inviteCode) {
-                        joinMutation.mutate({
-                          inviteCode: server.inviteCode,
-                          serverId: server.id,
-                        })
-                      }
-                    }}
-                    disabled={joinMutation.isPending}
-                    className="flex items-center gap-1.5 px-4 py-1.5 bg-[#5865F2] hover:bg-[#4752C4] text-white rounded-[3px] text-[14px] font-medium transition disabled:opacity-50"
-                  >
-                    {t('discover.joinButton')}
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-        )
-      })}
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="w-20 h-20 rounded-full bg-bg-tertiary flex items-center justify-center mb-4">
+        <Search size={32} className="text-text-muted" />
+      </div>
+      <h3 className="text-lg font-semibold text-text-primary mb-2">
+        {isSearching ? t('discover.noSearchResults') : t('discover.emptyTitle')}
+      </h3>
+      <p className="text-text-secondary text-sm max-w-sm">
+        {isSearching ? t('discover.noSearchResultsDesc') : t('discover.emptyDesc')}
+      </p>
     </div>
   )
 }
 
-// Channels Tab Component
-function ChannelsTab({
-  channels,
+// Feed Card Component
+function FeedCard({
+  item,
   joinedServerIds,
+  joinMutation,
   navigate,
   t,
   formatTimeAgo,
+  getHeatLevel,
 }: {
-  channels: DiscoverChannel[]
+  item: FeedItem
   joinedServerIds: Set<string>
+  joinMutation: ReturnType<typeof useMutation>
   navigate: ReturnType<typeof useNavigate>
   t: (key: string, options?: Record<string, unknown>) => string
   formatTimeAgo: (date: string) => string
+  getHeatLevel: (score: number) => { level: string; color: string; icon: typeof Flame | null }
 }) {
-  if (channels.length === 0) {
-    return <div className="text-center text-text-muted py-12">{t('discover.noChannels')}</div>
+  const heat = getHeatLevel(item.heatScore)
+
+  if (item.type === 'server') {
+    const server = item.data as ServerData
+    const isJoined = joinedServerIds.has(server.id)
+
+    return (
+      <div
+        onClick={() => {
+          if (isJoined) {
+            navigate({
+              to: '/servers/$serverSlug',
+              params: { serverSlug: server.slug ?? server.id },
+            })
+          }
+        }}
+        className="bg-bg-secondary rounded-2xl p-4 hover:bg-[#383a40] transition cursor-pointer border border-[#1e1f22] group"
+      >
+        <div className="flex gap-4">
+          {/* Server Icon */}
+          <div className="relative shrink-0">
+            <div className="w-16 h-16 rounded-2xl overflow-hidden bg-bg-tertiary">
+              {server.iconUrl ? (
+                <img src={server.iconUrl} alt="" className="w-full h-full object-cover" />
+              ) : (
+                <img src={getCatAvatar(0)} alt={server.name} className="w-full h-full" />
+              )}
+            </div>
+            {server.isPublic && (
+              <div className="absolute -top-1 -right-1 w-5 h-5 bg-green-500 rounded-full flex items-center justify-center">
+                <Shield size={10} className="text-white" />
+              </div>
+            )}
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <h3 className="font-bold text-text-primary text-[16px] truncate">{server.name}</h3>
+                <div className="flex items-center gap-3 mt-1">
+                  <span className="flex items-center gap-1 text-[12px] text-text-muted">
+                    <Users size={12} />
+                    {server.memberCount} {t('discover.members')}
+                  </span>
+                  {heat.icon && (
+                    <span className={['flex items-center gap-1 text-[12px]', heat.color].join(' ')}>
+                      <heat.icon size={12} />
+                      {t('discover.heat.hot')}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {isJoined ? (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    navigate({
+                      to: '/servers/$serverSlug',
+                      params: { serverSlug: server.slug ?? server.id },
+                    })
+                  }}
+                  className="px-4 py-1.5 bg-green-500 hover:bg-green-600 text-white rounded-lg text-[13px] font-medium transition"
+                >
+                  {t('discover.enterButton')}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    joinMutation.mutate({ inviteCode: server.inviteCode })
+                  }}
+                  disabled={joinMutation.isPending}
+                  className="px-4 py-1.5 bg-primary hover:bg-primary/80 text-white rounded-lg text-[13px] font-medium transition disabled:opacity-50"
+                >
+                  {t('discover.joinButton')}
+                </button>
+              )}
+            </div>
+
+            {server.description && (
+              <p className="text-text-secondary text-[14px] mt-2 line-clamp-2">
+                {server.description}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    )
   }
 
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-      {channels.map((channel) => {
-        const isJoined = joinedServerIds.has(channel.server.id)
-        return (
-          <div
-            key={channel.id}
-            onClick={() => {
-              if (isJoined) {
-                navigate({
-                  to: '/servers/$serverSlug/channels/$channelId',
-                  params: {
-                    serverSlug: channel.server.slug ?? channel.server.id,
-                    channelId: channel.id,
-                  },
-                })
-              } else {
-                navigate({
-                  to: '/servers/$serverSlug',
-                  params: { serverSlug: channel.server.slug ?? channel.server.id },
-                })
-              }
-            }}
-            className="bg-bg-secondary rounded-[16px] overflow-hidden hover:bg-[#383a40] hover:-translate-y-0.5 hover:shadow-xl transition-all duration-200 group flex flex-col cursor-pointer border border-[#1e1f22] relative p-4"
-          >
-            <div className="flex items-start gap-3 mb-3">
-              <div className="w-12 h-12 rounded-[12px] overflow-hidden bg-bg-tertiary flex items-center justify-center shrink-0">
-                {channel.server.iconUrl ? (
-                  <img src={channel.server.iconUrl} alt="" className="w-full h-full object-cover" />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-[18px] font-bold text-text-primary bg-primary/20">
-                    {channel.server.name.charAt(0)}
-                  </div>
-                )}
+  if (item.type === 'channel') {
+    const channel = item.data as ChannelData
+    const isJoined = joinedServerIds.has(channel.server.id)
+
+    return (
+      <div
+        onClick={() => {
+          if (isJoined) {
+            navigate({
+              to: '/servers/$serverSlug/channels/$channelId',
+              params: {
+                serverSlug: channel.server.slug ?? channel.server.id,
+                channelId: channel.id,
+              },
+            })
+          } else {
+            navigate({
+              to: '/servers/$serverSlug',
+              params: { serverSlug: channel.server.slug ?? channel.server.id },
+            })
+          }
+        }}
+        className="bg-bg-secondary rounded-2xl p-4 hover:bg-[#383a40] transition cursor-pointer border border-[#1e1f22]"
+      >
+        <div className="flex gap-4">
+          {/* Server Icon */}
+          <div className="w-12 h-12 rounded-xl overflow-hidden bg-bg-tertiary shrink-0">
+            {channel.server.iconUrl ? (
+              <img src={channel.server.iconUrl} alt="" className="w-full h-full object-cover" />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-lg font-bold text-primary/60">
+                {channel.server.name.charAt(0)}
               </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <Hash size={14} className="text-text-muted" />
-                  <h3 className="font-bold text-[#f2f3f5] text-[15px] truncate">{channel.name}</h3>
-                </div>
-                <p className="text-text-secondary text-[13px] truncate">{channel.server.name}</p>
+            )}
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-text-muted text-[13px]">{channel.server.name}</span>
+              <span className="text-text-muted">/</span>
+              <div className="flex items-center gap-1">
+                <Hash size={14} className="text-text-muted" />
+                <span className="font-semibold text-text-primary">{channel.name}</span>
               </div>
             </div>
 
             {channel.topic && (
-              <p className="text-text-secondary text-[13px] mb-3 line-clamp-2">{channel.topic}</p>
+              <p className="text-text-secondary text-[13px] mb-2">{channel.topic}</p>
             )}
 
             {channel.lastMessage && (
-              <div className="bg-bg-tertiary rounded-lg p-3 mb-3">
-                <p className="text-text-primary text-[13px] line-clamp-2 mb-1">
+              <div className="bg-bg-tertiary/50 rounded-lg p-3 mt-2">
+                <p className="text-text-secondary text-[13px] line-clamp-2">
                   {channel.lastMessage.content}
                 </p>
-                <p className="text-text-muted text-[11px]">
+                <p className="text-text-muted text-[11px] mt-1">
                   {formatTimeAgo(channel.lastMessage.createdAt)}
                 </p>
               </div>
             )}
 
-            <div className="flex items-center justify-between mt-auto pt-2 border-t border-bg-tertiary">
-              <div className="flex items-center gap-2">
-                <span className="text-[12px] font-medium text-text-muted">
-                  {channel.memberCount} {t('discover.members')}
-                </span>
-              </div>
+            <div className="flex items-center gap-3 mt-3">
+              <span className="flex items-center gap-1 text-[12px] text-text-muted">
+                <MessageCircle size={12} />
+                {channel.memberCount} {t('discover.members')}
+              </span>
               {!isJoined && (
-                <span className="text-[11px] text-text-muted bg-bg-tertiary px-2 py-1 rounded">
+                <span className="text-[11px] text-text-muted bg-bg-tertiary px-2 py-0.5 rounded">
                   {t('discover.joinToView')}
                 </span>
               )}
             </div>
           </div>
-        )
-      })}
-    </div>
-  )
-}
-
-// Rentals Tab Component
-function RentalsTab({
-  rentals,
-  t,
-  formatTimeAgo,
-}: {
-  rentals: DiscoverRental[]
-  t: (key: string, options?: Record<string, unknown>) => string
-  formatTimeAgo: (date: string) => string
-}) {
-  if (rentals.length === 0) {
-    return <div className="text-center text-text-muted py-12">{t('discover.noRentals')}</div>
+        </div>
+      </div>
+    )
   }
 
-  const getDeviceTierLabel = (tier: string | null) => {
-    switch (tier) {
-      case 'high_end':
-        return t('discover.deviceTier.highEnd')
-      case 'mid_range':
-        return t('discover.deviceTier.midRange')
-      case 'low_end':
-        return t('discover.deviceTier.lowEnd')
-      default:
-        return t('discover.deviceTier.unknown')
-    }
-  }
+  if (item.type === 'rental') {
+    const rental = item.data as RentalData
 
-  const getOsTypeLabel = (os: string | null) => {
-    switch (os) {
-      case 'macos':
-        return 'macOS'
-      case 'windows':
-        return 'Windows'
-      case 'linux':
-        return 'Linux'
-      default:
-        return os ?? 'Unknown'
-    }
-  }
+    return (
+      <div className="bg-bg-secondary rounded-2xl p-4 border border-[#1e1f22]">
+        <div className="flex gap-4">
+          {/* Agent Avatar */}
+          <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-purple-500/20 to-blue-500/20 flex items-center justify-center shrink-0">
+            <span className="text-2xl">🤖</span>
+          </div>
 
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-      {rentals.map((rental) => (
-        <div
-          key={rental.contractId}
-          className="bg-bg-secondary rounded-[16px] overflow-hidden border border-[#1e1f22] relative p-4"
-        >
-          <div className="flex items-start gap-3 mb-3">
-            <div className="w-12 h-12 rounded-[12px] overflow-hidden bg-bg-tertiary flex items-center justify-center shrink-0">
-              {rental.agent ? (
-                <div className="w-full h-full flex items-center justify-center text-[20px]">🤖</div>
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-[18px] font-bold text-text-primary bg-primary/20">
-                  {rental.listing?.title?.charAt(0) ?? '?'}
-                </div>
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <h3 className="font-bold text-text-primary text-[16px]">
+                  {rental.listing?.title || t('discover.unknownListing')}
+                </h3>
+                <p className="text-text-secondary text-[13px]">
+                  {rental.agent?.name || t('discover.unknownAgent')}
+                </p>
+              </div>
+              <div className="flex items-center gap-1 text-[12px] text-text-muted">
+                <Zap size={12} />
+                {t('discover.rentedSince')} {formatTimeAgo(rental.startedAt)}
+              </div>
+            </div>
+
+            {rental.listing?.description && (
+              <p className="text-text-secondary text-[13px] mt-2 line-clamp-2">
+                {rental.listing.description}
+              </p>
+            )}
+
+            <div className="flex flex-wrap gap-2 mt-3">
+              {rental.listing?.deviceTier && (
+                <span className="text-[11px] px-2 py-1 bg-bg-tertiary rounded-full text-text-secondary">
+                  {rental.listing.deviceTier}
+                </span>
+              )}
+              {rental.listing?.osType && (
+                <span className="text-[11px] px-2 py-1 bg-bg-tertiary rounded-full text-text-secondary">
+                  {rental.listing.osType}
+                </span>
+              )}
+              {rental.agent?.status && (
+                <span
+                  className={[
+                    'text-[11px] px-2 py-1 rounded-full',
+                    rental.agent.status === 'online'
+                      ? 'bg-green-500/20 text-green-400'
+                      : rental.agent.status === 'error'
+                        ? 'bg-red-500/20 text-red-400'
+                        : 'bg-bg-tertiary text-text-secondary',
+                  ].join(' ')}
+                >
+                  {rental.agent.status}
+                </span>
               )}
             </div>
-            <div className="flex-1 min-w-0">
-              <h3 className="font-bold text-[#f2f3f5] text-[15px] truncate">
-                {rental.listing?.title ?? t('discover.unknownListing')}
-              </h3>
-              <p className="text-text-secondary text-[13px]">
-                {rental.agent?.name ?? t('discover.unknownAgent')}
-              </p>
-            </div>
-          </div>
 
-          {rental.listing?.description && (
-            <p className="text-text-secondary text-[13px] mb-3 line-clamp-2">
-              {rental.listing.description}
-            </p>
-          )}
-
-          <div className="flex flex-wrap gap-2 mb-3">
-            {rental.listing?.deviceTier && (
-              <span className="text-[11px] px-2 py-1 bg-bg-tertiary rounded-full text-text-secondary">
-                {getDeviceTierLabel(rental.listing.deviceTier)}
-              </span>
-            )}
-            {rental.listing?.osType && (
-              <span className="text-[11px] px-2 py-1 bg-bg-tertiary rounded-full text-text-secondary">
-                {getOsTypeLabel(rental.listing.osType)}
-              </span>
-            )}
-            {rental.agent?.status && (
-              <span
-                className={[
-                  'text-[11px] px-2 py-1 rounded-full',
-                  rental.agent.status === 'online'
-                    ? 'bg-green-500/20 text-green-400'
-                    : rental.agent.status === 'error'
-                      ? 'bg-red-500/20 text-red-400'
-                      : 'bg-bg-tertiary text-text-secondary',
-                ].join(' ')}
-              >
-                {rental.agent.status}
-              </span>
-            )}
-          </div>
-
-          <div className="flex items-center justify-between pt-3 border-t border-bg-tertiary">
-            <div className="flex items-center gap-2">
-              <div className="w-6 h-6 rounded-full overflow-hidden bg-bg-tertiary">
+            <div className="flex items-center gap-2 mt-3 pt-3 border-t border-bg-tertiary">
+              <div className="w-6 h-6 rounded-full bg-bg-tertiary overflow-hidden">
                 {rental.tenant?.avatarUrl ? (
                   <img
                     src={rental.tenant.avatarUrl}
@@ -620,21 +641,23 @@ function RentalsTab({
                     className="w-full h-full object-cover"
                   />
                 ) : (
-                  <div className="w-full h-full flex items-center justify-center text-[10px] text-text-primary">
+                  <div className="w-full h-full flex items-center justify-center text-[10px]">
                     👤
                   </div>
                 )}
               </div>
               <span className="text-text-secondary text-[12px]">
-                {rental.tenant?.displayName ?? rental.tenant?.username ?? t('discover.unknownUser')}
+                {rental.tenant?.displayName || rental.tenant?.username || t('discover.unknownUser')}
               </span>
-            </div>
-            <div className="text-text-muted text-[12px]">
-              {t('discover.rentedSince')} {formatTimeAgo(rental.startedAt)}
+              <span className="text-text-muted text-[12px]">
+                · {rental.listing?.hourlyRate}虾币/h
+              </span>
             </div>
           </div>
         </div>
-      ))}
-    </div>
-  )
+      </div>
+    )
+  }
+
+  return null
 }

--- a/apps/web/src/pages/discover.tsx
+++ b/apps/web/src/pages/discover.tsx
@@ -323,7 +323,7 @@ export function DiscoverPage() {
           ) : allItems.length === 0 ? (
             <EmptyState isSearching={isSearching} t={t} />
           ) : (
-            <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {allItems.map((item, index) => (
                 <FeedCard
                   key={`${item.type}-${item.id}-${index}`}
@@ -414,77 +414,83 @@ function FeedCard({
             })
           }
         }}
-        className="bg-bg-secondary rounded-2xl p-4 hover:bg-[#383a40] transition cursor-pointer border border-[#1e1f22] group"
+        className="bg-bg-secondary rounded-2xl overflow-hidden hover:bg-[#383a40] hover:-translate-y-0.5 hover:shadow-xl transition-all duration-200 cursor-pointer border border-[#1e1f22] group relative"
       >
-        <div className="flex gap-4">
-          {/* Server Icon */}
-          <div className="relative shrink-0">
-            <div className="w-16 h-16 rounded-2xl overflow-hidden bg-bg-tertiary">
-              {server.iconUrl ? (
-                <img src={server.iconUrl} alt="" className="w-full h-full object-cover" />
-              ) : (
-                <img src={getCatAvatar(0)} alt={server.name} className="w-full h-full" />
-              )}
-            </div>
-            {server.isPublic && (
-              <div className="absolute -top-1 -right-1 w-5 h-5 bg-green-500 rounded-full flex items-center justify-center">
-                <Shield size={10} className="text-white" />
-              </div>
+        {/* Banner */}
+        <div className="h-[120px] bg-gradient-to-br from-[#5865F2]/20 to-[#5865F2]/5 relative">
+          {server.bannerUrl ? (
+            <img
+              src={server.bannerUrl}
+              alt=""
+              className="w-full h-full object-cover absolute inset-0"
+            />
+          ) : null}
+          {server.isPublic && (
+            <span className="absolute top-3 right-3 flex items-center gap-1 px-2.5 py-1 bg-black/50 backdrop-blur-md text-white text-[11px] font-bold rounded-full z-10 uppercase tracking-widest">
+              <Shield size={12} />
+              {t('discover.public')}
+            </span>
+          )}
+        </div>
+
+        {/* Icon overlay */}
+        <div className="absolute top-[92px] left-4 p-1.5 bg-bg-secondary group-hover:bg-[#383a40] rounded-[18px] transition-colors duration-200 z-20">
+          <div className="w-[48px] h-[48px] rounded-[12px] overflow-hidden bg-bg-tertiary flex items-center justify-center">
+            {server.iconUrl ? (
+              <img src={server.iconUrl} alt="" className="w-full h-full object-cover" />
+            ) : (
+              <img src={getCatAvatar(0)} alt={server.name} className="w-9 h-9" />
             )}
           </div>
+        </div>
 
-          {/* Content */}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-start justify-between gap-2">
-              <div>
-                <h3 className="font-bold text-text-primary text-[16px] truncate">{server.name}</h3>
-                <div className="flex items-center gap-3 mt-1">
-                  <span className="flex items-center gap-1 text-[12px] text-text-muted">
-                    <Users size={12} />
-                    {server.memberCount} {t('discover.members')}
-                  </span>
-                  {heat.icon && (
-                    <span className={['flex items-center gap-1 text-[12px]', heat.color].join(' ')}>
-                      <heat.icon size={12} />
-                      {t('discover.heat.hot')}
-                    </span>
-                  )}
-                </div>
-              </div>
+        {/* Content */}
+        <div className="pt-10 p-4 flex flex-col flex-1">
+          <h3 className="font-bold text-[#f2f3f5] text-[16px] mb-1 truncate">{server.name}</h3>
+          <p className="text-text-primary text-[14px] mb-4 line-clamp-2 min-h-[2.5rem] flex-1">
+            {server.description ?? t('discover.noDescription')}
+          </p>
 
-              {isJoined ? (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    navigate({
-                      to: '/servers/$serverSlug',
-                      params: { serverSlug: server.slug ?? server.id },
-                    })
-                  }}
-                  className="px-4 py-1.5 bg-green-500 hover:bg-green-600 text-white rounded-lg text-[13px] font-medium transition"
-                >
-                  {t('discover.enterButton')}
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    joinMutation.mutate({ inviteCode: server.inviteCode })
-                  }}
-                  disabled={joinMutation.isPending}
-                  className="px-4 py-1.5 bg-primary hover:bg-primary/80 text-white rounded-lg text-[13px] font-medium transition disabled:opacity-50"
-                >
-                  {t('discover.joinButton')}
-                </button>
+          <div className="flex items-center justify-between mt-auto">
+            <div className="flex items-center gap-2">
+              <span className="flex items-center gap-1.5 text-[12px] font-medium text-text-muted">
+                <div className="w-2 h-2 rounded-full bg-[#23a559]"></div>
+                {server.memberCount} {t('discover.members')}
+              </span>
+              {heat.icon && (
+                <span className={['flex items-center gap-1 text-[12px]', heat.color].join(' ')}>
+                  <heat.icon size={12} />
+                  {t('discover.heat.hot')}
+                </span>
               )}
             </div>
 
-            {server.description && (
-              <p className="text-text-secondary text-[14px] mt-2 line-clamp-2">
-                {server.description}
-              </p>
+            {isJoined ? (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  navigate({
+                    to: '/servers/$serverSlug',
+                    params: { serverSlug: server.slug ?? server.id },
+                  })
+                }}
+                className="flex items-center gap-1.5 px-4 py-1.5 bg-[#23a559] hover:bg-[#1d8749] text-white rounded-[3px] text-[14px] font-medium transition"
+              >
+                {t('discover.enterButton')}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  joinMutation.mutate({ inviteCode: server.inviteCode })
+                }}
+                disabled={joinMutation.isPending}
+                className="flex items-center gap-1.5 px-4 py-1.5 bg-[#5865F2] hover:bg-[#4752C4] text-white rounded-[3px] text-[14px] font-medium transition disabled:opacity-50"
+              >
+                {t('discover.joinButton')}
+              </button>
             )}
           </div>
         </div>

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -15,7 +15,7 @@ import {
   User,
   Users,
 } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { UserAvatar } from '../../components/common/avatar'
 import { useAppStatus } from '../../hooks/use-app-status'
@@ -141,6 +141,16 @@ export function SettingsPage() {
   )
   const [activeDmChannelId, setActiveDmChannelId] = useState<string | null>(searchParams.dm || null)
   const [collapsed, setCollapsed] = useState(loadCollapsedState)
+
+  // Sync activeTab with URL search params
+  useEffect(() => {
+    if (searchParams.tab) {
+      setActiveTab(searchParams.tab as SettingsTab)
+    }
+    if (searchParams.dm !== undefined) {
+      setActiveDmChannelId(searchParams.dm || null)
+    }
+  }, [searchParams.tab, searchParams.dm])
 
   const toggleSection = useCallback((key: string) => {
     setCollapsed((prev) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,13 +16,13 @@ importers:
         version: 2.4.8
       '@commitlint/cli':
         specifier: ^20.5.0
-        version: 20.5.0(@types/node@25.3.3)(conventional-commits-parser@6.3.0)(typescript@5.9.3)
+        version: 20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)
       '@commitlint/config-conventional':
         specifier: ^20.5.0
         version: 20.5.0
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.3.3)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -34,7 +34,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.3.3)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/admin:
     dependencies:
@@ -459,12 +459,15 @@ importers:
       '@types/mime-types':
         specifier: ^2.1.4
         version: 2.1.4
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.3.3)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
@@ -476,7 +479,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.3.3)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -591,7 +594,7 @@ importers:
         version: 4.2.2
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.3.3)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cli:
     dependencies:
@@ -4995,8 +4998,8 @@ packages:
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
-  '@types/node@25.3.3':
-    resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
@@ -13380,11 +13383,11 @@ snapshots:
   '@cloudflare/workers-types@4.20260120.0':
     optional: true
 
-  '@commitlint/cli@20.5.0(@types/node@25.3.3)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
+  '@commitlint/cli@20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 20.5.0
       '@commitlint/lint': 20.5.0
-      '@commitlint/load': 20.5.0(@types/node@25.3.3)(typescript@5.9.3)
+      '@commitlint/load': 20.5.0(@types/node@25.5.0)(typescript@5.9.3)
       '@commitlint/read': 20.5.0(conventional-commits-parser@6.3.0)
       '@commitlint/types': 20.5.0
       tinyexec: 1.0.4
@@ -13433,14 +13436,14 @@ snapshots:
       '@commitlint/rules': 20.5.0
       '@commitlint/types': 20.5.0
 
-  '@commitlint/load@20.5.0(@types/node@25.3.3)(typescript@5.9.3)':
+  '@commitlint/load@20.5.0(@types/node@25.5.0)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.5.0
       '@commitlint/types': 20.5.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.3.3)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.5.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
       is-plain-obj: 4.1.0
       lodash.mergewith: 4.6.2
       picocolors: 1.1.1
@@ -17308,7 +17311,7 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.3.3':
+  '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
 
@@ -17404,7 +17407,7 @@ snapshots:
       '@urql/core': 5.2.0
       wonka: 6.3.5
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.3.3)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -17416,7 +17419,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.3.3)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -17435,13 +17438,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -18516,9 +18519,9 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@25.3.3)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.2.0(@types/node@25.5.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -25214,7 +25217,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -25223,7 +25226,7 @@ snapshots:
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -25261,10 +25264,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@types/node@25.3.3)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -25281,10 +25284,10 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.0
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

Add new discover endpoints and UI tabs for:
- Public channels with latest messages
- Active buddy rentals

## Changes

### Backend
- Add GET /api/discover/channels endpoint - returns public channels from public servers with latest messages
- Add GET /api/discover/rentals endpoint - returns currently active buddy rentals

### Web
- Update discover page with tabs (Servers/Channels/Rentals)
- Servers tab: existing functionality with join/enter buttons
- Channels tab: shows public channels with last message preview
- Rentals tab: shows active rentals with agent info

### Translations
- Add i18n translations for new features (en/zh-CN)

## Testing
- Type check passed
- Lint passed

## Screenshots
N/A - UI follows existing explore servers style for consistency.