### PR TITLE
ci(docker): add multi-stage build for Dockerfile.e2e

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,7 @@
-FROM mcr.microsoft.com/playwright:v1.59.0-jammy
+# ─────────────────────────────────────────────
+# Stage 1: Builder - install deps & build packages
+# ─────────────────────────────────────────────
+FROM mcr.microsoft.com/playwright:v1.59.0-jammy AS builder
 
 RUN corepack enable && corepack prepare pnpm@10.19.0 --activate
 
@@ -7,10 +10,47 @@ RUN corepack enable && corepack prepare pnpm@10.19.0 --activate
 RUN git config --global url."https://github.com/".insteadOf "git@github.com:" && \
     git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
 
+WORKDIR /workspace
+
+# Layer 1: Workspace manifests + lockfile (cached unless dependencies change)
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/admin/package.json ./apps/admin/
+COPY apps/desktop/package.json ./apps/desktop/
+COPY apps/mobile/package.json ./apps/mobile/
+COPY apps/playground/package.json ./apps/playground/
+COPY apps/server/package.json ./apps/server/
+COPY apps/web/package.json ./apps/web/
+COPY packages/cli/package.json ./packages/cli/
+COPY packages/oauth/package.json ./packages/oauth/
+COPY packages/openclaw-shadowob/package.json ./packages/openclaw-shadowob/
+COPY packages/sdk/package.json ./packages/sdk/
+COPY packages/shared/package.json ./packages/shared/
+COPY packages/ui/package.json ./packages/ui/
+
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+# Layer 2: Source code + build packages
+COPY . .
+
+RUN pnpm build:packages
+
+# ─────────────────────────────────────────────
+# Stage 2: Runner - copy built artifacts + source for e2e
+# ─────────────────────────────────────────────
+FROM mcr.microsoft.com/playwright:v1.59.0-jammy AS runner
+
+RUN corepack enable && corepack prepare pnpm@10.19.0 --activate
+
 RUN npm install -g openclaw@latest
 
 WORKDIR /workspace
 
-COPY . .
+# Copy all built artifacts from builder (node_modules + dist/)
+# .dockerignore excludes these from the build context, so COPY . . won't overwrite them
+COPY --from=builder /workspace/node_modules ./node_modules
+COPY --from=builder /workspace/apps ./apps
+COPY --from=builder /workspace/packages ./packages
 
-RUN pnpm install --frozen-lockfile --ignore-scripts
+# Copy remaining source files (scripts, configs, docs, etc.)
+# Excludes node_modules/ and dist/ per .dockerignore
+COPY . .


### PR DESCRIPTION
## Summary

Adds multi-stage build to Dockerfile.e2e for faster builds and smaller images.

## Changes

- **Stage 1 (builder)**: Installs dependencies with optimized layer caching (selective COPY of package manifests + lockfile), then builds all packages
- **Stage 2 (runner)**: Copies only built artifacts (node_modules + dist) from builder, then overlays source files for e2e test execution
- Leverages existing `.dockerignore` to ensure `COPY . .` in runner doesn't overwrite builder artifacts

## Benefits

- **Faster rebuilds**: Dependency install layer cached unless package.json/lockfile changes
- **No redundant builds**: Packages built once in builder, reused in runner
- **Cleaner separation**: Runner only carries what's needed for e2e execution

Found during devops audit review.