### PR TITLE
fix(ci): include server E2E tests in CI pipeline

### DIFF
--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,0 +1,10 @@
+import { configDefaults, defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [...configDefaults.exclude],
+  },
+})


### PR DESCRIPTION
## Summary

Fixes a CI configuration issue where server E2E tests were excluded from the test pipeline.

## Root Cause

The root `vitest.config.ts` has an `exclude` pattern of `apps/**` which was excluding all 22 server E2E tests in `apps/server/__tests__/`. Since the server didn't have its own `vitest.config.ts`, vitest fell back to the root config when running in CI.

## Changes

- Add `apps/server/vitest.config.ts` with explicit test include pattern
- Prevents fallback to root config's `apps/**` exclusion

## Impact

- 22 server E2E tests will now run in CI
- Tests include: dm-e2e, e2e, mobile-e2e, oauth-e2e, rental-e2e, sdk-e2e, shop-e2e, socket-realtime-e2e, workspace-e2e, and more

Found during testing audit review.