### PR TITLE
fix(security): do not expose internal error details in production

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -42,8 +42,6 @@ export function createApp(container: AppContainer) {
     return c.json(
       {
         error: status >= 500 ? 'Internal Server Error' : message,
-        // Beta: always include detail for easier debugging
-        ...(status >= 500 ? { detail: message } : {}),
       },
       status as 400,
     )


### PR DESCRIPTION
## Summary

Removes beta debug mode that exposed internal error details to clients.

## Changes

- Remove detail field from 500 error responses
- 500 errors return generic 'Internal Server Error' only
- Internal errors are still logged server-side

Found during security audit review.