### PR TITLE
feat(server): relax message content limit to 16KB + auto-chunking

### DIFF
--- a/apps/server/__tests__/services.test.ts
+++ b/apps/server/__tests__/services.test.ts
@@ -266,6 +266,117 @@ describe('MessageService', () => {
       expect(result).toEqual([{ emoji: '👍', count: 2, userIds: ['u1', 'u2'] }])
     })
   })
+
+  describe('long content handling', () => {
+    it('should send message with content at the new 16KB limit', async () => {
+      const longContent = 'A'.repeat(16000)
+      const mockMessage = {
+        id: 'msg-long',
+        content: longContent,
+        channelId: 'ch1',
+        authorId: 'u1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isEdited: false,
+        isPinned: false,
+      }
+      const messageDao = createMockMessageDao({
+        create: vi.fn().mockResolvedValue(mockMessage),
+      })
+      const userDao = createMockUserDao({
+        findById: vi.fn().mockResolvedValue({
+          id: 'u1',
+          username: 'testuser',
+          displayName: 'Test',
+          isBot: false,
+        }),
+      })
+      const service = new MessageService({
+        messageDao: messageDao as any,
+        userDao: userDao as any,
+        channelDao: { updateLastMessageAt: vi.fn() } as any,
+        agentDao: {} as any,
+        agentDashboardDao: {} as any,
+      })
+
+      const result = await service.send('ch1', 'u1', { content: longContent })
+      expect(result.content).toBe(longContent)
+      expect(result.content.length).toBe(16000)
+    })
+
+    it('should send message with 8KB agent response', async () => {
+      const agentContent = 'This is a detailed agent response. '.repeat(200) // ~7200 chars
+      const mockMessage = {
+        id: 'msg-agent',
+        content: agentContent,
+        channelId: 'ch1',
+        authorId: 'bot-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isEdited: false,
+        isPinned: false,
+      }
+      const messageDao = createMockMessageDao({
+        create: vi.fn().mockResolvedValue(mockMessage),
+      })
+      const userDao = createMockUserDao({
+        findById: vi.fn().mockResolvedValue({
+          id: 'bot-1',
+          username: 'testbot',
+          displayName: 'Test Bot',
+          isBot: true,
+        }),
+      })
+      const service = new MessageService({
+        messageDao: messageDao as any,
+        userDao: userDao as any,
+        channelDao: { updateLastMessageAt: vi.fn() } as any,
+        agentDao: { findByUserId: vi.fn().mockResolvedValue(null) } as any,
+        agentDashboardDao: {
+          incrementMessageCount: vi.fn(),
+          incrementHourlyMessage: vi.fn(),
+          createEvent: vi.fn(),
+        } as any,
+      })
+
+      const result = await service.send('ch1', 'bot-1', { content: agentContent })
+      expect(result.content).toBe(agentContent)
+      expect(result.content.length).toBe(agentContent.length)
+    })
+
+    it('should update message with long content', async () => {
+      const longContent = 'B'.repeat(12000)
+      const existingMessage = {
+        id: 'msg1',
+        content: 'short',
+        channelId: 'ch1',
+        authorId: 'u1',
+      }
+      const updatedMessage = { ...existingMessage, content: longContent, isEdited: true }
+      const messageDao = createMockMessageDao({
+        findById: vi.fn().mockResolvedValue(existingMessage),
+        update: vi.fn().mockResolvedValue(updatedMessage),
+      })
+      const userDao = createMockUserDao({
+        findById: vi.fn().mockResolvedValue({
+          id: 'u1',
+          username: 'testuser',
+          displayName: 'Test',
+          isBot: false,
+        }),
+      })
+      const service = new MessageService({
+        messageDao: messageDao as any,
+        userDao: userDao as any,
+        channelDao: {} as any,
+        agentDao: {} as any,
+        agentDashboardDao: {} as any,
+      })
+
+      const result = await service.update('msg1', 'u1', { content: longContent })
+      expect(result.content).toBe(longContent)
+    })
+  })
 })
 
 describe('NotificationService', () => {

--- a/apps/server/__tests__/validators.test.ts
+++ b/apps/server/__tests__/validators.test.ts
@@ -108,8 +108,13 @@ describe('Message Validators', () => {
     })
 
     it('should reject content exceeding max length', () => {
-      const result = sendMessageSchema.safeParse({ content: 'a'.repeat(4001) })
+      const result = sendMessageSchema.safeParse({ content: 'a'.repeat(16001) })
       expect(result.success).toBe(false)
+    })
+
+    it('should accept content at exactly max length', () => {
+      const result = sendMessageSchema.safeParse({ content: 'a'.repeat(16000) })
+      expect(result.success).toBe(true)
     })
 
     it('should accept optional threadId as UUID', () => {

--- a/apps/server/src/handlers/dm.handler.ts
+++ b/apps/server/src/handlers/dm.handler.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import type { Server as SocketIOServer } from 'socket.io'
 import { z } from 'zod'
 import type { AppContainer } from '../container'
+import { LIMITS } from '@shadowob/shared'
 import { logger } from '../lib/logger'
 import { authMiddleware } from '../middleware/auth.middleware'
 
@@ -106,7 +107,7 @@ export function createDmHandler(container: AppContainer) {
     zValidator(
       'json',
       z.object({
-        content: z.string().min(1).max(4000),
+        content: z.string().min(1).max(LIMITS.MESSAGE_CONTENT_MAX),
         replyToId: z.string().uuid().optional(),
         attachments: z
           .array(
@@ -142,9 +143,9 @@ export function createDmHandler(container: AppContainer) {
       try {
         const channel = await dmService.getChannelById(id)
         if (channel) {
-          const otherUserId = (channel.userAId === user.userId ? channel.userBId : channel.userAId)!
+          const otherUserId = channel.userAId === user.userId ? channel.userBId : channel.userAId
           await relayDmToBot(io, container, id, user.userId, otherUserId, {
-            id: message.id!,
+            id: message.id,
             content: message.content ?? content,
             author: message.author,
             createdAt: message.createdAt,
@@ -171,7 +172,7 @@ export function createDmHandler(container: AppContainer) {
   // PATCH /api/dm/channels/:channelId/messages/:messageId — edit a DM message
   dmHandler.patch(
     '/channels/:channelId/messages/:messageId',
-    zValidator('json', z.object({ content: z.string().min(1).max(4000) })),
+    zValidator('json', z.object({ content: z.string().min(1).max(LIMITS.MESSAGE_CONTENT_MAX) })),
     async (c) => {
       const dmService = container.resolve('dmService')
       const channelId = c.req.param('channelId')

--- a/packages/openclaw-shadowob/__tests__/chunk.test.ts
+++ b/packages/openclaw-shadowob/__tests__/chunk.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { chunkText } from '../src/outbound.js'
+
+describe('chunkText', () => {
+  it('returns single chunk when text fits', () => {
+    const result = chunkText('hello world', 16000)
+    expect(result).toEqual(['hello world'])
+  })
+
+  it('splits at paragraph boundary', () => {
+    const text = 'First paragraph.\n\nSecond paragraph.\n\nThird paragraph.'
+    const result = chunkText(text, 30)
+    // Should split at \n\n boundaries
+    expect(result.every((c) => c.length <= 30)).toBe(true)
+    expect(result.join(' ')).toContain('First paragraph')
+    expect(result.join(' ')).toContain('Second paragraph')
+    expect(result.join(' ')).toContain('Third paragraph')
+  })
+
+  it('splits at line break when no paragraph break', () => {
+    const text = 'Line one.\nLine two.\nLine three.\nLine four.'
+    const result = chunkText(text, 25)
+    expect(result.every((c) => c.length <= 25)).toBe(true)
+  })
+
+  it('splits at sentence punctuation as fallback', () => {
+    const text = 'First sentence. Second sentence. Third sentence.'
+    const result = chunkText(text, 25)
+    expect(result.every((c) => c.length <= 25)).toBe(true)
+  })
+
+  it('splits at Chinese punctuation', () => {
+    const text = '这是第一段很长的话。这是第二段很长的话。这是第三段很长的话。'
+    const result = chunkText(text, 20)
+    expect(result.every((c) => c.length <= 20)).toBe(true)
+    expect(result.length).toBeGreaterThan(1)
+  })
+
+  it('hard-splits at maxLen when no natural break', () => {
+    const text = 'A'.repeat(100)
+    const result = chunkText(text, 20)
+    expect(result.length).toBe(5)
+    expect(result.every((c) => c.length <= 20)).toBe(true)
+  })
+
+  it('handles exact boundary', () => {
+    const text = 'A'.repeat(16000)
+    const result = chunkText(text, 16000)
+    expect(result).toEqual(['A'.repeat(16000)])
+  })
+
+  it('handles empty string', () => {
+    const result = chunkText('', 16000)
+    expect(result).toEqual([''])
+  })
+
+  it('preserves content across multiple chunks', () => {
+    const paragraphs = Array.from(
+      { length: 10 },
+      (_, i) => `Paragraph ${i + 1}: ${'x'.repeat(500)}`,
+    )
+    const text = paragraphs.join('\n\n')
+    const result = chunkText(text, 4000)
+    expect(result.every((c) => c.length <= 4000)).toBe(true)
+    // All original content should be present
+    const joined = result.join('')
+    for (let i = 0; i < 10; i++) {
+      expect(joined).toContain(`Paragraph ${i + 1}`)
+    }
+  })
+})

--- a/packages/openclaw-shadowob/src/outbound.ts
+++ b/packages/openclaw-shadowob/src/outbound.ts
@@ -12,6 +12,54 @@ import type { OpenClawConfig } from 'openclaw/plugin-sdk/core'
 import { DEFAULT_ACCOUNT_ID, getAccountConfig } from './config.js'
 import type { ShadowAccountConfig } from './types.js'
 
+/** Max single-message content length (matches server LIMITS.MESSAGE_CONTENT_MAX) */
+const CHUNK_SIZE = 16000
+
+/**
+ * Split text into chunks that fit within the server's message length limit.
+ * Prefers breaking at paragraph boundaries (\n\n), then line breaks (\n),
+ * then sentence-ending punctuation, with a hard fallback at exact byte offset.
+ */
+export function chunkText(text: string, maxLen: number = CHUNK_SIZE): string[] {
+  if (text.length <= maxLen) return [text]
+
+  const chunks: string[] = []
+  let remaining = text
+
+  while (remaining.length > maxLen) {
+    let splitAt = maxLen
+
+    // 1. Paragraph boundary (\n\n)
+    const paraIdx = remaining.lastIndexOf('\n\n', maxLen)
+    if (paraIdx > maxLen * 0.5) {
+      splitAt = paraIdx + 2
+    } else {
+      // 2. Line break (\n)
+      const lineIdx = remaining.lastIndexOf('\n', maxLen)
+      if (lineIdx > maxLen * 0.6) {
+        splitAt = lineIdx + 1
+      } else {
+        // 3. Sentence-ending punctuation
+        const head = remaining.slice(0, maxLen)
+        const sentenceRe = /[。！？.!?][\s\u200B]*$/
+        const m = head.match(sentenceRe)
+        if (m && m.index !== undefined && m.index > maxLen * 0.4) {
+          splitAt = m.index + m[0].length
+        }
+      }
+    }
+
+    chunks.push(remaining.slice(0, splitAt).trimEnd())
+    remaining = remaining.slice(splitAt).trimStart()
+  }
+
+  if (remaining.length > 0) {
+    chunks.push(remaining)
+  }
+
+  return chunks
+}
+
 /** Parse a Shadow target string like "shadowob:channel:<channelId>" */
 export function parseTarget(to: string): { channelId?: string; threadId?: string } {
   const parts = to.split(':')
@@ -51,8 +99,8 @@ function resolveClient(
  */
 export const shadowOutbound = {
   deliveryMode: 'direct' as const,
-  chunker: null,
-  textChunkLimit: 4000,
+  chunker: chunkText,
+  textChunkLimit: CHUNK_SIZE,
 
   attachedResults: {
     sendText: async (params: {
@@ -70,18 +118,27 @@ export const shadowOutbound = {
       const { channelId, threadId: parsedThreadId } = parseTarget(params.to)
       const threadId = params.threadId ?? parsedThreadId
 
-      let message: ShadowMessage
-      if (threadId) {
-        message = await client.sendToThread(threadId, params.text)
-      } else if (channelId) {
-        message = await client.sendMessage(channelId, params.text, {
-          replyToId: params.replyToMessageId,
-        })
-      } else {
-        throw new Error('Could not resolve target channel or thread')
+      const chunks = chunkText(params.text)
+      let lastMessageId: string | undefined
+
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i]!
+        // First chunk uses the original replyToId; subsequent chunks reply to the previous one
+        const replyTo = i === 0 ? params.replyToMessageId : lastMessageId
+        let message: ShadowMessage
+        if (threadId) {
+          message = await client.sendToThread(threadId, chunk)
+        } else if (channelId) {
+          message = await client.sendMessage(channelId, chunk, {
+            replyToId: replyTo,
+          })
+        } else {
+          throw new Error('Could not resolve target channel or thread')
+        }
+        lastMessageId = message.id
       }
 
-      return { messageId: message.id }
+      return { messageId: lastMessageId! }
     },
   },
 
@@ -109,23 +166,29 @@ export const shadowOutbound = {
         Boolean,
       ) as string[]
 
-      // Create a message to attach media to
+      // Create a message to attach media to (chunk text if it exceeds limit)
       const content = params.text || '\u200B'
-      let message: ShadowMessage
-      if (threadId) {
-        message = await client.sendToThread(threadId, content)
-      } else if (channelId) {
-        message = await client.sendMessage(channelId, content, {
-          replyToId: params.replyToMessageId,
-        })
-      } else {
-        throw new Error('Could not resolve target channel or thread')
+      const contentChunks = chunkText(content)
+      let message: ShadowMessage | undefined
+
+      for (let i = 0; i < contentChunks.length; i++) {
+        const chunk = contentChunks[i]!
+        const replyTo = i === 0 ? params.replyToMessageId : message?.id
+        if (threadId) {
+          message = await client.sendToThread(threadId, chunk)
+        } else if (channelId) {
+          message = await client.sendMessage(channelId, chunk, {
+            replyToId: replyTo,
+          })
+        } else {
+          throw new Error('Could not resolve target channel or thread')
+        }
       }
 
       // Upload each media URL, fallback to sending URL as text on failure
       for (const mediaUrl of mediaUrls) {
         try {
-          await client.uploadMediaFromUrl(mediaUrl, message.id)
+          await client.uploadMediaFromUrl(mediaUrl, message!.id)
         } catch {
           // Fallback: send the URL as text
           if (threadId) {

--- a/packages/shared/__tests__/constants.test.ts
+++ b/packages/shared/__tests__/constants.test.ts
@@ -39,7 +39,7 @@ describe('SERVER_EVENTS', () => {
 
 describe('LIMITS', () => {
   it('should define message limits', () => {
-    expect(LIMITS.MESSAGE_CONTENT_MAX).toBe(4000)
+    expect(LIMITS.MESSAGE_CONTENT_MAX).toBe(16000)
     expect(LIMITS.MESSAGES_PER_PAGE).toBe(50)
   })
 

--- a/packages/shared/src/constants/limits.ts
+++ b/packages/shared/src/constants/limits.ts
@@ -1,6 +1,6 @@
 export const LIMITS = {
-  /** Max message content length */
-  MESSAGE_CONTENT_MAX: 4000,
+  /** Max message content length (16KB — enough for detailed agent responses) */
+  MESSAGE_CONTENT_MAX: 16000,
   /** Max username length */
   USERNAME_MAX: 32,
   /** Min username length */


### PR DESCRIPTION
## Problem

Agent replies exceeding 4000 characters fail with a 400 error. The `openclaw-shadowob` plugin had `chunker: null`, so no auto-splitting happened.

## Solution

### 1. Server-side limit: 4000 → 16000

| File | Change |
|------|--------|
| `packages/shared/src/constants/limits.ts` | `MESSAGE_CONTENT_MAX` → **16000** |
| `apps/server/src/handlers/dm.handler.ts` | Replaced hardcoded `4000` with `LIMITS.MESSAGE_CONTENT_MAX` |

### 2. Plugin auto-chunking (based on PR #144)

| File | Change |
|------|--------|
| `packages/openclaw-shadowob/src/outbound.ts` | New `chunkText()` — splits at paragraph → line → punctuation boundaries |
| | Wired as `outbound.chunker` (was `null`) |
| | `sendText()` and `sendMedia()` auto-chunk with reply threading |

### 3. DB unaffected — PostgreSQL `text` has no limit, **no migration needed**

## Tests

- ✅ 9 chunk unit tests
- ✅ 3 service-level tests
- ✅ Updated validator + constants tests

## Why 16KB?

Enough for detailed agent responses (5-10KB typical), 4× the previous limit, chunking as fallback.