### PR TITLE
docs(decisions): add OAuth open platform design decision

### DIFF
--- a/docs/decisions/oauth-platform-design.md
+++ b/docs/decisions/oauth-platform-design.md
@@ -1,0 +1,287 @@
+# OAuth Open Platform Design Decision
+
+> **Decision ID**: DEC-001
+> **Decision Date**: 2026-03-29
+> **Status**: Approved
+> **Decision Maker**: Peng Mao
+> **Recorder**: Xiao Zha
+
+---
+
+## 1. Background
+
+Shadow (虾豆) aims to enable third-party service providers to access user accounts through OAuth authorization. Target providers include news, gaming, and creative services that need to:
+
+- Establish connections with the community
+- Create servers or invite users to join servers after authorization
+- Push messages to channels and interact with users
+
+The existing OAuth implementation supports basic Authorization Code Flow, but scope is limited to `user:read` and `user:email`. This decision document defines the expansion into a full open platform.
+
+---
+
+## 2. Decision Summary
+
+| Decision Item | Decision |
+|---------------|----------|
+| Scope Expansion | Expand to servers, channels, messages, attachments, workspaces, and Buddy |
+| Token Strategy | Keep Opaque Token (no JWT migration) |
+| PKCE Support | Phase 1: Not supported (service providers are server-side apps using client_secret) |
+| Developer Portal | Required; Phase 1 includes App management, authorization stats, API docs |
+| Provider Onboarding | Self-registration; review mechanism can be added later |
+| Enterprise Features | Phase 1: Not needed; extensibility reserved |
+| Scope Validation | Middleware-based unified validation + route-declared scopes |
+| Buddy Design | Buddy = Agent + User; associated with OAuth App sub-accounts |
+
+---
+
+## 3. Scope Design
+
+### 3.1 Scope List
+
+| Scope | Description | Resource |
+|-------|-------------|----------|
+| `user:read` | Read basic user information | User |
+| `user:email` | Read user email (requires user:read) | User |
+| `servers:read` | Read user's server list | Server |
+| `servers:write` | Create servers, invite users to join servers | Server |
+| `channels:read` | Read server channel list | Channel |
+| `channels:write` | Create channels | Channel |
+| `messages:read` | Read channel message history | Message |
+| `messages:write` | Send messages to channels | Message |
+| `attachments:read` | Read attachment information | Attachment |
+| `attachments:write` | Upload attachments | Attachment |
+| `workspaces:read` | Read workspace information | Workspace |
+| `workspaces:write` | Create/modify workspace nodes | Workspace |
+| `buddies:create` | Create Buddy Bot | Buddy (Agent + User) |
+| `buddies:manage` | Manage Buddy (send messages, configure, etc.) | Buddy |
+
+### 3.2 Scope Groups (for authorization page display)
+
+| Group | Included Scopes | Description |
+|-------|-----------------|-------------|
+| **User Info** | `user:read`, `user:email` | Basic identity information |
+| **Servers** | `servers:read`, `servers:write` | Server management and invitations |
+| **Channels & Messages** | `channels:read`, `channels:write`, `messages:read`, `messages:write` | Content interaction |
+| **Attachments** | `attachments:read`, `attachments:write` | File uploads |
+| **Workspaces** | `workspaces:read`, `workspaces:write` | Project file management |
+| **Buddy** | `buddies:create`, `buddies:manage` | Bot creation and management |
+
+### 3.3 Scope Validation Mechanism
+
+Middleware-based unified validation + route-declared scopes:
+
+```typescript
+// Middleware implementation example
+export function oauthScopeMiddleware(requiredScopes: string[]) {
+  return async (c: Context, next: Next) => {
+    const token = c.get('oauthToken') // from authMiddleware
+    const grantedScopes = token.scope.split(' ')
+    
+    const hasAllScopes = requiredScopes.every(s => grantedScopes.includes(s))
+    if (!hasAllScopes) {
+      return c.json({ error: 'insufficient_scope', required: requiredScopes }, 403)
+    }
+    
+    await next()
+  }
+}
+
+// Route definition example
+oauthHandler.get('/servers', 
+  oauthAuthMiddleware,           // OAuth token validation
+  oauthScopeMiddleware(['servers:read']),
+  async (c) => { ... }
+)
+```
+
+---
+
+## 4. Buddy Design
+
+### 4.1 Buddy Definition
+
+Buddy is a virtual Bot created by service providers with dual identity:
+- **User Identity**: User record in `users` table with `isBot = true`, can join servers and channels
+- **Agent Identity**: Agent record in `agents` table, can execute AI tasks
+
+### 4.2 Data Model Extensions
+
+New fields to associate Buddy with OAuth App:
+
+```sql
+-- users table extension
+ALTER TABLE users ADD COLUMN oauth_app_id UUID REFERENCES oauth_apps(id);
+ALTER TABLE users ADD COLUMN parent_user_id UUID REFERENCES users(id); -- parent account for sub-account
+
+-- agents table extension
+ALTER TABLE agents ADD COLUMN oauth_app_id UUID REFERENCES oauth_apps(id);
+ALTER TABLE agents ADD COLUMN buddy_user_id UUID REFERENCES users(id); -- Buddy's associated User
+```
+
+### 4.3 Buddy Creation Flow
+
+```
+OAuth App (Service Provider)
+    ↓ creates sub-account
+Sub-account (users, isBot=true, oauth_app_id=app.id)
+    ↓ creates Buddy
+Buddy Agent (agents, buddy_user_id=sub-account.id, oauth_app_id=app.id)
+```
+
+### 4.4 Buddy Capabilities
+
+- Controlled by OAuth App to send messages (via `messages:write` scope)
+- Join servers and channels (as a regular user)
+- Optional: Execute AI tasks (Agent capabilities)
+
+---
+
+## 5. Token Strategy
+
+### 5.1 Decision: Keep Opaque Token
+
+Phase 1 maintains the current Opaque Token strategy, no JWT migration.
+
+| Token Type | Format | Storage | Expiration |
+|------------|--------|----------|------------|
+| Access Token | `oat_xxx` | SHA-256 hash in database | 1 hour |
+| Refresh Token | `ort_xxx` | SHA-256 hash in database | 30 days |
+
+### 5.2 Future Extensions
+
+If stateless validation or high-volume API calls are needed later:
+- JWT Access Token (15min) + Opaque Refresh Token
+- Redis blacklist for instant revocation
+
+---
+
+## 6. Developer Portal
+
+### 6.1 Phase 1 Feature Scope
+
+| Module | Content |
+|--------|---------|
+| **OAuth App Management** | Create, edit, delete App; view Client ID; reset Secret (shown once at creation) |
+| **Authorization Stats** | Authorized user list; authorization stats by date |
+| **API Docs** | OAuth integration guide; Scope descriptions; SDK usage examples; Error codes |
+
+### 6.2 Portal Location
+
+Under API docs page in `website`:
+- `/docs/api/oauth` - API documentation
+- `/docs/api/oauth/apps` - App management (requires login)
+
+### 6.3 Reserved Extensions
+
+- App review entry (disabled initially)
+- Advanced stats (API call volume, error rate, response time)
+- Webhook configuration
+
+---
+
+## 7. Service Provider Onboarding
+
+### 7.1 Phase 1: Self-Registration
+
+```
+1. Service provider developer registers Shadow account
+2. Access developer portal, create OAuth App
+3. Configure redirect_uri, select scopes
+4. Immediately obtain Client ID/Secret, start integration
+```
+
+### 7.2 Future Extension: Sensitive Scope Review
+
+For sensitive scopes (e.g., large-scale `servers:write` invitations):
+- Application review process
+- Usage monitoring
+- Violation penalty mechanism
+
+---
+
+## 8. API Endpoint Design
+
+### 8.1 OAuth Provider Endpoints (existing + extensions)
+
+| Endpoint | Method | Description | Scope |
+|----------|--------|-------------|-------|
+| `/api/oauth/apps` | POST | Create OAuth App | Login required |
+| `/api/oauth/apps` | GET | List my Apps | Login required |
+| `/api/oauth/apps/:id` | PATCH | Update App | Login required |
+| `/api/oauth/apps/:id` | DELETE | Delete App | Login required |
+| `/api/oauth/apps/:id/reset-secret` | POST | Reset Secret | Login required |
+| `/oauth/authorize` | GET | Authorization page | Login required |
+| `/api/oauth/authorize` | POST | User approves authorization | Login required |
+| `/api/oauth/token` | POST | Exchange Token | Public |
+| `/api/oauth/userinfo` | GET | User information | `user:read` |
+
+### 8.2 OAuth API Endpoints (new)
+
+| Endpoint | Method | Description | Scope |
+|----------|--------|-------------|-------|
+| `/api/oauth/servers` | GET | User's server list | `servers:read` |
+| `/api/oauth/servers` | POST | Create server | `servers:write` |
+| `/api/oauth/servers/:id/invite` | POST | Invite user to join | `servers:write` |
+| `/api/oauth/servers/:id/channels` | GET | Channel list | `channels:read` |
+| `/api/oauth/channels` | POST | Create channel | `channels:write` |
+| `/api/oauth/channels/:id/messages` | GET | Message history | `messages:read` |
+| `/api/oauth/channels/:id/messages` | POST | Send message | `messages:write` |
+| `/api/oauth/attachments` | POST | Upload attachment | `attachments:write` |
+| `/api/oauth/workspaces/:id` | GET | Workspace info | `workspaces:read` |
+| `/api/oauth/buddies` | POST | Create Buddy | `buddies:create` |
+| `/api/oauth/buddies/:id/messages` | POST | Buddy send message | `buddies:manage` |
+
+---
+
+## 9. Implementation Plan
+
+### 9.1 Phase 1: Scope Expansion
+
+- Expand scope definitions and validation
+- Add OAuth API endpoints (servers, channels, messages)
+- Update `@shadowob/oauth` SDK
+
+### 9.2 Phase 2: Buddy Support
+
+- Data model extensions (users, agents tables)
+- Buddy creation API
+- Buddy message sending API
+
+### 9.3 Phase 3: Developer Portal
+
+- OAuth App management page
+- Authorization stats page
+- API documentation page
+
+---
+
+## 10. Risks and Mitigation
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Provider abuses invitation feature | Mass spam invitations | Monitor invitation volume, set thresholds, anomaly alerts |
+| Buddy abuses message push | Channel flooded with spam | Message rate limits, users can block Buddy |
+| OAuth App Secret leaked | Security risk | Secret shown only once, reset supported, IP whitelist (reserved) |
+
+---
+
+## 11. Appendix
+
+### 11.1 Existing OAuth Implementation
+
+See `docs/oauth.md` and:
+- `packages/oauth/` - OAuth SDK
+- `apps/server/src/services/oauth.service.ts` - OAuth service
+- `apps/server/src/handlers/oauth.handler.ts` - OAuth handler
+- `apps/server/src/db/schema/oauth.ts` - Data models
+
+### 11.2 References
+
+- OAuth 2.0 Specification: https://oauth.net/2/
+- Discord OAuth Design: https://discord.com/developers/docs/topics/oauth2
+- Slack OAuth Design: https://api.slack.com/docs/oauth
+
+---
+
+_Document recorded by Xiao Zha, confirmed by Peng Mao._

--- a/docs/decisions/oauth-platform-design.zh-CN.md
+++ b/docs/decisions/oauth-platform-design.zh-CN.md
@@ -1,0 +1,287 @@
+# OAuth 开放平台设计决策
+
+> **决策编号**: DEC-001
+> **决策日期**: 2026-03-29
+> **状态**: 已批准
+> **决策者**: 彭猫
+> **记录者**: 小炸
+
+---
+
+## 1. 背景
+
+虾豆（Shadow）旨在通过 OAuth 授权使第三方服务商能够访问用户账号。目标服务商包括资讯、游戏、创意类服务，需要：
+
+- 与社区建立连接
+- 用户授权后创建服务器或邀请用户加入服务器
+- 推送消息到频道，与用户互动
+
+现有 OAuth 实现支持基础的 Authorization Code Flow，但 scope 仅限于 `user:read` 和 `user:email`。本文档定义扩展为完整开放平台的决策。
+
+---
+
+## 2. 决策摘要
+
+| 决策项 | 决策结果 |
+|--------|----------|
+| Scope 扩展 | 扩展至服务器、频道、消息、附件、工作区、Buddy |
+| Token 方案 | 保持 Opaque Token（不迁移 JWT） |
+| PKCE 支持 | 第一期不支持（服务商为服务端应用，使用 client_secret） |
+| 开发者门户 | 需要开发；第一期包含 App 管理、授权统计、API 文档 |
+| 服务商入驻 | 自助注册；后续可增加审核机制 |
+| 企业级功能 | 第一期不需要；预留扩展性 |
+| Scope 验证 | 中间件统一验证 + 路由声明 scope |
+| Buddy 设计 | Buddy = Agent + User；关联 OAuth App 子账户 |
+
+---
+
+## 3. Scope 设计
+
+### 3.1 Scope 列表
+
+| Scope | 描述 | 对应资源 |
+|-------|------|----------|
+| `user:read` | 读取用户基本信息 | User |
+| `user:email` | 读取用户邮箱（需配合 user:read） | User |
+| `servers:read` | 读取用户所在服务器列表 | Server |
+| `servers:write` | 创建服务器、邀请用户加入服务器 | Server |
+| `channels:read` | 读取服务器频道列表 | Channel |
+| `channels:write` | 创建频道 | Channel |
+| `messages:read` | 读取频道消息历史 | Message |
+| `messages:write` | 发送消息到频道 | Message |
+| `attachments:read` | 读取附件信息 | Attachment |
+| `attachments:write` | 上传附件 | Attachment |
+| `workspaces:read` | 读取工作区信息 | Workspace |
+| `workspaces:write` | 创建/修改工作区节点 | Workspace |
+| `buddies:create` | 创建 Buddy Bot | Buddy (Agent + User) |
+| `buddies:manage` | 管理 Buddy（发送消息、配置等） | Buddy |
+
+### 3.2 Scope 分组（供授权页面展示）
+
+| 分组 | 包含 Scope | 说明 |
+|------|------------|------|
+| **用户信息** | `user:read`, `user:email` | 基础身份信息 |
+| **服务器** | `servers:read`, `servers:write` | 服务器管理与邀请 |
+| **频道与消息** | `channels:read`, `channels:write`, `messages:read`, `messages:write` | 内容交互 |
+| **附件** | `attachments:read`, `attachments:write` | 文件上传 |
+| **工作区** | `workspaces:read`, `workspaces:write` | 项目文件管理 |
+| **Buddy** | `buddies:create`, `buddies:manage` | Bot 创建与管理 |
+
+### 3.3 Scope 验证机制
+
+采用中间件统一验证 + 路由声明 scope：
+
+```typescript
+// 中间件实现示例
+export function oauthScopeMiddleware(requiredScopes: string[]) {
+  return async (c: Context, next: Next) => {
+    const token = c.get('oauthToken') // 从 authMiddleware 获取
+    const grantedScopes = token.scope.split(' ')
+    
+    const hasAllScopes = requiredScopes.every(s => grantedScopes.includes(s))
+    if (!hasAllScopes) {
+      return c.json({ error: 'insufficient_scope', required: requiredScopes }, 403)
+    }
+    
+    await next()
+  }
+}
+
+// 路由定义示例
+oauthHandler.get('/servers', 
+  oauthAuthMiddleware,           // OAuth token 验证
+  oauthScopeMiddleware(['servers:read']),
+  async (c) => { ... }
+)
+```
+
+---
+
+## 4. Buddy 设计
+
+### 4.1 Buddy 定义
+
+Buddy 是服务商创建的虚拟 Bot，具有双重身份：
+- **User 身份**: `users` 表中 `isBot = true` 的用户，可以加入服务器和频道
+- **Agent 身份**: `agents` 表中的 Agent，可以执行 AI 任务
+
+### 4.2 数据模型扩展
+
+新增字段关联 Buddy 到 OAuth App：
+
+```sql
+-- users 表扩展
+ALTER TABLE users ADD COLUMN oauth_app_id UUID REFERENCES oauth_apps(id);
+ALTER TABLE users ADD COLUMN parent_user_id UUID REFERENCES users(id); -- 子账户的父账户
+
+-- agents 表扩展
+ALTER TABLE agents ADD COLUMN oauth_app_id UUID REFERENCES oauth_apps(id);
+ALTER TABLE agents ADD COLUMN buddy_user_id UUID REFERENCES users(id); -- Buddy 关联的 User
+```
+
+### 4.3 Buddy 创建流程
+
+```
+OAuth App (服务商)
+    ↓ 创建子账户
+子账户 (users, isBot=true, oauth_app_id=app.id)
+    ↓ 创建 Buddy
+Buddy Agent (agents, buddy_user_id=子账户.id, oauth_app_id=app.id)
+```
+
+### 4.4 Buddy 能力
+
+- 被 OAuth App 控制发送消息（通过 `messages:write` scope）
+- 加入服务器、频道（作为普通用户）
+- 可选：执行 AI 任务（Agent 能力）
+
+---
+
+## 5. Token 方案
+
+### 5.1 决策：保持 Opaque Token
+
+第一期保持当前 Opaque Token 方案，不迁移 JWT。
+
+| Token 类型 | 格式 | 存储方式 | 过期时间 |
+|------------|------|----------|----------|
+| Access Token | `oat_xxx` | SHA-256 hash 存数据库 | 1 小时 |
+| Refresh Token | `ort_xxx` | SHA-256 hash 存数据库 | 30 天 |
+
+### 5.2 后续扩展考虑
+
+如果未来需要无状态验证或大规模 API 调用：
+- JWT Access Token（15min）+ Opaque Refresh Token
+- Redis 黑名单支持即时撤销
+
+---
+
+## 6. 开发者门户
+
+### 6.1 第一期功能范围
+
+| 功能模块 | 内容 |
+|----------|------|
+| **OAuth App 管理** | 创建、编辑、删除 App；查看 Client ID；重置 Secret（创建时显示一次） |
+| **授权统计** | 已授权用户列表；按日期授权统计 |
+| **API 文档** | OAuth 接入指南；Scope 说明；SDK 使用示例；错误码说明 |
+
+### 6.2 入口位置
+
+放在 `website` 的 API 文档页面下方：
+- `/docs/api/oauth` - API 文档
+- `/docs/api/oauth/apps` - App 管理（需登录）
+
+### 6.3 预留扩展
+
+- App 审核入口（暂不启用）
+- 高级统计（API 调用量、错误率、响应时间）
+- Webhook 配置
+
+---
+
+## 7. 服务商入驻流程
+
+### 7.1 第一期：自助注册
+
+```
+1. 服务商开发者注册虾豆账号
+2. 进入开发者门户，创建 OAuth App
+3. 配置 redirect_uri、选择 scope
+4. 立即获得 Client ID/Secret，可开始接入
+```
+
+### 7.2 后续扩展：敏感 Scope 审核
+
+对于敏感 scope（如大规模 `servers:write` 邀请）：
+- 申请审核流程
+- 使用量监控
+- 违规处罚机制
+
+---
+
+## 8. API 端点设计
+
+### 8.1 OAuth Provider 端点（现有 + 扩展）
+
+| 端点 | 方法 | 说明 | Scope |
+|------|------|------|-------|
+| `/api/oauth/apps` | POST | 创建 OAuth App | 需登录 |
+| `/api/oauth/apps` | GET | 列出我的 App | 需登录 |
+| `/api/oauth/apps/:id` | PATCH | 更新 App | 需登录 |
+| `/api/oauth/apps/:id` | DELETE | 删除 App | 需登录 |
+| `/api/oauth/apps/:id/reset-secret` | POST | 重置 Secret | 需登录 |
+| `/oauth/authorize` | GET | 授权页面 | 需登录 |
+| `/api/oauth/authorize` | POST | 用户同意授权 | 需登录 |
+| `/api/oauth/token` | POST | 交换 Token | 公开 |
+| `/api/oauth/userinfo` | GET | 用户信息 | `user:read` |
+
+### 8.2 OAuth API 端点（新增）
+
+| 端点 | 方法 | 说明 | Scope |
+|------|------|------|-------|
+| `/api/oauth/servers` | GET | 用户服务器列表 | `servers:read` |
+| `/api/oauth/servers` | POST | 创建服务器 | `servers:write` |
+| `/api/oauth/servers/:id/invite` | POST | 邀请用户加入 | `servers:write` |
+| `/api/oauth/servers/:id/channels` | GET | 频道列表 | `channels:read` |
+| `/api/oauth/channels` | POST | 创建频道 | `channels:write` |
+| `/api/oauth/channels/:id/messages` | GET | 消息历史 | `messages:read` |
+| `/api/oauth/channels/:id/messages` | POST | 发送消息 | `messages:write` |
+| `/api/oauth/attachments` | POST | 上传附件 | `attachments:write` |
+| `/api/oauth/workspaces/:id` | GET | 工作区信息 | `workspaces:read` |
+| `/api/oauth/buddies` | POST | 创建 Buddy | `buddies:create` |
+| `/api/oauth/buddies/:id/messages` | POST | Buddy 发送消息 | `buddies:manage` |
+
+---
+
+## 9. 实施计划
+
+### 9.1 第一阶段：Scope 扩展
+
+- 扩展 scope 定义和验证
+- 新增 OAuth API 端点（服务器、频道、消息）
+- 更新 `@shadowob/oauth` SDK
+
+### 9.2 第二阶段：Buddy 支持
+
+- 数据模型扩展（users、agents 表）
+- Buddy 创建 API
+- Buddy 消息发送 API
+
+### 9.3 第三阶段：开发者门户
+
+- OAuth App 管理页面
+- 授权统计页面
+- API 文档页面
+
+---
+
+## 10. 风险与缓解
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| 服务商滥用邀请功能 | 大量垃圾邀请 | 监控邀请量、设置阈值、异常告警 |
+| Buddy 滥用消息推送 | 频道被垃圾消息淹没 | 消息频率限制、用户可屏蔽 Buddy |
+| OAuth App 泄露 Secret | 安全风险 | Secret 仅显示一次、支持重置、IP 白名单（预留） |
+
+---
+
+## 11. 附录
+
+### 11.1 现有 OAuth 实现
+
+参见 `docs/oauth.md` 和以下代码：
+- `packages/oauth/` - OAuth SDK
+- `apps/server/src/services/oauth.service.ts` - OAuth 服务
+- `apps/server/src/handlers/oauth.handler.ts` - OAuth Handler
+- `apps/server/src/db/schema/oauth.ts` - 数据模型
+
+### 11.2 参考资料
+
+- OAuth 2.0 规范: https://oauth.net/2/
+- Discord OAuth 设计: https://discord.com/developers/docs/topics/oauth2
+- Slack OAuth 设计: https://api.slack.com/docs/oauth
+
+---
+
+_文档由小炸记录，彭猫确认。_

--- a/packages/openclaw-shadowob/skills/shadowob/SKILL.md
+++ b/packages/openclaw-shadowob/skills/shadowob/SKILL.md
@@ -197,36 +197,20 @@ shadowob workspace folders delete <folder-id>
 ```bash
 # Shop info
 shadowob shop get <server-id> --json
-shadowob shop update <server-id> [--name <name>] [--description <desc>] --json
-
-# Categories
-shadowob shop categories list <server-id> --json
-shadowob shop categories create <server-id> --name <name> [--description <desc>] --json
-shadowob shop categories update <category-id> [--name <name>] [--description <desc>] --json
-shadowob shop categories delete <category-id>
 
 # Products
-shadowob shop products list <server-id> [--category-id <id>] --json
-shadowob shop products get <product-id> --json
-shadowob shop products create <server-id> --name <name> --price <n> [--description <desc>] [--category-id <id>] [--stock <n>] --json
-shadowob shop products update <product-id> [--name <name>] [--price <n>] [--description <desc>] [--stock <n>] --json
-shadowob shop products delete <product-id>
+shadowob shop products list <server-id> --json
+shadowob shop products get <server-id> <product-id> --json
 
 # Cart
 shadowob shop cart list <server-id> --json
-shadowob shop cart add <server-id> --product-id <id> [--quantity <n>] --json
-shadowob shop cart update <item-id> --quantity <n> --json
-shadowob shop cart remove <item-id>
 
 # Orders
-shadowob shop orders list [--server-id <id>] --json
-shadowob shop orders get <order-id> --json
-shadowob shop orders create <server-id> [--note <text>] --json
+shadowob shop orders list <server-id> --json
+shadowob shop orders get <server-id> <order-id> --json
 
 # Wallet
 shadowob shop wallet balance --json
-shadowob shop wallet transactions [--limit <n>] --json
-shadowob shop wallet topup --amount <n> --json
 ```
 
 ## Apps
@@ -273,50 +257,42 @@ shadowob notifications preferences update [--email-enabled <bool>] [--push-enabl
 # List friends
 shadowob friends list --json
 
-# Requests
+# Friend requests
 shadowob friends requests [--incoming] [--outgoing] --json
-shadowob friends add <user-id> [--message <text>] --json
-shadowob friends accept <user-id> --json
-shadowob friends reject <user-id>
+shadowob friends add <username> [--message <text>] --json
+shadowob friends accept <request-id> --json
+shadowob friends reject <request-id> --json
 
-# Manage
-shadowob friends remove <user-id>
-shadowob friends block <user-id>
-shadowob friends unblock <user-id>
-shadowob friends blocked --json
+# Remove friend
+shadowob friends remove <friendship-id> --json
 ```
 
 ## Invites
 
 ```bash
-# List invites
-shadowob invites list <server-id> --json
+# List your invite codes
+shadowob invites list --json
 
-# Create/Revoke
-shadowob invites create <server-id> [--max-uses <n>] [--expires-in <hours>] --json
-shadowob invites revoke <invite-id>
-shadowob invites regenerate <server-id> --json
+# Create invite code
+shadowob invites create [--max-uses <n>] [--expires-in <hours>] --json
 
-# Get by code
-shadowob invites get <invite-code> --json
+# Deactivate/Delete invite
+shadowob invites deactivate <invite-id>
+shadowob invites delete <invite-id>
 ```
 
 ## OAuth
 
 ```bash
-# List apps
+# List OAuth apps
 shadowob oauth list --json
 
-# Get/Create/Update/Delete
-shadowob oauth get <app-id> --json
+# Create OAuth app
 shadowob oauth create --name <name> [--description <desc>] [--redirect-uri <uri>] [--homepage <url>] --json
+
+# Update/Delete OAuth app
 shadowob oauth update <app-id> [--name <name>] [--description <desc>] [--redirect-uri <uri>] [--homepage <url>] --json
 shadowob oauth delete <app-id>
-shadowob oauth regenerate-secret <app-id> --json
-
-# Tokens
-shadowob oauth tokens list --json
-shadowob oauth tokens revoke <token-id>
 ```
 
 ## Marketplace
@@ -340,23 +316,18 @@ shadowob marketplace contracts extend <contract-id> --hours <n> --json
 ## Media
 
 ```bash
-# Upload/Download
+# Upload a file
 shadowob media upload --file <path> [--server-id <id>] [--channel-id <id>] --json
-shadowob media download <content-ref> [--output <path>]
-shadowob media delete <content-ref>
-shadowob media list [--server-id <id>] [--channel-id <id>] [--limit <n>] --json
+
+# Download a file
+shadowob media download <file-url> [--output <path>]
 ```
 
 ## Search
 
 ```bash
-# Global search
-shadowob search global --query <text> [--server-id <id>] [--channel-id <id>] [--type <type>] [--limit <n>] --json
-
-# Specific searches
+# Search messages
 shadowob search messages --query <text> [--server-id <id>] [--channel-id <id>] [--author-id <id>] [--after <date>] [--before <date>] [--has-attachments] [--limit <n>] --json
-shadowob search users --query <text> [--limit <n>] --json
-shadowob search servers --query <text> [--limit <n>] --json
 ```
 
 ## Listen (Real-time Events)


### PR DESCRIPTION
## Summary

Add decision document DEC-001 for OAuth platform expansion.

### Key Decisions

- **Scope Expansion**: Extend to servers, channels, messages, attachments, workspaces, Buddy
- **Buddy Design**: Dual identity (Agent + User) linked to OAuth App sub-accounts
- **Token Strategy**: Keep Opaque Token (no JWT migration for Phase 1)
- **Scope Validation**: Middleware-based unified validation + route-declared scopes
- **Developer Portal**: Phase 1 includes App management, authorization stats, API docs

### Files

- `docs/decisions/oauth-platform-design.md` - English version
- `docs/decisions/oauth-platform-design.zh-CN.md` - Chinese translation

### Implementation Plan

- Phase 1: Scope expansion + OAuth API endpoints + SDK update
- Phase 2: Buddy support + data model extensions
- Phase 3: Developer portal