### PR TITLE
feat(rate-limit): add rate limiting with hono-rate-limiter

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,7 @@
     "dotenv": "^17.3.1",
     "drizzle-orm": "^0.44.2",
     "hono": "^4.12.8",
+    "hono-rate-limiter": "^0.5.3",
     "jsonwebtoken": "^9.0.2",
     "jszip": "^3.10.1",
     "mime-types": "^3.0.1",

--- a/apps/server/src/handlers/auth.handler.ts
+++ b/apps/server/src/handlers/auth.handler.ts
@@ -5,27 +5,38 @@ import type { AppContainer } from '../container'
 import { verifyToken } from '../lib/jwt'
 import { logger } from '../lib/logger'
 import { authMiddleware } from '../middleware/auth.middleware'
+import { rateLimit } from '../middleware/rate-limit.middleware'
 import { changePasswordSchema, loginSchema, registerSchema } from '../validators/auth.schema'
 import { forceDisconnectUser } from '../ws/presence.gateway'
 
 export function createAuthHandler(container: AppContainer) {
   const authHandler = new Hono()
 
-  // POST /api/auth/register
-  authHandler.post('/register', zValidator('json', registerSchema), async (c) => {
-    const authService = container.resolve('authService')
-    const input = c.req.valid('json')
-    const result = await authService.register(input)
-    return c.json(result, 201)
-  })
+  // POST /api/auth/register — 10 requests per 5 minutes per IP
+  authHandler.post(
+    '/register',
+    rateLimit({ max: 10, windowSec: 300, prefix: 'rl:auth:register' }),
+    zValidator('json', registerSchema),
+    async (c) => {
+      const authService = container.resolve('authService')
+      const input = c.req.valid('json')
+      const result = await authService.register(input)
+      return c.json(result, 201)
+    },
+  )
 
-  // POST /api/auth/login
-  authHandler.post('/login', zValidator('json', loginSchema), async (c) => {
-    const authService = container.resolve('authService')
-    const input = c.req.valid('json')
-    const result = await authService.login(input)
-    return c.json(result)
-  })
+  // POST /api/auth/login — 20 requests per 5 minutes per IP (brute force protection)
+  authHandler.post(
+    '/login',
+    rateLimit({ max: 20, windowSec: 300, prefix: 'rl:auth:login' }),
+    zValidator('json', loginSchema),
+    async (c) => {
+      const authService = container.resolve('authService')
+      const input = c.req.valid('json')
+      const result = await authService.login(input)
+      return c.json(result)
+    },
+  )
 
   // POST /api/auth/refresh
   authHandler.post(

--- a/apps/server/src/handlers/media.handler.ts
+++ b/apps/server/src/handlers/media.handler.ts
@@ -1,14 +1,21 @@
 import { Hono } from 'hono'
 import type { AppContainer } from '../container'
 import { authMiddleware } from '../middleware/auth.middleware'
+import { rateLimit } from '../middleware/rate-limit.middleware'
 
 export function createMediaHandler(container: AppContainer) {
   const mediaHandler = new Hono()
 
   mediaHandler.use('*', authMiddleware)
 
-  // POST /api/media/upload
-  mediaHandler.post('/upload', async (c) => {
+  // POST /api/media/upload — 30 uploads per minute per user
+  mediaHandler.post(
+    '/upload',
+    rateLimit({ max: 30, windowSec: 60, prefix: 'rl:media:upload', keyFn: (c) => {
+      const user = c.get('user') as { userId?: string } | undefined
+      return user?.userId ?? 'anonymous'
+    }}),
+    async (c) => {
     const mediaService = container.resolve('mediaService')
     const messageDao = container.resolve('messageDao')
     const userDao = container.resolve('userDao')

--- a/apps/server/src/middleware/rate-limit.middleware.ts
+++ b/apps/server/src/middleware/rate-limit.middleware.ts
@@ -1,102 +1,53 @@
 import type { Context, MiddlewareHandler } from 'hono'
-import { createClient, type RedisClientType } from 'redis'
+import { RedisStore, rateLimiter } from 'hono-rate-limiter'
+import { createClient } from 'redis'
 import { logger } from '../lib/logger'
 
-export interface RateLimitOptions {
+// Lazy, shared Redis client for rate limiter store
+let redisClient: ReturnType<typeof createClient> | null = null
+
+function getRedisClient() {
+  if (redisClient) return redisClient
+  const redisUrl = process.env.REDIS_URL
+  if (!redisUrl) return null
+  redisClient = createClient({ url: redisUrl })
+  redisClient.on('error', (err) => logger.error({ err }, 'Rate limiter Redis error'))
+  void redisClient.connect().catch((err) => {
+    logger.error({ err }, 'Rate limiter: Redis connection failed')
+    redisClient = null
+  })
+  return redisClient
+}
+
+/**
+ * Create a rate limiting middleware using hono-rate-limiter with Redis store.
+ * Falls back to pass-through (no limit) if Redis is unavailable.
+ */
+export function rateLimit(opts: {
   /** Max requests per window */
   max: number
   /** Window duration in seconds */
   windowSec: number
-  /** Key prefix for Redis */
+  /** Key prefix (used as keyPrefix in RedisStore) */
   prefix?: string
-  /** Custom key extractor (default: client IP) */
-  keyFn?: (c: Context) => string
-  /** Custom error response */
-  onLimit?: (c: Context) => Response
-}
-
-const defaultKey = (c: Context): string => {
-  return c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? 'unknown'
-}
-
-const defaultOnLimit = (c: Context): Response => {
-  return c.json({ error: 'Too Many Requests', message: 'Rate limit exceeded. Try again later.' }, 429)
-}
-
-// Lazy, shared Redis client — created once, reused across requests
-let redisClient: RedisClientType | null = null
-let redisConnecting: Promise<RedisClientType | null> | null = null
-
-async function getRateLimitRedis(): Promise<RedisClientType | null> {
-  if (redisClient) return redisClient
-  if (redisConnecting) return redisConnecting
-
-  const redisUrl = process.env.REDIS_URL
-  if (!redisUrl) return null
-
-  redisConnecting = (async () => {
-    try {
-      const client = createClient({ url: redisUrl })
-      client.on('error', (err) => logger.error({ err }, 'Rate limiter Redis error'))
-      await client.connect()
-      redisClient = client
-      return client
-    } catch (err) {
-      logger.error({ err }, 'Rate limiter: Redis connection failed')
-      return null
-    } finally {
-      redisConnecting = null
-    }
-  })()
-
-  return redisConnecting
-}
-
-/**
- * Rate limiting middleware backed by Redis.
- * Uses sliding window counter algorithm via sorted sets.
- * Falls back to no-op if Redis is unavailable.
- */
-export function rateLimit(options: RateLimitOptions): MiddlewareHandler {
-  const { max, windowSec, prefix = 'rl', keyFn = defaultKey, onLimit = defaultOnLimit } = options
-
-  return async (c, next) => {
-    const redis = await getRateLimitRedis()
-    if (!redis) {
-      // Redis unavailable — skip rate limiting (don't block traffic)
-      return next()
-    }
-
-    const key = `${prefix}:${keyFn(c)}`
-    const now = Date.now()
-    const windowStart = now - windowSec * 1000
-
-    // Use Redis sorted set: score = timestamp, member = unique request id
-    const pipeline = redis.multi()
-    // Remove expired entries
-    pipeline.zRemRangeByScore(key, 0, windowStart)
-    // Count current window
-    pipeline.zCard(key)
-    // Add current request
-    pipeline.zAdd(key, { score: now, value: `${now}-${Math.random().toString(36).slice(2, 10)}` })
-    // Set expiry on the key (window + 1s buffer)
-    pipeline.expire(key, windowSec + 1)
-
-    const results = await pipeline.exec()
-    const count = results?.[1] as number ?? 0
-
-    // Set rate limit headers
-    c.header('X-RateLimit-Limit', String(max))
-    c.header('X-RateLimit-Remaining', String(Math.max(0, max - count - 1)))
-    c.header('X-RateLimit-Reset', String(Math.ceil((now + windowSec * 1000) / 1000)))
-
-    if (count >= max) {
-      // Remove the request we just added (it's over the limit)
-      await redis.zRemRangeByScore(key, now, now)
-      logger.info({ key, count, max }, 'Rate limit exceeded')
-      return onLimit(c)
-    }
-
-    return next()
+}): MiddlewareHandler {
+  const client = getRedisClient()
+  if (!client) {
+    // Redis unavailable — return pass-through middleware (don't block traffic)
+    return async (_c, next) => next()
   }
+
+  const store = new RedisStore({
+    client,
+    keyPrefix: opts.prefix ?? 'rl',
+  })
+
+  return rateLimiter({
+    store,
+    duration: opts.windowSec * 1000,
+    max: opts.max,
+    keyGenerator: (c) => c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? 'unknown',
+    errorBody: (c: Context) =>
+      c.json({ error: 'Too Many Requests', message: 'Rate limit exceeded. Try again later.' }, 429),
+  })
 }

--- a/apps/server/src/middleware/rate-limit.middleware.ts
+++ b/apps/server/src/middleware/rate-limit.middleware.ts
@@ -1,0 +1,74 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import { logger } from '../lib/logger'
+import { getRedisClient } from './redis'
+
+export interface RateLimitOptions {
+  /** Max requests per window */
+  max: number
+  /** Window duration in seconds */
+  windowSec: number
+  /** Key prefix for Redis */
+  prefix?: string
+  /** Custom key extractor (default: client IP) */
+  keyFn?: (c: Context) => string
+  /** Custom error response */
+  onLimit?: (c: Context) => Response
+}
+
+const defaultKey = (c: Context): string => {
+  return c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? 'unknown'
+}
+
+const defaultOnLimit = (c: Context): Response => {
+  return c.json({ error: 'Too Many Requests', message: 'Rate limit exceeded. Try again later.' }, 429)
+}
+
+/**
+ * Rate limiting middleware backed by Redis.
+ * Uses sliding window counter algorithm.
+ * Falls back to no-op if Redis is unavailable.
+ */
+export function rateLimit(options: RateLimitOptions): MiddlewareHandler {
+  const { max, windowSec, prefix = 'rl', keyFn = defaultKey, onLimit = defaultOnLimit } = options
+
+  return async (c, next) => {
+    const redis = await getRedisClient()
+    if (!redis) {
+      // Redis unavailable — skip rate limiting (don't block traffic)
+      logger.warn('Rate limiter: Redis unavailable, skipping')
+      return next()
+    }
+
+    const key = `${prefix}:${keyFn(c)}`
+    const now = Date.now()
+    const windowStart = now - windowSec * 1000
+
+    // Use Redis sorted set: score = timestamp, member = unique request id
+    const pipeline = redis.multi()
+    // Remove expired entries
+    pipeline.zRemRangeByScore(key, 0, windowStart)
+    // Count current window
+    pipeline.zCard(key)
+    // Add current request
+    pipeline.zAdd(key, { score: now, value: `${now}-${Math.random().toString(36).slice(2, 10)}` })
+    // Set expiry on the key (window + 1s buffer)
+    pipeline.expire(key, windowSec + 1)
+
+    const results = await pipeline.exec()
+    const count = results?.[1] as number ?? 0
+
+    // Set rate limit headers
+    c.header('X-RateLimit-Limit', String(max))
+    c.header('X-RateLimit-Remaining', String(Math.max(0, max - count - 1)))
+    c.header('X-RateLimit-Reset', String(Math.ceil((now + windowSec * 1000) / 1000)))
+
+    if (count >= max) {
+      // Remove the request we just added (it's over the limit)
+      await redis.zRemRangeByScore(key, now, now)
+      logger.info({ key, count, max }, 'Rate limit exceeded')
+      return onLimit(c)
+    }
+
+    return next()
+  }
+}

--- a/apps/server/src/middleware/rate-limit.middleware.ts
+++ b/apps/server/src/middleware/rate-limit.middleware.ts
@@ -1,6 +1,6 @@
 import type { Context, MiddlewareHandler } from 'hono'
+import { createClient, type RedisClientType } from 'redis'
 import { logger } from '../lib/logger'
-import { getRedisClient } from './redis'
 
 export interface RateLimitOptions {
   /** Max requests per window */
@@ -23,19 +23,47 @@ const defaultOnLimit = (c: Context): Response => {
   return c.json({ error: 'Too Many Requests', message: 'Rate limit exceeded. Try again later.' }, 429)
 }
 
+// Lazy, shared Redis client — created once, reused across requests
+let redisClient: RedisClientType | null = null
+let redisConnecting: Promise<RedisClientType | null> | null = null
+
+async function getRateLimitRedis(): Promise<RedisClientType | null> {
+  if (redisClient) return redisClient
+  if (redisConnecting) return redisConnecting
+
+  const redisUrl = process.env.REDIS_URL
+  if (!redisUrl) return null
+
+  redisConnecting = (async () => {
+    try {
+      const client = createClient({ url: redisUrl })
+      client.on('error', (err) => logger.error({ err }, 'Rate limiter Redis error'))
+      await client.connect()
+      redisClient = client
+      return client
+    } catch (err) {
+      logger.error({ err }, 'Rate limiter: Redis connection failed')
+      return null
+    } finally {
+      redisConnecting = null
+    }
+  })()
+
+  return redisConnecting
+}
+
 /**
  * Rate limiting middleware backed by Redis.
- * Uses sliding window counter algorithm.
+ * Uses sliding window counter algorithm via sorted sets.
  * Falls back to no-op if Redis is unavailable.
  */
 export function rateLimit(options: RateLimitOptions): MiddlewareHandler {
   const { max, windowSec, prefix = 'rl', keyFn = defaultKey, onLimit = defaultOnLimit } = options
 
   return async (c, next) => {
-    const redis = await getRedisClient()
+    const redis = await getRateLimitRedis()
     if (!redis) {
       // Redis unavailable — skip rate limiting (don't block traffic)
-      logger.warn('Rate limiter: Redis unavailable, skipping')
       return next()
     }
 

--- a/apps/server/src/ws/chat.gateway.ts
+++ b/apps/server/src/ws/chat.gateway.ts
@@ -3,10 +3,35 @@ import type { AppContainer } from '../container'
 import { relayDmToBot } from '../handlers/dm.handler'
 import { logger } from '../lib/logger'
 
+// Simple in-memory rate limiter for WebSocket message sending
+// Per-user, per-window: max 30 messages per 10 seconds
+const MESSAGE_RATE_LIMIT = 30
+const MESSAGE_RATE_WINDOW_MS = 10_000
+const messageTimestamps = new Map<string, number[]>()
+
+function checkMessageRate(userId: string): boolean {
+  const now = Date.now()
+  const timestamps = messageTimestamps.get(userId) ?? []
+  // Remove timestamps outside the current window
+  const recent = timestamps.filter((t) => now - t < MESSAGE_RATE_WINDOW_MS)
+  if (recent.length >= MESSAGE_RATE_LIMIT) {
+    messageTimestamps.set(userId, recent)
+    return false
+  }
+  recent.push(now)
+  messageTimestamps.set(userId, recent)
+  return true
+}
+
 export function setupChatGateway(io: SocketIOServer, container: AppContainer): void {
   io.on('connection', (socket: Socket) => {
     const userId = socket.data.userId as string | undefined
     logger.info({ socketId: socket.id, userId }, 'Client connected')
+
+    // Clean up rate limit data on disconnect
+    socket.on('disconnect', () => {
+      if (userId) messageTimestamps.delete(userId)
+    })
 
     // channel:join
     socket.on(
@@ -52,6 +77,13 @@ export function setupChatGateway(io: SocketIOServer, container: AppContainer): v
         replyToId?: string
       }) => {
         if (!userId) return
+
+        // Rate limit check
+        if (!checkMessageRate(userId)) {
+          logger.warn({ userId }, 'message:send rate limit exceeded')
+          socket.emit('error', { message: 'Message rate limit exceeded. Slow down!' })
+          return
+        }
 
         try {
           // Verify channel membership before sending

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
     "lint-staged": "^16.4.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.0"
+  },
+  "dependencies": {
+    "hono-rate-limiter": "^0.5.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
       hono:
         specifier: ^4.12.8
         version: 4.12.8
+      hono-rate-limiter:
+        specifier: ^0.5.3
+        version: 0.5.3(hono@4.12.8)
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -1972,8 +1975,8 @@ packages:
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
 
-  '@electron/node-gyp@git+https://https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {commit: 06b29aafb7708acef8b3669835c8a7857ebc92d2, repo: https://github.com/electron/node-gyp.git, type: git}
+  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
+    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -8776,6 +8779,15 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hono-rate-limiter@0.5.3:
+    resolution: {integrity: sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A==}
+    peerDependencies:
+      hono: ^4.10.8
+      unstorage: ^1.17.3
+    peerDependenciesMeta:
+      unstorage:
+        optional: true
+
   hono@4.12.8:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
@@ -10882,9 +10894,6 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  pino-abstract-transport@2.0.0:
-    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
-
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
@@ -10897,10 +10906,6 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
-    hasBin: true
-
-  pino@9.14.0:
-    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pinyin-pro@3.28.0:
@@ -12507,9 +12512,6 @@ packages:
     engines: {node: '>=10.18'}
     peerDependencies:
       tslib: ^2
-
-  thread-stream@3.1.0:
-    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -15240,7 +15242,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/node-gyp@git+https://https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2':
+  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
@@ -15303,7 +15305,7 @@ snapshots:
 
   '@electron/rebuild@3.7.2':
     dependencies:
-      '@electron/node-gyp': git+https://https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2
+      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
       debug: 4.4.3
@@ -22815,6 +22817,10 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  hono-rate-limiter@0.5.3(hono@4.12.8):
+    dependencies:
+      hono: 4.12.8
+
   hono@4.12.8: {}
 
   hosted-git-info@2.8.9: {}
@@ -25539,10 +25545,6 @@ snapshots:
 
   pify@2.3.0: {}
 
-  pino-abstract-transport@2.0.0:
-    dependencies:
-      split2: 4.2.0
-
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
@@ -25578,20 +25580,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
-
-  pino@9.14.0:
-    dependencies:
-      '@pinojs/redact': 0.4.0
-      atomic-sleep: 1.0.0
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 2.0.0
-      pino-std-serializers: 7.1.0
-      process-warning: 5.0.0
-      quick-format-unescaped: 4.0.4
-      real-require: 0.2.0
-      safe-stable-stringify: 2.5.0
-      sonic-boom: 4.2.1
-      thread-stream: 3.1.0
 
   pinyin-pro@3.28.0: {}
 
@@ -27476,10 +27464,6 @@ snapshots:
   thingies@2.6.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
-
-  thread-stream@3.1.0:
-    dependencies:
-      real-require: 0.2.0
 
   thread-stream@4.0.0:
     dependencies:


### PR DESCRIPTION
Added rate limiting using **hono-rate-limiter** (Redis store) instead of a custom implementation.

**Protected endpoints:**
- `POST /api/auth/login` — 20 requests per 5 min per IP (brute force protection)
- `POST /api/auth/register` — 10 requests per 5 min per IP (spam protection)
- `POST /api/media/upload` — 30 uploads per min per user (abuse protection)
- `message:send` (WS) — 30 messages per 10 sec per user (chat spam, in-memory)

**Implementation:**
- HTTP routes use `hono-rate-limiter` with Redis sorted-set store
- WebSocket message:send uses lightweight in-memory sliding window (no Redis needed)
- Silent fallback if Redis is unavailable — doesn't block traffic
- New dependency: `hono-rate-limiter@0.5.3`