### PR TITLE
fix(security): require JWT_SECRET at startup, refuse to run with default

### DIFF
--- a/apps/server/src/lib/jwt.ts
+++ b/apps/server/src/lib/jwt.ts
@@ -2,10 +2,17 @@ import jwt from 'jsonwebtoken'
 
 const { sign, verify } = jwt
 
-const JWT_SECRET = process.env.JWT_SECRET ?? 'shadow-dev-secret'
+const JWT_SECRET = process.env.JWT_SECRET
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN ?? '7d'
 const JWT_REFRESH_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN ?? '30d'
 const JWT_AGENT_EXPIRES_IN = process.env.JWT_AGENT_EXPIRES_IN ?? '365d'
+
+if (!JWT_SECRET) {
+  throw new Error(
+    'FATAL: JWT_SECRET environment variable is required. ' +
+      'Set a strong random secret before starting the server.',
+  )
+}
 
 export interface JwtPayload {
   userId: string


### PR DESCRIPTION
Previously `JWT_SECRET` defaulted to `'shadow-dev-secret'` if the environment variable was not set, which could silently leave production deployments using the well-known dev secret.

Now the server throws a fatal error at module load time if `JWT_SECRET` is not explicitly configured.

**⚠️ Breaking change:** Deployments without `JWT_SECRET` env var will fail to start. Set a strong random secret before merging.