### PR TITLE
feat(i18n): add useToast hook for i18n-aware toast messages

### DIFF
--- a/apps/web/src/hooks/use-toast.ts
+++ b/apps/web/src/hooks/use-toast.ts
@@ -1,0 +1,28 @@
+/**
+ * i18n-aware toast hook.
+ * Wraps showToast with useTranslation so components can pass translation keys
+ * instead of hardcoded strings.
+ */
+import { useTranslation } from 'react-i18next'
+import { showToast, type ToastType } from '../lib/toast'
+
+/** Return type: a function that accepts a translation key and shows a toast. */
+export type UseToastFn = (messageKey: string, type?: ToastType) => void
+
+/**
+ * Hook that returns a toast function bound to the current i18n context.
+ *
+ * Usage:
+ * ```tsx
+ * const toast = useToast()
+ * toast('toast.success.saved', 'success')
+ * ```
+ */
+export function useToast(): UseToastFn {
+  const { t } = useTranslation()
+
+  return (messageKey: string, type: ToastType = 'info') => {
+    const message = t(messageKey, messageKey) // fallback to key itself if missing
+    showToast(message, type)
+  }
+}

--- a/apps/web/src/lib/toast.ts
+++ b/apps/web/src/lib/toast.ts
@@ -3,7 +3,7 @@
  * Uses DOM manipulation to avoid React re-render overhead.
  */
 
-type ToastType = 'error' | 'success' | 'info'
+export type ToastType = 'error' | 'success' | 'info'
 
 type ToastHook = (message: string, type?: ToastType) => void
 
@@ -61,4 +61,23 @@ export function showToast(message: string, type: ToastType = 'info') {
     el.style.transform = 'translateY(-8px)'
     setTimeout(() => el.remove(), 300)
   }, TOAST_DURATION)
+}
+
+/**
+ * Factory function that creates an i18n-aware toast function.
+ * Useful outside of React component context (e.g. in services, utilities,
+ * or after fetching the i18n instance).
+ *
+ * Usage:
+ * ```ts
+ * import { i18n } from './i18n'
+ * const toast = createI18nToast(i18n)
+ * toast('toast.error.network', 'error')
+ * ```
+ */
+export function createI18nToast(t: (key: string) => string) {
+  return (messageKey: string, type: ToastType = 'info') => {
+    const message = t(messageKey)
+    showToast(message, type)
+  }
 }


### PR DESCRIPTION
## Summary

Adds useToast hook that wraps showToast with i18n t() support, enabling components to pass translation keys instead of hardcoded strings.

## Changes

- **Create `useToast` hook** (`apps/web/src/hooks/use-toast.ts`)
  - Wraps `showToast` with `useTranslation()` from react-i18next
  - Components can now pass translation keys: `toast('toast.success.saved', 'success')`
  - Falls back to the key itself if translation is missing

- **Update `lib/toast.ts`**
  - Export `ToastType` type for external consumers
  - Add `createI18nToast(t)` factory function for non-component contexts (services, utilities)

## Usage

```tsx
// In a React component
const toast = useToast()
toast('toast.success.saved', 'success')

// Outside React (e.g. in a service)
import { createI18nToast } from '@/lib/toast'
import { i18n } from '@/i18n'
const toast = createI18nToast(i18n.t.bind(i18n))
toast('toast.error.network', 'error')
```

Found during i18n audit review.