### PR TITLE
i18n(mobile): add missing splash keys to ja/ko/zh-TW locales

### DIFF
--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -1125,5 +1125,16 @@
     "sortByName": "名前順",
     "sortByDate": "日付順",
     "sortBySize": "サイズ順"
+  },
+  "splash": {
+    "welcome": "Shadow へようこそ",
+    "welcomeDesc": "AI コミュニティを構築して、エージェントをチームメイトに",
+    "chat": "リアルタイムチャット",
+    "chatDesc": "チャンネルでコミュニティとチャット。Markdown、画像、絵文字に対応",
+    "buddy": "AI アシスタント Buddy",
+    "buddyDesc": "チャンネルに AI アシスタントを追加して、質問回答やタスク実行を支援",
+    "community": "コミュニティを作成",
+    "communityDesc": "自分のサーバーを作成して、同じ趣味の友達を招待",
+    "getStarted": "始めよう"
   }
 }

--- a/apps/mobile/src/i18n/locales/ko.json
+++ b/apps/mobile/src/i18n/locales/ko.json
@@ -1125,5 +1125,16 @@
     "sortByName": "이름순",
     "sortByDate": "날짜순",
     "sortBySize": "크기순"
+  },
+  "splash": {
+    "welcome": "Shadow에 오신 것을 환영합니다",
+    "welcomeDesc": "AI 커뮤니티를 구축하고 에이전트를 팀원으로",
+    "chat": "실시간 채팅",
+    "chatDesc": "채널에서 커뮤니티와 채팅하세요. Markdown, 이미지, 이모지 지원",
+    "buddy": "AI 어시스턴트 Buddy",
+    "buddyDesc": "채널에 AI 어시스턴트를 추가하여 질문 답변과 작업 실행을 지원받으세요",
+    "community": "커뮤니티 만들기",
+    "communityDesc": "나만의 서버를 만들고 뜻이 맞는 친구들을 초대하세요",
+    "getStarted": "시작하기"
   }
 }

--- a/apps/mobile/src/i18n/locales/zh-TW.json
+++ b/apps/mobile/src/i18n/locales/zh-TW.json
@@ -1122,5 +1122,16 @@
     "sortByName": "按名稱排序",
     "sortByDate": "按日期排序",
     "sortBySize": "按大小排序"
+  },
+  "splash": {
+    "welcome": "歡迎來到 Shadow",
+    "welcomeDesc": "構建你的 AI 社群，讓搭子成為你的隊友",
+    "chat": "即時聊天",
+    "chatDesc": "在頻道中與社群成員即時交流，支援 Markdown、圖片、表情",
+    "buddy": "AI 搭子 Buddy",
+    "buddyDesc": "添加 AI 搭子到頻道，讓它幫你回答問題、執行任務",
+    "community": "創建社群",
+    "communityDesc": "創建你自己的伺服器，邀請志同道合的朋友加入",
+    "getStarted": "開始使用"
   }
 }


### PR DESCRIPTION
Add missing splash.* keys to ja.json, ko.json, zh-TW.json.

## Changes
- **ja.json**: Added `splash.welcome`, `splash.welcomeDesc`, `splash.chat`, `splash.chatDesc`, `splash.buddy`, `splash.buddyDesc`, `splash.community`, `splash.communityDesc`, `splash.getStarted`
- **ko.json**: Added same splash keys with Korean translations
- **zh-TW.json**: Added same splash keys with Traditional Chinese translations