### PR TITLE
refactor(ws): fix gateway cross-layer imports

### DIFF
--- a/apps/server/src/handlers/dm.handler.ts
+++ b/apps/server/src/handlers/dm.handler.ts
@@ -1,61 +1,11 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
-import type { Server as SocketIOServer } from 'socket.io'
 import { z } from 'zod'
 import type { AppContainer } from '../container'
 import { LIMITS } from '@shadowob/shared'
 import { logger } from '../lib/logger'
 import { authMiddleware } from '../middleware/auth.middleware'
-
-/**
- * Relay a DM to a bot user for AI processing.
- * Shared by both REST and WebSocket send paths to avoid duplication.
- */
-export async function relayDmToBot(
-  io: SocketIOServer,
-  container: AppContainer,
-  dmChannelId: string,
-  senderId: string,
-  otherUserId: string,
-  message: {
-    id: string
-    content: string
-    author?: unknown
-    createdAt: unknown
-    replyToId?: string | null
-    attachments?: { id: string; filename: string; url: string; contentType: string; size: number }[]
-  },
-) {
-  const userDao = container.resolve('userDao')
-  const otherUser = await userDao.findById(otherUserId)
-  if (!otherUser?.isBot) return
-
-  // Ensure bot socket is in DM room
-  const botSockets = await io.in(`user:${otherUserId}`).fetchSockets()
-  for (const bs of botSockets) {
-    bs.join(`dm:${dmChannelId}`)
-  }
-  logger.info({ otherUserId, dmChannelId, botSocketCount: botSockets.length }, 'Relaying DM to bot')
-
-  if (botSockets.length === 0) {
-    logger.warn({ otherUserId, dmChannelId }, 'Bot has no active sockets — DM relay may be missed')
-  }
-
-  const dmPayload = {
-    id: message.id,
-    content: message.content,
-    dmChannelId,
-    channelId: `dm:${dmChannelId}`,
-    authorId: senderId,
-    author: message.author,
-    senderId,
-    receiverId: otherUserId,
-    createdAt: message.createdAt,
-    replyToId: message.replyToId ?? null,
-    attachments: message.attachments ?? [],
-  }
-  io.to(`dm:${dmChannelId}`).to(`user:${otherUserId}`).emit('dm:message:new', dmPayload)
-}
+import { relayDmToBot } from '../lib/dm-relay'
 
 export function createDmHandler(container: AppContainer) {
   const dmHandler = new Hono()

--- a/apps/server/src/lib/dm-relay.ts
+++ b/apps/server/src/lib/dm-relay.ts
@@ -1,0 +1,56 @@
+import type { Server as SocketIOServer } from 'socket.io'
+import type { AppContainer } from '../container'
+import { logger } from './logger'
+
+/**
+ * Relay a DM to a bot user for AI processing.
+ * Shared by both REST and WebSocket send paths to avoid duplication.
+ *
+ * This is a utility function, not a handler or service — it coordinates
+ * Socket.IO emission with user/DM lookups and belongs in the lib layer.
+ */
+export async function relayDmToBot(
+  io: SocketIOServer,
+  container: AppContainer,
+  dmChannelId: string,
+  senderId: string,
+  otherUserId: string,
+  message: {
+    id: string
+    content: string
+    author?: unknown
+    createdAt: unknown
+    replyToId?: string | null
+    attachments?: { id: string; filename: string; url: string; contentType: string; size: number }[]
+  },
+) {
+  const userDao = container.resolve('userDao')
+  const otherUser = await userDao.findById(otherUserId)
+  if (!otherUser?.isBot) return
+
+  // Ensure bot socket is in DM room
+  const botSockets = await io.in(`user:${otherUserId}`).fetchSockets()
+  for (const bs of botSockets) {
+    bs.join(`dm:${dmChannelId}`)
+  }
+  logger.info({ otherUserId, dmChannelId, botSocketCount: botSockets.length }, 'Relaying DM to bot')
+
+  if (botSockets.length === 0) {
+    logger.warn({ otherUserId, dmChannelId }, 'Bot has no active sockets — DM relay may be missed')
+  }
+
+  const dmPayload = {
+    id: message.id,
+    content: message.content,
+    dmChannelId,
+    channelId: `dm:${dmChannelId}`,
+    authorId: senderId,
+    author: message.author,
+    senderId,
+    receiverId: otherUserId,
+    createdAt: message.createdAt,
+    replyToId: message.replyToId ?? null,
+    attachments: message.attachments ?? [],
+  }
+  io.to(`dm:${dmChannelId}`).to(`user:${otherUserId}`).emit('dm:message:new', dmPayload)
+}

--- a/apps/server/src/ws/chat.gateway.ts
+++ b/apps/server/src/ws/chat.gateway.ts
@@ -1,6 +1,6 @@
 import type { Socket, Server as SocketIOServer } from 'socket.io'
 import type { AppContainer } from '../container'
-import { relayDmToBot } from '../handlers/dm.handler'
+import { relayDmToBot } from '../lib/dm-relay'
 import { logger } from '../lib/logger'
 
 export function setupChatGateway(io: SocketIOServer, container: AppContainer): void {


### PR DESCRIPTION
## Summary

Fixes architecture issues where gateways were importing handlers directly, breaking the layered architecture.

## Changes

- Move `relayDmToBot` from `handlers/dm.handler.ts` to `lib/dm-relay.ts`
- Both the REST handler and WebSocket gateway now import from the shared lib layer
- Remove direct handler imports from gateways
- Maintain proper Handler → Service → DAO architecture

## Details

**Before:** `chat.gateway.ts` imported `relayDmToBot` from `../handlers/dm.handler`, violating the layered architecture (Gateway → Handler).

**After:** `relayDmToBot` lives in `lib/dm-relay.ts` as a shared utility, imported by both handler and gateway.

Found during architecture audit review.