### PR TITLE
i18n(mobile): add missing member policy keys to ja/ko/zh-TW locales

### DIFF
--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -428,7 +428,14 @@
     "inChannel": "参加中",
     "inviteMembers": "メンバーを招待",
     "searchMembers": "メンバーを検索...",
-    "allMembersAdded": "全てのサーバーメンバーがこのチャンネルに参加済みです"
+    "allMembersAdded": "全てのサーバーメンバーがこのチャンネルに参加済みです",
+    "policyBuddyInteraction": "Buddy 間のやり取り",
+    "policyReplyToBuddy": "他の Buddy のメッセージに返信",
+    "policyReplyToBuddyDesc": "この Buddy がチャンネル内の他の Buddy からのメッセージに返信できるようにします",
+    "policyMaxBuddyChainDepth": "最大会話チェーン深度",
+    "policyMaxBuddyChainDepthDesc": "Buddy 間の無限ループを防ぎます（デフォルト: 3）",
+    "policySmartReply": "スマート返信",
+    "policySmartReplyDesc": "明らかに他のユーザー宛てのメッセージをスキップします（例：他の人を @メンションしているが、この Buddy は含まれていない場合）"
   },
   "features": {
     "pageTitle": "必要なコラボ機能がすべて揃っています",

--- a/apps/mobile/src/i18n/locales/ko.json
+++ b/apps/mobile/src/i18n/locales/ko.json
@@ -428,7 +428,14 @@
     "inChannel": "채널 참여 중",
     "inviteMembers": "멤버 초대",
     "searchMembers": "멤버 검색...",
-    "allMembersAdded": "모든 서버 멤버가 이 채널에 이미 참여 중입니다"
+    "allMembersAdded": "모든 서버 멤버가 이 채널에 이미 참여 중입니다",
+    "policyBuddyInteraction": "Buddy 간 상호작용",
+    "policyReplyToBuddy": "다른 Buddy의 메시지에 답장",
+    "policyReplyToBuddyDesc": "이 Buddy가 채널 내 다른 Buddy가 보낸 메시지에 답장할 수 있도록 허용합니다",
+    "policyMaxBuddyChainDepth": "최대 대화 체인 깊이",
+    "policyMaxBuddyChainDepthDesc": "Buddy 간 무한 루프를 방지합니다 (기본값: 3)",
+    "policySmartReply": "스마트 답장",
+    "policySmartReplyDesc": "명백히 다른 사람을 대상으로 하는 메시지를 건너뜁니다 (예: 다른 사람을 @멘션했지만 이 Buddy는 포함되지 않은 경우)"
   },
   "features": {
     "pageTitle": "필요한 모든 협업 기능",

--- a/apps/mobile/src/i18n/locales/zh-TW.json
+++ b/apps/mobile/src/i18n/locales/zh-TW.json
@@ -425,7 +425,14 @@
     "inChannel": "已加入頻道",
     "inviteMembers": "邀請成員",
     "searchMembers": "搜尋成員...",
-    "allMembersAdded": "所有伺服器成員已在此頻道中"
+    "allMembersAdded": "所有伺服器成員已在此頻道中",
+    "policyBuddyInteraction": "Buddy 互動",
+    "policyReplyToBuddy": "回覆其他 Buddy 的訊息",
+    "policyReplyToBuddyDesc": "允許此 Buddy 回覆頻道中其他 Buddy 傳送的訊息",
+    "policyMaxBuddyChainDepth": "最大對話鏈深度",
+    "policyMaxBuddyChainDepthDesc": "防止 Buddy 之間無限循環對話（預設：3）",
+    "policySmartReply": "智能回覆",
+    "policySmartReplyDesc": "跳過明顯針對其他人的訊息（如 @了別人但沒 @ 自己）"
   },
   "features": {
     "pageTitle": "所有你需要的協作功能",


### PR DESCRIPTION
Add 7 missing member.policy* keys to ja.json, ko.json, zh-TW.json.

- `policyBuddyInteraction`
- `policyReplyToBuddy` / `policyReplyToBuddyDesc`
- `policyMaxBuddyChainDepth` / `policyMaxBuddyChainDepthDesc`
- `policySmartReply` / `policySmartReplyDesc`