### PR TITLE
ci: fail build on critical npm vulnerabilities

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -35,8 +35,7 @@ jobs:
           node-version: 22
 
       - name: Run pnpm audit
-        run: pnpm audit --prod 2>&1 || true
-        # pnpm audit returns non-zero on findings — log but don't block yet
+        run: pnpm audit --prod --audit-level critical
 
       - name: Check for critical/high vulnerabilities
         run: |
@@ -53,7 +52,8 @@ jobs:
           ")
           echo "Critical + High vulnerabilities: $CRITICAL"
           if [ "$CRITICAL" -gt 0 ] 2>/dev/null; then
-            echo "::warning::Found $CRITICAL critical/high npm vulnerabilities"
+            echo "::error::Found $CRITICAL critical/high npm vulnerabilities — please review and update dependencies"
+            exit 1
           fi
 
   docker-scan:


### PR DESCRIPTION
## Summary

Changes pnpm audit to fail the CI build when critical vulnerabilities are found.

## Changes

- Use `--audit-level critical` flag so `pnpm audit` exits non-zero on critical vulnerabilities
- Removed `|| true` that was swallowing audit exit codes
- Upgraded the critical/high check step from `::warning::` to `::error::` with `exit 1` to actually fail the build
- Lower severity issues still shown as warnings

Found during devops audit review.