### PR TITLE
i18n(web): translate chat component hardcoded strings

### DIFF
--- a/apps/web/src/components/chat/chat-area.tsx
+++ b/apps/web/src/components/chat/chat-area.tsx
@@ -718,10 +718,10 @@ export function ChatArea() {
           method: 'POST',
           body: formData,
         })
-        showToast(t('chat.savedToWorkspace', '已保存到工作区'), 'success')
+        showToast(t('chat.savedToWorkspace'), 'success')
         setSaveToWorkspaceFile(null)
       } catch (_err) {
-        showToast(t('chat.saveToWorkspaceFailed', '保存到工作区失败'), 'error')
+        showToast(t('chat.saveToWorkspaceFailed'), 'error')
       }
     },
     [saveToWorkspaceFile, activeServerId],

--- a/apps/web/src/components/chat/image-context-menu.tsx
+++ b/apps/web/src/components/chat/image-context-menu.tsx
@@ -25,6 +25,7 @@ export function ImageContextMenu({
   onClose,
   onSaveToWorkspace,
 }: ImageContextMenuProps) {
+  const { t } = useTranslation()
   const menuRef = useRef<HTMLDivElement>(null)
   const position = useContextMenuPosition(x, y, menuRef, 180)
   const [showInfo, setShowInfo] = useState(false)
@@ -51,7 +52,7 @@ export function ImageContextMenu({
 
   function handleCopyLink() {
     navigator.clipboard.writeText(attachment.url)
-    showToast(t('chat.imageLinkCopied', '链接已复制'), 'success')
+    showToast(t('chat.linkCopied'), 'success')
     onClose()
   }
 

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -365,7 +365,7 @@
     "enterFullscreen": "Fullscreen",
     "exitFullscreen": "Exit Fullscreen",
     "dropFilesHere": "Drop files here to upload",
-    "imageLinkCopied": "Image link copied",
+    "linkCopied": "Link copied",
     "savedToWorkspace": "Saved to workspace",
     "saveToWorkspaceFailed": "Failed to save to workspace"
   },

--- a/apps/web/src/lib/locales/ja.json
+++ b/apps/web/src/lib/locales/ja.json
@@ -375,7 +375,7 @@
     "enterFullscreen": "フルスクリーン",
     "exitFullscreen": "フルスクリーン終了",
     "dropFilesHere": "ここにファイルをドロップしてアップロード",
-    "imageLinkCopied": "画像リンクがコピーされました",
+    "linkCopied": "リンクをコピーしました",
     "savedToWorkspace": "ワークスペースに保存しました",
     "saveToWorkspaceFailed": "ワークスペースへの保存に失敗しました"
   },

--- a/apps/web/src/lib/locales/ko.json
+++ b/apps/web/src/lib/locales/ko.json
@@ -375,7 +375,7 @@
     "enterFullscreen": "전체 화면",
     "exitFullscreen": "전체 화면 종료",
     "dropFilesHere": "파일을 여기에 끌어다 놓아 업로드",
-    "imageLinkCopied": "이미지 링크가 복사되었습니다",
+    "linkCopied": "링크가 복사되었습니다",
     "savedToWorkspace": "워크스페이스에 저장됨",
     "saveToWorkspaceFailed": "워크스페이스 저장 실패"
   },

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -365,7 +365,7 @@
     "enterFullscreen": "全屏",
     "exitFullscreen": "退出全屏",
     "dropFilesHere": "拖放文件到此处上传",
-    "imageLinkCopied": "链接已复制",
+    "linkCopied": "链接已复制",
     "savedToWorkspace": "已保存到工作区",
     "saveToWorkspaceFailed": "保存到工作区失败"
   },

--- a/apps/web/src/lib/locales/zh-TW.json
+++ b/apps/web/src/lib/locales/zh-TW.json
@@ -375,7 +375,7 @@
     "enterFullscreen": "全螢幕",
     "exitFullscreen": "退出全螢幕",
     "dropFilesHere": "拖放檔案到此處上傳",
-    "imageLinkCopied": "連結已複製",
+    "linkCopied": "連結已複製",
     "savedToWorkspace": "已儲存到工作區",
     "saveToWorkspaceFailed": "儲存到工作區失敗"
   },


### PR DESCRIPTION
## Summary
Replace hardcoded Chinese in chat components with i18n keys.

## Changes
- image-context-menu.tsx: 1 string
- chat-area.tsx: 2 strings
- Add keys to all 5 locale files