### PR TITLE
fix(security): remove hardcoded credentials from prod compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Copy this file to .env and fill in the values before running docker-compose.prod.yml
+# cp .env.example .env
+
+# ── Required ──────────────────────────────────────────────────────────────
+JWT_SECRET=              # Random string, min 32 chars. Generate: openssl rand -hex 32
+POSTGRES_PASSWORD=       # Strong password for PostgreSQL
+MINIO_ROOT_USER=         # MinIO admin username (alphanumeric)
+MINIO_ROOT_PASSWORD=     # MinIO admin password, min 8 chars
+ADMIN_PASSWORD=          # Admin account password for Shadow
+OAUTH_BASE_URL=          # Public URL of the web app, e.g. https://shadowob.com
+
+# ── Optional (sane defaults) ─────────────────────────────────────────────
+POSTGRES_USER=shadow
+POSTGRES_DB=shadow
+JWT_EXPIRES_IN=7d
+MINIO_BUCKET=shadow
+ADMIN_EMAIL=admin@shadowob.app
+ADMIN_USERNAME=admin
+
+# Stripe (only if accepting payments)
+# STRIPE_SECRET_KEY=sk_live_...
+# STRIPE_WEBHOOK_SECRET=whsec_...

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,18 +1,21 @@
 # Production docker-compose for public deployment
 # Usage: docker-compose -f docker-compose.prod.yml up -d
+#
+# ⚠️  All sensitive values MUST be provided via a .env file.
+#     See .env.example for required variables.
 
 services:
   postgres:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: shadow
-      POSTGRES_PASSWORD: shadow
-      POSTGRES_DB: shadow
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-shadow}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U shadow']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-shadow}']
       interval: 5s
       timeout: 3s
       retries: 5
@@ -33,8 +36,8 @@ services:
     restart: unless-stopped
     command: server /data --console-address ':9001'
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
     volumes:
       - miniodata:/data
     healthcheck:
@@ -51,22 +54,24 @@ services:
     ports:
       - '3002:3002'
     environment:
-      DATABASE_URL: postgresql://shadow:shadow@postgres:5432/shadow
+      DATABASE_URL: postgresql://${POSTGRES_USER:-shadow}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-shadow}
       REDIS_URL: redis://redis:6379
-      JWT_SECRET: shadow-prod-secret-change-me
-      JWT_EXPIRES_IN: 7d
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
+      JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-7d}
       PORT: 3002
       HOST: 0.0.0.0
       MINIO_ENDPOINT: minio
       MINIO_PORT: 9000
       MINIO_USE_SSL: 'false'
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
-      MINIO_BUCKET: shadow
-      ADMIN_EMAIL: admin@shadowob.app
-      ADMIN_PASSWORD: admin123456
-      ADMIN_USERNAME: admin
-      OAUTH_BASE_URL: http://120.53.105.115:3000
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+      MINIO_BUCKET: ${MINIO_BUCKET:-shadow}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@shadowob.app}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:?ADMIN_PASSWORD is required}
+      ADMIN_USERNAME: ${ADMIN_USERNAME:-admin}
+      OAUTH_BASE_URL: ${OAUTH_BASE_URL:?OAUTH_BASE_URL is required}
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -80,7 +85,7 @@ services:
       context: .
       dockerfile: apps/web/Dockerfile
       args:
-        VITE_API_BASE: http://120.53.105.115:3002
+        VITE_API_BASE: ${OAUTH_BASE_URL:?OAUTH_BASE_URL is required}/api
     restart: unless-stopped
     ports:
       - '3000:3000'


### PR DESCRIPTION
## Problem

`docker-compose.prod.yml` contained hardcoded default secrets:
- `JWT_SECRET: shadow-prod-secret-change-me`
- `ADMIN_PASSWORD: admin123456`
- `MINIO_ROOT_PASSWORD: minioadmin`

Anyone deploying with the default compose file would expose all credentials.

## Changes

- Replace all hardcoded values with `${VAR:?required}` guards — containers **refuse to start** without a `.env` file
- Add `.env.example` template with documentation and a command to generate ``JWT_SECRET``
- Add missing `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` env vars
- Remove hardcoded IP from `OAUTH_BASE_URL`

## Required env vars

`JWT_SECRET`, `POSTGRES_PASSWORD`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `ADMIN_PASSWORD`, `OAUTH_BASE_URL`
