### PR TITLE
test(services): add unit tests for WalletService, AuthService, NotificationService

### DIFF
--- a/apps/server/src/services/auth.service.test.ts
+++ b/apps/server/src/services/auth.service.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mocked } from 'vitest'
+import type { UserDao } from '../dao/user.dao'
+import type { InviteCodeDao } from '../dao/invite-code.dao'
+import type { AgentDao } from '../dao/agent.dao'
+import type { PasswordChangeLogDao } from '../dao/password-change-log.dao'
+import type { TaskCenterService } from '../services/task-center.service'
+import { AuthService } from './auth.service'
+
+// Mock bcryptjs
+vi.mock('bcryptjs', () => ({
+  hash: vi.fn().mockResolvedValue('$2a$12$mockhash'),
+  compare: vi.fn().mockResolvedValue(true),
+}))
+
+// Mock jwt
+vi.mock('../lib/jwt', () => ({
+  signAccessToken: vi.fn().mockReturnValue('mock-access-token'),
+  signRefreshToken: vi.fn().mockReturnValue('mock-refresh-token'),
+  verifyToken: vi.fn().mockReturnValue({ userId: 'user-1', email: 'test@test.com', username: 'testuser' }),
+}))
+
+// Mock id generator
+vi.mock('../lib/id', () => ({
+  randomFixedDigits: vi.fn().mockReturnValue('123456'),
+}))
+
+describe('AuthService', () => {
+  const mockUser = {
+    id: 'user-1',
+    email: 'test@test.com',
+    username: 'testuser',
+    displayName: 'Test User',
+    passwordHash: '$2a$12$mockhash',
+    isAdmin: false,
+    isBot: false,
+    status: 'online' as const,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+
+  const mockInviteCode = {
+    id: 'invite-1',
+    code: 'ABC123',
+    createdBy: 'admin-1',
+    usedBy: null,
+    usedAt: null,
+    isActive: true,
+    note: 'Test invite',
+    createdAt: new Date(),
+  }
+
+  const mockUserDao: Mocked<UserDao> = {
+    findByEmail: vi.fn(),
+    findByUsername: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+  } as unknown as Mocked<UserDao>
+
+  const mockInviteCodeDao: Mocked<InviteCodeDao> = {
+    findAvailable: vi.fn(),
+    markUsed: vi.fn(),
+  } as unknown as Mocked<InviteCodeDao>
+
+  const mockAgentDao: Mocked<AgentDao> = {
+    findByUserId: vi.fn(),
+  } as unknown as Mocked<AgentDao>
+
+  const mockTaskCenterService: Mocked<TaskCenterService> = {
+    grantWelcomeReward: vi.fn(),
+  } as unknown as Mocked<TaskCenterService>
+
+  const mockPasswordChangeLogDao: Mocked<PasswordChangeLogDao> = {
+    create: vi.fn(),
+  } as unknown as Mocked<PasswordChangeLogDao>
+
+  let service: AuthService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUserDao.findByEmail.mockResolvedValue(null)
+    mockUserDao.findByUsername.mockResolvedValue(null)
+    mockUserDao.create.mockResolvedValue(mockUser)
+    mockInviteCodeDao.findAvailable.mockResolvedValue(mockInviteCode)
+    mockTaskCenterService.grantWelcomeReward.mockResolvedValue(undefined)
+
+    service = new AuthService({
+      userDao: mockUserDao,
+      inviteCodeDao: mockInviteCodeDao,
+      agentDao: mockAgentDao,
+      taskCenterService: mockTaskCenterService,
+      passwordChangeLogDao: mockPasswordChangeLogDao,
+    })
+  })
+
+  describe('register', () => {
+    it('rejects invalid invite code', async () => {
+      mockInviteCodeDao.findAvailable.mockResolvedValue(null)
+
+      await expect(
+        service.register({
+          email: 'test@test.com',
+          password: 'password123',
+          username: 'testuser',
+          inviteCode: 'INVALID',
+        }),
+      ).rejects.toThrow('Invalid or already used invite code')
+    })
+
+    it('rejects duplicate email', async () => {
+      mockUserDao.findByEmail.mockResolvedValue(mockUser)
+
+      await expect(
+        service.register({
+          email: 'test@test.com',
+          password: 'password123',
+          username: 'testuser',
+          inviteCode: 'ABC123',
+        }),
+      ).rejects.toThrow('Email already in use')
+    })
+
+    it('rejects duplicate username', async () => {
+      mockUserDao.findByUsername.mockResolvedValue(mockUser)
+
+      await expect(
+        service.register({
+          email: 'new@test.com',
+          password: 'password123',
+          username: 'testuser',
+          inviteCode: 'ABC123',
+        }),
+      ).rejects.toThrow('Username already taken')
+    })
+
+    it('creates user with valid invite code and grants welcome reward', async () => {
+      const result = await service.register({
+        email: 'new@test.com',
+        password: 'password123',
+        username: 'newuser',
+        inviteCode: 'ABC123',
+      })
+
+      expect(mockUserDao.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new@test.com',
+          username: 'newuser',
+        }),
+      )
+      expect(mockInviteCodeDao.markUsed).toHaveBeenCalledWith('invite-1', 'user-1')
+      expect(mockTaskCenterService.grantWelcomeReward).toHaveBeenCalledWith('user-1')
+      expect(result).toHaveProperty('token')
+      expect(result).toHaveProperty('user')
+    })
+  })
+
+  describe('login', () => {
+    it('rejects non-existent user', async () => {
+      mockUserDao.findByEmail.mockResolvedValue(null)
+
+      await expect(
+        service.login({ email: 'nope@test.com', password: 'password123' }),
+      ).rejects.toThrow('Invalid email or password')
+    })
+
+    it('returns tokens for valid credentials', async () => {
+      mockUserDao.findByEmail.mockResolvedValue(mockUser)
+
+      const result = await service.login({ email: 'test@test.com', password: 'password123' })
+
+      expect(result).toHaveProperty('token', 'mock-access-token')
+      expect(result).toHaveProperty('refreshToken', 'mock-refresh-token')
+      expect(result).toHaveProperty('user')
+    })
+  })
+
+  describe('refresh', () => {
+    it('returns new access token for valid refresh token', async () => {
+      const result = await service.refresh('mock-refresh-token')
+
+      expect(result).toHaveProperty('token', 'mock-access-token')
+    })
+  })
+})

--- a/apps/server/src/services/notification.service.test.ts
+++ b/apps/server/src/services/notification.service.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mocked } from 'vitest'
+import type { NotificationDao } from '../dao/notification.dao'
+import { NotificationService } from './notification.service'
+
+describe('NotificationService', () => {
+  const mockNotificationDao: Mocked<NotificationDao> = {
+    getPreference: vi.fn(),
+    upsertPreference: vi.fn(),
+    findMessageScopesByMessageIds: vi.fn(),
+    findChannelScopes: vi.fn(),
+    create: vi.fn(),
+    findByUserId: vi.fn(),
+    markRead: vi.fn(),
+    markAllRead: vi.fn(),
+    getUnreadCount: vi.fn(),
+    markScopeRead: vi.fn(),
+    getScopedUnread: vi.fn(),
+  } as unknown as Mocked<NotificationDao>
+
+  let service: NotificationService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new NotificationService({ notificationDao: mockNotificationDao })
+  })
+
+  describe('shouldKeepByStrategy', () => {
+    it('always keeps system notifications', () => {
+      // Access private method via any cast for testing
+      const svc = service as any
+      expect(svc.shouldKeepByStrategy('system', 'none')).toBe(true)
+      expect(svc.shouldKeepByStrategy('system', 'mention_only')).toBe(true)
+      expect(svc.shouldKeepByStrategy('system', 'all')).toBe(true)
+    })
+
+    it('keeps nothing when strategy is none (except system)', () => {
+      const svc = service as any
+      expect(svc.shouldKeepByStrategy('mention', 'none')).toBe(false)
+      expect(svc.shouldKeepByStrategy('dm', 'none')).toBe(false)
+      expect(svc.shouldKeepByStrategy('reply', 'none')).toBe(false)
+    })
+
+    it('only keeps mentions when strategy is mention_only', () => {
+      const svc = service as any
+      expect(svc.shouldKeepByStrategy('mention', 'mention_only')).toBe(true)
+      expect(svc.shouldKeepByStrategy('dm', 'mention_only')).toBe(false)
+      expect(svc.shouldKeepByStrategy('reply', 'mention_only')).toBe(false)
+    })
+
+    it('keeps all when strategy is all', () => {
+      const svc = service as any
+      expect(svc.shouldKeepByStrategy('mention', 'all')).toBe(true)
+      expect(svc.shouldKeepByStrategy('dm', 'all')).toBe(true)
+      expect(svc.shouldKeepByStrategy('reply', 'all')).toBe(true)
+    })
+  })
+
+  describe('create', () => {
+    it('skips notification when user strategy is none', async () => {
+      mockNotificationDao.getPreference.mockResolvedValue({
+        userId: 'user-1',
+        strategy: 'none',
+        mutedServerIds: [],
+        mutedChannelIds: [],
+      })
+
+      const result = await service.create({
+        userId: 'user-1',
+        type: 'dm',
+        title: 'Test',
+        body: 'Test body',
+      })
+
+      expect(result).toBeNull()
+      expect(mockNotificationDao.create).not.toHaveBeenCalled()
+    })
+
+    it('skips mention notification when strategy is mention_only and type is not mention', async () => {
+      mockNotificationDao.getPreference.mockResolvedValue({
+        userId: 'user-1',
+        strategy: 'mention_only',
+        mutedServerIds: [],
+        mutedChannelIds: [],
+      })
+
+      const result = await service.create({
+        userId: 'user-1',
+        type: 'dm',
+        title: 'DM',
+        body: 'Hey',
+      })
+
+      expect(result).toBeNull()
+      expect(mockNotificationDao.create).not.toHaveBeenCalled()
+    })
+
+    it('creates notification when strategy allows it', async () => {
+      mockNotificationDao.getPreference.mockResolvedValue({
+        userId: 'user-1',
+        strategy: 'all',
+        mutedServerIds: [],
+        mutedChannelIds: [],
+      })
+      mockNotificationDao.create.mockResolvedValue({
+        id: 'notif-1',
+        userId: 'user-1',
+        type: 'dm',
+        referenceId: null,
+        referenceType: null,
+        isRead: false,
+        createdAt: new Date(),
+      })
+
+      const result = await service.create({
+        userId: 'user-1',
+        type: 'dm',
+        title: 'Test',
+        body: 'Test body',
+      })
+
+      expect(mockNotificationDao.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          type: 'dm',
+        }),
+      )
+      expect(result).not.toBeNull()
+    })
+  })
+})

--- a/apps/server/src/services/wallet.service.test.ts
+++ b/apps/server/src/services/wallet.service.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mocked } from 'vitest'
+import { eq, sql } from 'drizzle-orm'
+import { wallets, walletTransactions } from '../db/schema'
+import type { Database } from '../db'
+import type { WalletDao } from '../dao/wallet.dao'
+import { WalletService } from './wallet.service'
+
+describe('WalletService', () => {
+  const mockWallet = {
+    id: 'wallet-1',
+    userId: 'user-1',
+    balance: 1000,
+    frozenAmount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+
+  const mockTx = {
+    update: vi.fn(),
+    insert: vi.fn(),
+  }
+
+  const mockDb: Mocked<Database> = {
+    transaction: vi.fn(async (fn) => fn(mockTx as unknown as ReturnType<typeof db.transaction extends (fn: infer F) => any ? F : never>)),
+  } as unknown as Mocked<Database>
+
+  const mockWalletDao: Mocked<WalletDao> = {
+    getOrCreate: vi.fn().mockResolvedValue(mockWallet),
+    findByUserId: vi.fn().mockResolvedValue(mockWallet),
+    getTransactions: vi.fn().mockResolvedValue([]),
+    countTransactions: vi.fn().mockResolvedValue(0),
+  } as unknown as Mocked<WalletDao>
+
+  let service: WalletService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWalletDao.getOrCreate.mockResolvedValue(mockWallet)
+    mockWalletDao.findByUserId.mockResolvedValue(mockWallet)
+
+    service = new WalletService({
+      walletDao: mockWalletDao,
+      db: mockDb,
+    })
+  })
+
+  describe('topUp', () => {
+    it('uses atomic balance increment and records transaction', async () => {
+      const chain = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([{ balance: 1500 }]),
+      }
+      mockTx.update.mockReturnValue(chain)
+      mockTx.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) })
+
+      const result = await service.topUp('user-1', 500, 'Test top-up')
+
+      expect(mockDb.transaction).toHaveBeenCalled()
+      expect(mockTx.update).toHaveBeenCalledWith(wallets)
+      expect(chain.set).toHaveBeenCalled()
+      expect(chain.returning).toHaveBeenCalled()
+      expect(result).toEqual(mockWallet)
+    })
+  })
+
+  describe('debit', () => {
+    it('uses atomic decrement with WHERE guard for insufficient balance', async () => {
+      const chain = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([{ balance: 500 }]),
+      }
+      mockTx.update.mockReturnValue(chain)
+      mockTx.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) })
+
+      const result = await service.debit('user-1', 500, 'order-1', 'order', 'Purchase')
+
+      expect(mockTx.update).toHaveBeenCalledWith(wallets)
+      expect(chain.where).toHaveBeenCalledWith(
+        expect.stringContaining('balance'),
+      )
+      expect(result).toBe(500)
+    })
+
+    it('throws Insufficient balance when WHERE guard matches no rows', async () => {
+      const chain = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([]),
+      }
+      mockTx.update.mockReturnValue(chain)
+
+      await expect(
+        service.debit('user-1', 9999, 'order-1', 'order', 'Purchase'),
+      ).rejects.toThrow('Insufficient balance')
+    })
+  })
+
+  describe('refund', () => {
+    it('uses atomic balance increment', async () => {
+      const chain = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([{ balance: 1200 }]),
+      }
+      mockTx.update.mockReturnValue(chain)
+      mockTx.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) })
+
+      const result = await service.refund('user-1', 200, 'order-1', 'order', 'Refund')
+
+      expect(mockTx.update).toHaveBeenCalledWith(wallets)
+      expect(chain.set).toHaveBeenCalledWith(
+        expect.objectContaining({ updatedAt: expect.any(Date) }),
+      )
+      expect(result).toBe(1200)
+    })
+  })
+
+  describe('settle', () => {
+    it('uses atomic balance increment for seller payout', async () => {
+      const chain = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([{ balance: 2000 }]),
+      }
+      mockTx.update.mockReturnValue(chain)
+      mockTx.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) })
+
+      const result = await service.settle('user-1', 1000, 'contract-1', 'rental', 'Settlement')
+
+      expect(mockTx.update).toHaveBeenCalledWith(wallets)
+      expect(result).toBe(2000)
+    })
+  })
+
+  describe('getOrCreateWallet', () => {
+    it('delegates to walletDao.getOrCreate', async () => {
+      await service.getOrCreateWallet('user-1')
+      expect(mockWalletDao.getOrCreate).toHaveBeenCalledWith('user-1')
+    })
+  })
+
+  describe('getTransactions', () => {
+    it('delegates to walletDao with pagination', async () => {
+      await service.getTransactions('user-1', 20, 10)
+      expect(mockWalletDao.getOrCreate).toHaveBeenCalledWith('user-1')
+      expect(mockWalletDao.getTransactions).toHaveBeenCalledWith(
+        mockWallet.id,
+        20,
+        10,
+      )
+    })
+  })
+})


### PR DESCRIPTION
Added 21 unit tests for three core services:

**WalletService (8 tests):**
- topUp: atomic balance increment + transaction record
- debit: atomic decrement with WHERE guard, insufficient balance error
- refund / settle: atomic balance increment
- getOrCreateWallet / getTransactions: DAO delegation

**AuthService (6 tests):**
- register: invalid invite code, duplicate email, duplicate username
- register success: creates user, marks invite, grants welcome reward
- login: non-existent user, valid credentials
- refresh: valid refresh token

**NotificationService (7 tests):**
- shouldKeepByStrategy: system/none/mention_only/all strategies
- create: skips when strategy is none/mention_only, creates when allowed

Uses `vi.mock` for external deps (bcryptjs, jwt, id generator) and typed mocks for DAOs.