### PR TITLE
fix(security): remove default passwords from docker-compose.yml

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -129,6 +129,10 @@ jobs:
 
       - name: Run E2E stack
         shell: bash
+        env:
+          JWT_SECRET: e2e-test-secret-not-for-production
+          ADMIN_EMAIL: admin@shadowob.app
+          ADMIN_PASSWORD: admin123456
         run: |
           docker compose -f docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from e2e-runner e2e-runner
 


### PR DESCRIPTION
## Summary

Removes default passwords and requires sensitive credentials to be set via environment variables.

## Changes

- **JWT_SECRET**: Removed default `shadow-dev-secret`, now requires ${JWT_SECRET:?message}
- **ADMIN_PASSWORD**: Removed default `admin123456`, now requires ${ADMIN_PASSWORD:?message}
- **ADMIN_EMAIL**: Removed default `admin@shadowob.app`, now requires ${ADMIN_EMAIL:?message}
- **Postgres**: Parameterized credentials with dev defaults (`shadow/shadow`) + security warning comments
- **MinIO**: Parameterized credentials with dev defaults (`minioadmin/minioadmin`) + security warning comments
- **DATABASE_URL**: Now uses parameterized Postgres vars
- **MINIO_ACCESS_KEY/SECRET_KEY**: Now reference ${MINIO_ROOT_USER/PASSWORD} consistently
- Updated `.env.example` header to cover both dev and prod

## Strategy

| Variable | Default? | Reason |
|----------|----------|--------|
| JWT_SECRET | ❌ Required | Critical security — no default allowed |
| ADMIN_PASSWORD | ❌ Required | Must be user-defined |
| ADMIN_EMAIL | ❌ Required | Must be user-defined |
| Postgres creds | ✅ Dev default | Convenience for local dev, prod file requires them |
| MinIO creds | ✅ Dev default | Convenience for local dev, prod file requires them |

Found during security audit review.