### PR TITLE
i18n(mobile): add missing chat keys to ja/ko/zh-TW locales

### DIFF
--- a/apps/mobile/src/i18n/locales/zh-TW.json
+++ b/apps/mobile/src/i18n/locales/zh-TW.json
@@ -370,7 +370,10 @@
     "isTyping": "正在輸入...",
     "areTyping": "正在輸入...",
     "copy": "複製",
-    "edit": "編輯"
+    "edit": "編輯",
+    "micPermissionDenied": "語音輸入需要麥克風權限",
+    "speechLang": "zh-TW",
+    "voiceInputUnavailable": "此版本不支援語音輸入，請使用開發版本。"
   },
   "member": {
     "title": "成員",


### PR DESCRIPTION
Add missing chat.* keys to ja.json, ko.json, zh-TW.json.

- **ja**: no missing keys
- **ko**: no missing keys
- **zh-TW**: added 3 missing keys:
  - `chat.micPermissionDenied`
  - `chat.speechLang`
  - `chat.voiceInputUnavailable`