### PR TITLE
fix(security): require JWT_SECRET env variable, remove hardcoded default

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -101,6 +101,8 @@ jobs:
     name: Unit/Integration tests
     runs-on: ubuntu-latest
     needs: changed-files
+    env:
+      JWT_SECRET: ci-test-secret-do-not-use-in-prod
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -120,6 +122,8 @@ jobs:
   e2e:
     name: E2E via docker-compose
     runs-on: ubuntu-latest
+    env:
+      JWT_SECRET: ci-test-secret-do-not-use-in-prod
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docker-compose.ci-tests.yml
+++ b/docker-compose.ci-tests.yml
@@ -41,7 +41,8 @@ services:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
       MINIO_BUCKET: shadow
-      JWT_SECRET: shadow-dev-secret
+      # CI test secret — never used in production
+      JWT_SECRET: ci-test-secret-do-not-use-in-prod
       OAUTH_BASE_URL: http://localhost:3000
       CORS_ORIGIN: http://localhost:3000
       ADMIN_EMAIL: admin@shadowob.app

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -48,7 +48,8 @@ services:
     environment:
       DATABASE_URL: postgresql://shadow:shadow@postgres:5432/shadow
       REDIS_URL: redis://redis:6379
-      JWT_SECRET: ${JWT_SECRET:-shadow-dev-secret}
+      # E2E test secret — never used in production
+      JWT_SECRET: ci-test-secret-do-not-use-in-prod
       JWT_EXPIRES_IN: 7d
       PORT: 3002
       HOST: 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     environment:
       DATABASE_URL: postgresql://shadow:shadow@postgres:5432/shadow
       REDIS_URL: redis://redis:6379
-      JWT_SECRET: ${JWT_SECRET:-shadow-dev-secret}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       JWT_EXPIRES_IN: 7d
       PORT: 3002
       HOST: 0.0.0.0


### PR DESCRIPTION
## Summary

Fixes a critical security issue where JWT_SECRET falls back to a hardcoded 'shadow-dev-secret' when not configured.

## Changes

- Remove hardcoded JWT_SECRET default value from docker-compose.yml (uses ${JWT_SECRET:?required} to fail if unset)
- Replace hardcoded secret in docker-compose.ci-tests.yml with explicit test-only value
- Replace hardcoded secret in docker-compose.e2e.yml with explicit test-only value
- JWT_SECRET validation already present in apps/server/src/lib/jwt.ts (throws on startup if unset)

## Risk

**Breaking change**: Production deployments must now set JWT_SECRET environment variable. Server will refuse to start without it.

Found during security audit review.