### PR TITLE
i18n(mobile): replace hardcoded Chinese strings with t() calls

### DIFF
--- a/apps/mobile/src/components/chat/markdown-renderer.tsx
+++ b/apps/mobile/src/components/chat/markdown-renderer.tsx
@@ -4,6 +4,7 @@ import { Check, Copy } from 'lucide-react-native'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Linking, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { EnrichedMarkdownText, type MarkdownStyle } from 'react-native-enriched-markdown'
+import { useTranslation } from 'react-i18next'
 import { showToast } from '../../lib/toast'
 import type { ColorTokens } from '../../theme'
 import { useColors } from '../../theme'
@@ -53,13 +54,14 @@ function CodeBlock({
   language?: string
   colors: ColorTokens
 }) {
+  const { t } = useTranslation()
   const [copied, setCopied] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleCopy = useCallback(async () => {
     await Clipboard.setStringAsync(code)
     setCopied(true)
-    showToast('已复制', 'success')
+    showToast(t('common.copied', 'Copied'), 'success')
     timerRef.current = setTimeout(() => setCopied(false), 2000)
   }, [code])
 

--- a/apps/mobile/src/components/common/avatar-editor.tsx
+++ b/apps/mobile/src/components/common/avatar-editor.tsx
@@ -4,6 +4,7 @@ import * as ImagePicker from 'expo-image-picker'
 import { Dices, Upload } from 'lucide-react-native'
 import { useState } from 'react'
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native'
+import { useTranslation } from 'react-i18next'
 import { fetchApi, getImageUrl } from '../../lib/api'
 import { showToast } from '../../lib/toast'
 import { fontSize, radius, spacing, useColors } from '../../theme'
@@ -15,6 +16,7 @@ interface AvatarEditorProps {
 }
 
 export function AvatarEditor({ value, userId, onChange }: AvatarEditorProps) {
+  const { t } = useTranslation()
   const colors = useColors()
   const [uploading, setUploading] = useState(false)
   const [tab, setTab] = useState<'preset' | 'upload'>('preset')
@@ -52,9 +54,9 @@ export function AvatarEditor({ value, userId, onChange }: AvatarEditorProps) {
         body: formData,
       })
       onChange(data.url)
-      showToast('头像已上传')
+      showToast(t('common.avatarUploaded', '头像已上传'))
     } catch (err) {
-      showToast(err instanceof Error ? err.message : '上传失败')
+      showToast(err instanceof Error ? err.message : t('common.uploadFailed', '上传失败'))
     } finally {
       setUploading(false)
     }

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -23,6 +23,8 @@
     "copied": "Copied",
     "loading": "Loading...",
     "uploading": "Uploading...",
+    "avatarUploaded": "Avatar uploaded",
+    "uploadFailed": "Upload failed",
     "delete": "Delete",
     "edit": "Edit",
     "close": "Close",

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -23,6 +23,8 @@
     "copied": "コピーしました",
     "loading": "読み込み中...",
     "uploading": "アップロード中...",
+    "avatarUploaded": "アバターがアップロードされました",
+    "uploadFailed": "アップロードに失敗しました",
     "delete": "削除",
     "edit": "編集",
     "close": "閉じる",

--- a/apps/mobile/src/i18n/locales/ko.json
+++ b/apps/mobile/src/i18n/locales/ko.json
@@ -23,6 +23,8 @@
     "copied": "복사됨",
     "loading": "로딩 중...",
     "uploading": "업로드 중...",
+    "avatarUploaded": "아바타가 업로드되었습니다",
+    "uploadFailed": "업로드 실패",
     "delete": "삭제",
     "edit": "편집",
     "close": "닫기",

--- a/apps/mobile/src/i18n/locales/zh-CN.json
+++ b/apps/mobile/src/i18n/locales/zh-CN.json
@@ -23,6 +23,8 @@
     "copied": "已复制",
     "loading": "加载中...",
     "uploading": "上传中...",
+    "avatarUploaded": "头像已上传",
+    "uploadFailed": "上传失败",
     "delete": "删除",
     "edit": "编辑",
     "close": "关闭",

--- a/apps/mobile/src/i18n/locales/zh-TW.json
+++ b/apps/mobile/src/i18n/locales/zh-TW.json
@@ -23,6 +23,8 @@
     "copied": "已複製",
     "loading": "載入中...",
     "uploading": "上傳中...",
+    "avatarUploaded": "頭像已上傳",
+    "uploadFailed": "上傳失敗",
     "delete": "刪除",
     "edit": "編輯",
     "close": "關閉",


### PR DESCRIPTION
## Summary

Replaces hardcoded Chinese strings in mobile components with i18n t() calls.

## Changes

- **markdown-renderer.tsx**: Replace hardcoded '已复制' in showToast with t('common.copied')
- **avatar-editor.tsx**: Replace hardcoded '头像已上传' and '上传失败' in showToast with t() calls
- Add missing keys to all 5 locale files (en, zh-CN, zh-TW, ja, ko)
- Ensure useTranslation is imported in both components

Found during i18n audit review.