### PR TITLE
fix(security): use crypto.randomBytes for invite code generation

### DIFF
--- a/apps/server/src/handlers/admin.handler.ts
+++ b/apps/server/src/handlers/admin.handler.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import { zValidator } from '@hono/zod-validator'
 import { sql } from 'drizzle-orm'
 import { Hono } from 'hono'
@@ -9,9 +10,10 @@ import { updateServerSchema } from '../validators/server.schema'
 
 function generateCode(length = 8): string {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+  const bytes = randomBytes(length)
   let code = ''
   for (let i = 0; i < length; i++) {
-    code += chars.charAt(Math.floor(Math.random() * chars.length))
+    code += chars.charAt(bytes[i]! % chars.length)
   }
   return code
 }


### PR DESCRIPTION
Replace `Math.random()` (predictable PRNG) with `crypto.randomBytes()` (cryptographically secure RNG) for generating admin invite codes.

`Math.random()` uses xorshift128+ which is not suitable for generating secrets — an attacker who observes enough outputs can predict future values and guess valid invite codes.