### PR TITLE
fix(e2e): remove .skip() from OAuth developer E2E test

### DIFF
--- a/apps/desktop/e2e/05_web/02_oauth_developer.spec.ts
+++ b/apps/desktop/e2e/05_web/02_oauth_developer.spec.ts
@@ -95,7 +95,7 @@ async function cleanupTestData(origin: string, token: string) {
 test.describe
   .serial('OAuth Developer Settings — UI', () => {
     test.setTimeout(300_000) // 5 minutes — OAuth flow involves many API calls and UI transitions
-    test.skip('creates, inspects, and deletes an OAuth app from developer settings', async ({
+    test('creates, inspects, and deletes an OAuth app from developer settings', async ({
       browser,
     }) => {
       await ensureScreenshotDir()


### PR DESCRIPTION
Removes `test.skip()` that blocked all pushes via pre-push hook. The test should be enabled or deleted — having it skipped is a footgun.
