### PR TITLE
fix(ws): add logging to all silent catch blocks in WebSocket gateways

### DIFF
--- a/apps/server/src/ws/app.gateway.ts
+++ b/apps/server/src/ws/app.gateway.ts
@@ -33,7 +33,8 @@ export function setupAppGateway(io: SocketIOServer, container: AppContainer): vo
           await socket.join(`channel:${app.channelId}`)
           logger.info({ userId, appId, channelId: app.channelId }, 'Joined app room')
           if (typeof ack === 'function') ack({ ok: true, channelId: app.channelId })
-        } catch {
+        } catch (err) {
+          logger.warn({ err, userId, appId }, 'app:join failed to lookup app')
           if (typeof ack === 'function') ack({ ok: false })
         }
       },
@@ -48,8 +49,8 @@ export function setupAppGateway(io: SocketIOServer, container: AppContainer): vo
         if (app?.channelId) {
           await socket.leave(`channel:${app.channelId}`)
         }
-      } catch {
-        /* ignore */
+      } catch (err) {
+        logger.warn({ err, userId, appId }, 'app:leave failed')
       }
     })
 
@@ -68,8 +69,8 @@ export function setupAppGateway(io: SocketIOServer, container: AppContainer): vo
           payload: data.payload,
           senderId: userId,
         })
-      } catch {
-        /* ignore */
+      } catch (err) {
+        logger.warn({ err, userId, appId: data.appId }, 'app:broadcast failed')
       }
     })
   })

--- a/apps/server/src/ws/chat.gateway.ts
+++ b/apps/server/src/ws/chat.gateway.ts
@@ -256,6 +256,8 @@ export function setupChatGateway(io: SocketIOServer, container: AppContainer): v
           } catch (err) {
             logger.warn({ err, userId, dmChannelId }, 'Rental message recording failed — non-critical')
           }
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : 'Failed to send DM'
           socket.emit('error', { message: msg })
         }
       },

--- a/apps/server/src/ws/chat.gateway.ts
+++ b/apps/server/src/ws/chat.gateway.ts
@@ -22,8 +22,8 @@ export function setupChatGateway(io: SocketIOServer, container: AppContainer): v
               if (typeof ack === 'function') ack({ ok: false })
               return
             }
-          } catch {
-            /* membership check failed, allow join as fallback */
+          } catch (err) {
+            logger.warn({ err, userId, channelId }, 'channel:join membership check failed — allowing join as fallback')
           }
         }
 
@@ -116,8 +116,8 @@ export function setupChatGateway(io: SocketIOServer, container: AppContainer): v
                 // Push notification to the target user via WS
                 io.to(`user:${originalMessage.authorId}`).emit('notification:new', notification)
               }
-            } catch {
-              /* notification creation failed, non-critical */
+            } catch (err) {
+              logger.warn({ err, userId, replyToId: data.replyToId }, 'Reply notification creation failed — non-critical')
             }
           }
 
@@ -152,8 +152,8 @@ export function setupChatGateway(io: SocketIOServer, container: AppContainer): v
                 }
               }
             }
-          } catch {
-            /* mention notification failed, non-critical */
+          } catch (err) {
+            logger.warn({ err, userId, channelId: data.channelId }, 'Mention notification failed — non-critical')
           }
         } catch (error) {
           const msg = error instanceof Error ? error.message : 'Failed to send message'
@@ -183,8 +183,8 @@ export function setupChatGateway(io: SocketIOServer, container: AppContainer): v
         }
         await socket.join(`dm:${dmChannelId}`)
         logger.info({ userId, dmChannelId, socketId: socket.id }, 'Joined DM room')
-      } catch {
-        /* ignore */
+      } catch (err) {
+        logger.warn({ err, userId, dmChannelId }, 'dm:join verification failed — denying join')
       }
     })
 
@@ -231,8 +231,8 @@ export function setupChatGateway(io: SocketIOServer, container: AppContainer): v
               senderId: userId,
             })
             io.to(`user:${otherUserId}`).emit('notification:new', notification)
-          } catch {
-            /* notification failed, non-critical */
+          } catch (err) {
+            logger.warn({ err, userId, dmChannelId }, 'DM notification failed — non-critical')
           }
 
           // Relay to bot using shared helper
@@ -253,11 +253,9 @@ export function setupChatGateway(io: SocketIOServer, container: AppContainer): v
           try {
             const rentalService = container.resolve('rentalService')
             await rentalService.recordRentalMessage(userId, otherUserId)
-          } catch {
-            /* non-critical */
+          } catch (err) {
+            logger.warn({ err, userId, dmChannelId }, 'Rental message recording failed — non-critical')
           }
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : 'Failed to send DM'
           socket.emit('error', { message: msg })
         }
       },

--- a/apps/server/src/ws/index.ts
+++ b/apps/server/src/ws/index.ts
@@ -21,7 +21,8 @@ export function setupWebSocket(io: SocketIOServer, container: AppContainer): voi
       socket.data.userId = payload.userId
       socket.data.username = payload.username
       next()
-    } catch {
+    } catch (err) {
+      logger.warn({ err, socketId: socket.id }, 'Socket authentication failed — invalid token')
       next(new Error('Invalid token'))
     }
   })


### PR DESCRIPTION
Replaced all empty catch blocks (`{ /* ignore */ }`, `{ /* non-critical */ }`) with `logger.warn/error` calls that include contextual metadata.

**Files changed:**
- `chat.gateway.ts` — 5 silent catches (membership check, reply notifications, mention notifications, dm:join, rental recording)
- `app.gateway.ts` — 3 silent catches (app:join, app:leave, app:broadcast)
- `index.ts` — 1 silent catch (socket auth)

**All errors now log:** userId, channelId/dmChannelId/appId, and error details. Makes debugging WS issues in production actually possible.