### PR TITLE
feat(cloud): bare-server k3s cluster management via SSH

### DIFF
--- a/apps/cloud/README.md
+++ b/apps/cloud/README.md
@@ -108,6 +108,93 @@ Write your own — see [Config Reference](#config-reference) below.
 | `shadowob-cloud doctor` | Check prerequisites |
 | `shadowob-cloud build` | Build Docker images for Git agents |
 | `shadowob-cloud images` | Manage runner images |
+| `shadowob-cloud cluster init` | Bootstrap k3s on bare servers |
+| `shadowob-cloud cluster import` | Register an existing kubeconfig locally |
+| `shadowob-cloud cluster status` | Check SSH + k3s health on all nodes |
+| `shadowob-cloud cluster list` | List all registered clusters |
+| `shadowob-cloud cluster kubeconfig <name>` | Print kubeconfig path |
+| `shadowob-cloud cluster destroy` | Uninstall k3s and remove local files |
+
+## Bare-Server Cluster Management
+
+Deploy to cloud servers (Ubuntu/Debian) over SSH with a single command — no existing K8s required.
+
+### How it works
+
+1. `cluster init` — SSH into each server, install k3s, form the cluster, store kubeconfig at `~/.shadow-cloud/clusters/<name>.yaml`
+2. `up --cluster <name>` — Pulumi uses the stored kubeconfig to deploy agents to that cluster
+
+### 1. Write a cluster.json
+
+```jsonc
+{
+  "name": "prod",
+  "nodes": [
+    {
+      "role": "master",
+      "host": "1.2.3.4",
+      "user": "root",
+      "sshKeyPath": "~/.ssh/id_rsa"
+    },
+    {
+      "role": "worker",
+      "host": "1.2.3.5",
+      "user": "root",
+      "password": "${env:SERVER_PASSWORD}"
+    }
+  ]
+}
+```
+
+Credentials never stored on disk — use `${env:VAR}` for passwords.
+
+### 2. Bootstrap k3s
+
+```bash
+shadowob-cloud cluster init                        # default: reads cluster.json
+shadowob-cloud cluster init --config my-cluster.json
+shadowob-cloud cluster init --force                # reinstall k3s even if already present
+```
+
+**Re-initializing safely:** If k3s is already installed on a node, `init` skips that node by default. Pass `--force` to fully reinstall (uninstalls first, then reinstalls).
+
+### 3. Deploy agents
+
+```bash
+shadowob-cloud up --cluster prod
+shadowob-cloud up --cluster prod --stack prod      # use a named Pulumi stack
+shadowob-cloud up --cluster prod --skip-provision  # skip Shadow resource provisioning
+```
+
+### 4. Manage the cluster
+
+```bash
+shadowob-cloud cluster status                      # SSH health + k3s version on each node
+shadowob-cloud cluster list                        # list all registered clusters
+shadowob-cloud cluster kubeconfig prod             # print kubeconfig path (use with kubectl)
+
+export KUBECONFIG=$(shadowob-cloud cluster kubeconfig prod)
+kubectl get pods -n my-team
+```
+
+### 5. Share cluster access across machines
+
+Another developer on a different machine can register the same cluster without running `init` again:
+
+```bash
+# On any machine that has the kubeconfig file:
+shadowob-cloud cluster import --name prod --file ./prod.yaml
+shadowob-cloud up --cluster prod
+```
+
+### 6. Tear down
+
+```bash
+shadowob-cloud cluster destroy                     # confirms prompt
+shadowob-cloud cluster destroy --yes               # skip confirmation
+```
+
+Runs `k3s-uninstall.sh` (master) and `k3s-agent-uninstall.sh` (workers) over SSH, then removes `~/.shadow-cloud/clusters/prod.*`.
 
 ## Dashboard
 

--- a/apps/cloud/__tests__/cluster/cluster.test.ts
+++ b/apps/cloud/__tests__/cluster/cluster.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for cluster config schema and parser.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  getMasterNode,
+  getWorkerNodes,
+  readClusterConfig,
+  resolveNodeCredentials,
+} from '../../src/cluster/parser.js'
+import { ClusterConfigSchema } from '../../src/cluster/schema.js'
+
+// ─── Schema validation ────────────────────────────────────────────────────────
+
+describe('ClusterConfigSchema', () => {
+  const validConfig = {
+    name: 'prod',
+    provider: 'ssh',
+    nodes: [
+      { role: 'master', host: '1.2.3.4', user: 'root', sshKeyPath: '~/.ssh/id_rsa' },
+      { role: 'worker', host: '1.2.3.5', user: 'ubuntu', sshKeyPath: '~/.ssh/id_rsa' },
+    ],
+  }
+
+  it('accepts a valid config', () => {
+    const result = ClusterConfigSchema.safeParse(validConfig)
+    expect(result.success).toBe(true)
+  })
+
+  it('defaults port to 22', () => {
+    const result = ClusterConfigSchema.safeParse(validConfig)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.nodes[0]!.port).toBe(22)
+    }
+  })
+
+  it('rejects config with no nodes', () => {
+    const result = ClusterConfigSchema.safeParse({ ...validConfig, nodes: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects config with two masters', () => {
+    const twoMasters = {
+      ...validConfig,
+      nodes: [
+        { role: 'master', host: '1.2.3.4', user: 'root', sshKeyPath: '~/.ssh/id_rsa' },
+        { role: 'master', host: '1.2.3.5', user: 'root', sshKeyPath: '~/.ssh/id_rsa' },
+      ],
+    }
+    const result = ClusterConfigSchema.safeParse(twoMasters)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects config with no master', () => {
+    const noMaster = {
+      ...validConfig,
+      nodes: [{ role: 'worker', host: '1.2.3.4', user: 'root', sshKeyPath: '~/.ssh/id_rsa' }],
+    }
+    const result = ClusterConfigSchema.safeParse(noMaster)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a node with neither sshKeyPath nor password', () => {
+    const noAuth = {
+      ...validConfig,
+      nodes: [{ role: 'master', host: '1.2.3.4', user: 'root' }],
+    }
+    const result = ClusterConfigSchema.safeParse(noAuth)
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a node with password only', () => {
+    const withPassword = {
+      ...validConfig,
+      nodes: [
+        { role: 'master', host: '1.2.3.4', user: 'root', password: 'secret' },
+        { role: 'worker', host: '1.2.3.5', user: 'ubuntu', sshKeyPath: '~/.ssh/id_rsa' },
+      ],
+    }
+    const result = ClusterConfigSchema.safeParse(withPassword)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid cluster name (uppercase)', () => {
+    const result = ClusterConfigSchema.safeParse({ ...validConfig, name: 'MyCluster' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unknown provider', () => {
+    const result = ClusterConfigSchema.safeParse({ ...validConfig, provider: 'terraform' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ─── readClusterConfig ────────────────────────────────────────────────────────
+
+describe('readClusterConfig', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `shadow-cloud-test-${Date.now()}`)
+    mkdirSync(tmpDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('reads and validates a valid cluster.json', () => {
+    const configPath = join(tmpDir, 'cluster.json')
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        name: 'test',
+        provider: 'ssh',
+        nodes: [{ role: 'master', host: '1.2.3.4', user: 'root', sshKeyPath: '~/.ssh/id_rsa' }],
+      }),
+    )
+
+    const config = readClusterConfig(configPath)
+    expect(config.name).toBe('test')
+    expect(config.nodes).toHaveLength(1)
+  })
+
+  it('throws on missing file', () => {
+    expect(() => readClusterConfig('/nonexistent/cluster.json')).toThrow('Failed to read')
+  })
+
+  it('throws on invalid JSON', () => {
+    const configPath = join(tmpDir, 'bad.json')
+    writeFileSync(configPath, '{ invalid json }')
+    expect(() => readClusterConfig(configPath)).toThrow('Failed to read')
+  })
+
+  it('throws on schema violation with descriptive message', () => {
+    const configPath = join(tmpDir, 'cluster.json')
+    writeFileSync(configPath, JSON.stringify({ name: 'test', provider: 'ssh', nodes: [] }))
+    expect(() => readClusterConfig(configPath)).toThrow('Invalid cluster.json')
+  })
+})
+
+// ─── resolveNodeCredentials ───────────────────────────────────────────────────
+
+describe('resolveNodeCredentials', () => {
+  it('expands ~ in sshKeyPath', () => {
+    const creds = resolveNodeCredentials({
+      role: 'master',
+      host: '1.2.3.4',
+      port: 22,
+      user: 'root',
+      sshKeyPath: '~/.ssh/id_rsa',
+    })
+    expect(creds.sshKeyPath).toMatch(/^\//)
+    expect(creds.sshKeyPath).toContain('.ssh/id_rsa')
+  })
+
+  it('resolves ${env:VAR} in password', () => {
+    process.env.TEST_SSH_PASS = 'supersecret'
+    const creds = resolveNodeCredentials({
+      role: 'worker',
+      host: '1.2.3.5',
+      port: 22,
+      user: 'ubuntu',
+      password: '${env:TEST_SSH_PASS}',
+    })
+    delete process.env.TEST_SSH_PASS
+    expect(creds.password).toBe('supersecret')
+  })
+
+  it('throws if env var is not set', () => {
+    delete process.env.MISSING_VAR
+    expect(() =>
+      resolveNodeCredentials({
+        role: 'worker',
+        host: '1.2.3.5',
+        port: 22,
+        user: 'ubuntu',
+        password: '${env:MISSING_VAR}',
+      }),
+    ).toThrow('MISSING_VAR')
+  })
+
+  it('returns plain password as-is', () => {
+    const creds = resolveNodeCredentials({
+      role: 'worker',
+      host: '1.2.3.5',
+      port: 22,
+      user: 'ubuntu',
+      password: 'plainpassword',
+    })
+    expect(creds.password).toBe('plainpassword')
+  })
+})
+
+// ─── getMasterNode / getWorkerNodes ───────────────────────────────────────────
+
+describe('getMasterNode / getWorkerNodes', () => {
+  const config = ClusterConfigSchema.parse({
+    name: 'test',
+    provider: 'ssh',
+    nodes: [
+      { role: 'master', host: '10.0.0.1', user: 'root', sshKeyPath: '~/.ssh/id_rsa' },
+      { role: 'worker', host: '10.0.0.2', user: 'ubuntu', sshKeyPath: '~/.ssh/id_rsa' },
+      { role: 'worker', host: '10.0.0.3', user: 'ubuntu', sshKeyPath: '~/.ssh/id_rsa' },
+    ],
+  })
+
+  it('getMasterNode returns the master', () => {
+    const master = getMasterNode(config)
+    expect(master.host).toBe('10.0.0.1')
+    expect(master.role).toBe('master')
+  })
+
+  it('getWorkerNodes returns only workers', () => {
+    const workers = getWorkerNodes(config)
+    expect(workers).toHaveLength(2)
+    expect(workers.every((w) => w.role === 'worker')).toBe(true)
+  })
+})

--- a/apps/cloud/__tests__/cluster/kubeconfig.test.ts
+++ b/apps/cloud/__tests__/cluster/kubeconfig.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for cluster kubeconfig management.
+ */
+
+import { mkdirSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ─── Mock homedir to use temp directory ──────────────────────────────────────
+
+const tmpRoot = join(tmpdir(), `shadow-cloud-kubeconfig-test-${Date.now()}`)
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return {
+    ...actual,
+    homedir: () => tmpRoot,
+  }
+})
+
+// Import AFTER mocking
+const {
+  storeKubeconfig,
+  loadKubeconfigPath,
+  loadClusterMeta,
+  listRegisteredClusters,
+  removeClusterFiles,
+} = await import('../../src/cluster/kubeconfig.js')
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('kubeconfig management', () => {
+  beforeEach(() => {
+    mkdirSync(tmpRoot, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  const sampleKubeconfig = `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+`.trim()
+
+  it('storeKubeconfig replaces 127.0.0.1 with master public IP', () => {
+    const meta = storeKubeconfig('my-cluster', sampleKubeconfig, '1.2.3.4', 3)
+    const stored = readFileSync(meta.kubeconfigPath, 'utf8')
+    expect(stored).toContain('https://1.2.3.4:6443')
+    expect(stored).not.toContain('127.0.0.1')
+  })
+
+  it('storeKubeconfig writes correct metadata', () => {
+    const meta = storeKubeconfig('my-cluster', sampleKubeconfig, '1.2.3.4', 3)
+    expect(meta.name).toBe('my-cluster')
+    expect(meta.masterHost).toBe('1.2.3.4')
+    expect(meta.nodeCount).toBe(3)
+    expect(meta.createdAt).toBeTruthy()
+  })
+
+  it('loadKubeconfigPath returns path for registered cluster', () => {
+    storeKubeconfig('test-cluster', sampleKubeconfig, '5.6.7.8', 2)
+    const path = loadKubeconfigPath('test-cluster')
+    expect(path).toContain('test-cluster.yaml')
+  })
+
+  it('loadKubeconfigPath throws for unknown cluster', () => {
+    expect(() => loadKubeconfigPath('nonexistent')).toThrow('nonexistent')
+  })
+
+  it('loadClusterMeta returns null for unknown cluster', () => {
+    const meta = loadClusterMeta('nonexistent')
+    expect(meta).toBeNull()
+  })
+
+  it('listRegisteredClusters returns empty array when no clusters', () => {
+    const list = listRegisteredClusters()
+    expect(list).toEqual([])
+  })
+
+  it('listRegisteredClusters returns all registered clusters', () => {
+    storeKubeconfig('alpha', sampleKubeconfig, '1.1.1.1', 2)
+    storeKubeconfig('beta', sampleKubeconfig, '2.2.2.2', 4)
+    const list = listRegisteredClusters()
+    const names = list.map((c) => c.name).sort()
+    expect(names).toEqual(['alpha', 'beta'])
+  })
+
+  it('removeClusterFiles cleans up both files', () => {
+    storeKubeconfig('to-remove', sampleKubeconfig, '3.3.3.3', 1)
+    removeClusterFiles('to-remove')
+    expect(loadClusterMeta('to-remove')).toBeNull()
+    expect(() => loadKubeconfigPath('to-remove')).toThrow()
+  })
+})

--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -58,6 +58,7 @@
     "jsonc-parser": "^3.3.1",
     "lucide-react": "^0.513.0",
     "monaco-editor": "^0.55.1",
+    "node-ssh": "^13.2.1",
     "postgres": "^3.4.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/cloud/src/clients/pulumi-client.ts
+++ b/apps/cloud/src/clients/pulumi-client.ts
@@ -28,6 +28,8 @@ export interface StackOptions {
   stateDir?: string
   /** kubectl context for K8s provider */
   kubeContext?: string
+  /** Path to a kubeconfig YAML file — takes precedence over kubeContext when set */
+  kubeConfigPath?: string
   /** Image pull policy for containers */
   imagePullPolicy?: 'Always' | 'IfNotPresent' | 'Never'
 }
@@ -49,6 +51,7 @@ export async function getOrCreateStack(options: StackOptions) {
     provision: options.provision,
     shadowServerUrl: options.shadowServerUrl,
     kubeContext: options.kubeContext ?? process.env.KUBECONFIG_CONTEXT ?? 'rancher-desktop',
+    kubeConfigPath: options.kubeConfigPath,
     imagePullPolicy: options.imagePullPolicy ?? 'IfNotPresent',
   }
 

--- a/apps/cloud/src/cluster/destroy.ts
+++ b/apps/cloud/src/cluster/destroy.ts
@@ -1,0 +1,58 @@
+/**
+ * Cluster destroy — uninstall k3s from all nodes via SSH.
+ */
+
+import { removeClusterFiles } from './kubeconfig.js'
+import { resolveNodeCredentials } from './parser.js'
+import type { ClusterConfig, NodeConfig } from './schema.js'
+import { SSHClient } from './ssh.js'
+
+export interface DestroyClusterOptions {
+  config: ClusterConfig
+  onLog?: (msg: string) => void
+}
+
+async function uninstallNode(node: NodeConfig, onLog?: (m: string) => void): Promise<void> {
+  const creds = resolveNodeCredentials(node)
+  const client = new SSHClient()
+  onLog?.(`[${node.role} ${creds.host}] Connecting...`)
+
+  try {
+    await client.connect(creds)
+
+    const script =
+      node.role === 'master'
+        ? 'if [ -f /usr/local/bin/k3s-uninstall.sh ]; then /usr/local/bin/k3s-uninstall.sh; fi'
+        : 'if [ -f /usr/local/bin/k3s-agent-uninstall.sh ]; then /usr/local/bin/k3s-agent-uninstall.sh; fi'
+
+    onLog?.(`[${node.role} ${creds.host}] Uninstalling k3s...`)
+    const result = await client.exec(script, {
+      onStdout: (c) => onLog?.(`[${node.role} ${creds.host}] ${c.trimEnd()}`),
+      onStderr: (c) => onLog?.(`[${node.role} ${creds.host}] ${c.trimEnd()}`),
+    })
+
+    if (result.code !== 0) {
+      onLog?.(`[${node.role} ${creds.host}] Warning: uninstall script exited ${result.code}`)
+    } else {
+      onLog?.(`[${node.role} ${creds.host}] k3s uninstalled \u2713`)
+    }
+  } catch (err) {
+    onLog?.(`[${node.role} ${creds.host}] Error: ${(err as Error).message}`)
+  } finally {
+    await client.dispose()
+  }
+}
+
+/**
+ * Uninstall k3s from all nodes and remove local kubeconfig/metadata.
+ */
+export async function destroyCluster(options: DestroyClusterOptions): Promise<void> {
+  const { config, onLog } = options
+
+  onLog?.(`Destroying cluster "${config.name}"...`)
+
+  await Promise.all(config.nodes.map((node) => uninstallNode(node, onLog)))
+
+  removeClusterFiles(config.name)
+  onLog?.(`Cluster "${config.name}" destroyed and local files removed.`)
+}

--- a/apps/cloud/src/cluster/init.ts
+++ b/apps/cloud/src/cluster/init.ts
@@ -1,0 +1,174 @@
+/**
+ * Cluster init — installs k3s on bare servers via SSH and forms a cluster.
+ *
+ * Flow:
+ *   1. SSH → master: install k3s server
+ *   2. SSH → master: wait for k3s ready
+ *   3. SSH → master: read node-token
+ *   4. SSH → workers (parallel): install k3s agent and join
+ *   5. SSH → master: read kubeconfig
+ *   6. Store kubeconfig locally
+ */
+
+import { storeKubeconfig } from './kubeconfig.js'
+import { getMasterNode, getWorkerNodes, resolveNodeCredentials } from './parser.js'
+import type { ClusterConfig, ClusterMeta, NodeConfig } from './schema.js'
+import { SSHClient } from './ssh.js'
+
+export interface InitClusterOptions {
+  config: ClusterConfig
+  force?: boolean
+  onLog?: (msg: string) => void
+}
+
+/** k3s install script URL */
+const K3S_INSTALL_URL = 'https://get.k3s.io'
+
+function log(onLog: ((m: string) => void) | undefined, msg: string) {
+  onLog?.(msg)
+}
+
+// ─── Master ───────────────────────────────────────────────────────────────────
+
+async function isK3sInstalled(client: SSHClient): Promise<boolean> {
+  const result = await client.exec('which k3s')
+  return result.code === 0
+}
+
+async function installMaster(
+  master: NodeConfig,
+  force: boolean,
+  onLog?: (m: string) => void,
+): Promise<{ token: string; kubeconfig: string }> {
+  const creds = resolveNodeCredentials(master)
+  const client = new SSHClient()
+
+  log(onLog, `[master ${creds.host}] Connecting via SSH...`)
+  await client.connect(creds)
+
+  try {
+    const alreadyInstalled = await isK3sInstalled(client)
+    if (alreadyInstalled && !force) {
+      log(
+        onLog,
+        `[master ${creds.host}] k3s already installed — skipping install (use --force to reinstall)`,
+      )
+      log(onLog, `[master ${creds.host}] Reading existing token and kubeconfig...`)
+    } else {
+      if (alreadyInstalled && force) {
+        log(onLog, `[master ${creds.host}] k3s already installed — reinstalling (--force)`)
+        await client.exec('/usr/local/bin/k3s-uninstall.sh 2>/dev/null || true')
+      }
+      // Install k3s server with public IP in TLS SAN so external kubeconfig works
+      log(onLog, `[master ${creds.host}] Installing k3s server...`)
+      await client.execOrThrow(
+        `curl -sfL ${K3S_INSTALL_URL} | INSTALL_K3S_EXEC="server --tls-san ${creds.host}" sh -`,
+        {
+          onStdout: (c) => log(onLog, `[master] ${c.trimEnd()}`),
+          onStderr: (c) => log(onLog, `[master] ${c.trimEnd()}`),
+          errorMessage: `Failed to install k3s on master ${creds.host}`,
+        },
+      )
+    }
+
+    // Wait until k3s is ready (kubectl get nodes succeeds)
+    log(onLog, `[master ${creds.host}] Waiting for k3s to be ready...`)
+    await client.execOrThrow(
+      `timeout 120 sh -c 'until k3s kubectl get nodes > /dev/null 2>&1; do sleep 3; done'`,
+      { errorMessage: 'k3s master did not become ready within 120s' },
+    )
+
+    // Read node token
+    log(onLog, `[master ${creds.host}] Reading node token...`)
+    const tokenResult = await client.execOrThrow('cat /var/lib/rancher/k3s/server/node-token', {
+      errorMessage: 'Failed to read k3s node token',
+    })
+    const token = tokenResult.stdout.trim()
+    if (!token) throw new Error('k3s node token is empty')
+
+    // Read kubeconfig
+    log(onLog, `[master ${creds.host}] Reading kubeconfig...`)
+    const kubeconfigResult = await client.execOrThrow('cat /etc/rancher/k3s/k3s.yaml', {
+      errorMessage: 'Failed to read k3s kubeconfig',
+    })
+
+    return { token, kubeconfig: kubeconfigResult.stdout }
+  } finally {
+    await client.dispose()
+  }
+}
+
+// ─── Workers ──────────────────────────────────────────────────────────────────
+
+async function installWorker(
+  worker: NodeConfig,
+  masterHost: string,
+  token: string,
+  force: boolean,
+  onLog?: (m: string) => void,
+): Promise<void> {
+  const creds = resolveNodeCredentials(worker)
+  const client = new SSHClient()
+
+  log(onLog, `[worker ${creds.host}] Connecting via SSH...`)
+  await client.connect(creds)
+
+  try {
+    const alreadyInstalled = await isK3sInstalled(client)
+    if (alreadyInstalled && !force) {
+      log(
+        onLog,
+        `[worker ${creds.host}] k3s already installed — skipping install (use --force to reinstall)`,
+      )
+      return
+    }
+    if (alreadyInstalled && force) {
+      log(onLog, `[worker ${creds.host}] k3s already installed — reinstalling (--force)`)
+      await client.exec('/usr/local/bin/k3s-agent-uninstall.sh 2>/dev/null || true')
+    }
+    log(onLog, `[worker ${creds.host}] Installing k3s agent and joining cluster...`)
+    // Quote token to prevent shell injection if token contains special characters
+    const escapedToken = token.replace(/'/g, "'\\''")
+    await client.execOrThrow(
+      `curl -sfL ${K3S_INSTALL_URL} | K3S_URL=https://${masterHost}:6443 K3S_TOKEN='${escapedToken}' sh -`,
+      {
+        onStdout: (c) => log(onLog, `[worker ${creds.host}] ${c.trimEnd()}`),
+        onStderr: (c) => log(onLog, `[worker ${creds.host}] ${c.trimEnd()}`),
+        errorMessage: `Failed to install k3s agent on worker ${creds.host}`,
+      },
+    )
+    log(onLog, `[worker ${creds.host}] Agent joined cluster ✓`)
+  } finally {
+    await client.dispose()
+  }
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+/**
+ * Bootstrap a k3s cluster on bare servers defined in cluster.json.
+ * Returns the stored cluster metadata.
+ */
+export async function initCluster(options: InitClusterOptions): Promise<ClusterMeta> {
+  const { config, force = false, onLog } = options
+  const master = getMasterNode(config)
+  const workers = getWorkerNodes(config)
+
+  log(onLog, `Initializing cluster "${config.name}" with ${config.nodes.length} nodes...`)
+
+  // Step 1–3: install master and get token
+  const { token, kubeconfig } = await installMaster(master, force, onLog)
+
+  // Step 4: install workers in parallel
+  if (workers.length > 0) {
+    log(onLog, `Installing ${workers.length} worker(s) in parallel...`)
+    await Promise.all(workers.map((w) => installWorker(w, master.host, token, force, onLog)))
+  }
+
+  // Step 5: store kubeconfig
+  const meta = storeKubeconfig(config.name, kubeconfig, master.host, config.nodes.length)
+  log(onLog, `Kubeconfig stored at ${meta.kubeconfigPath}`)
+  log(onLog, `Cluster "${config.name}" is ready. Use: shadowob-cloud up --cluster ${config.name}`)
+
+  return meta
+}

--- a/apps/cloud/src/cluster/kubeconfig.ts
+++ b/apps/cloud/src/cluster/kubeconfig.ts
@@ -1,0 +1,163 @@
+/**
+ * Kubeconfig management — store and retrieve kubeconfigs for registered clusters.
+ *
+ * Kubeconfigs are stored at ~/.shadow-cloud/clusters/<name>.yaml
+ * Metadata is stored at ~/.shadow-cloud/clusters/<name>.json
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+import type { ClusterMeta } from './schema.js'
+
+// ─── Paths ────────────────────────────────────────────────────────────────────
+
+export function getClustersDir(): string {
+  return resolve(homedir(), '.shadow-cloud', 'clusters')
+}
+
+export function getKubeconfigPath(clusterName: string): string {
+  return join(getClustersDir(), `${clusterName}.yaml`)
+}
+
+export function getMetaPath(clusterName: string): string {
+  return join(getClustersDir(), `${clusterName}.json`)
+}
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+/**
+ * Persist a kubeconfig YAML and cluster metadata to disk.
+ * Rewrites the server endpoint from 127.0.0.1 to the master's public IP.
+ */
+export function storeKubeconfig(
+  clusterName: string,
+  rawKubeconfig: string,
+  masterPublicIp: string,
+  nodeCount: number,
+): ClusterMeta {
+  const dir = getClustersDir()
+  mkdirSync(dir, { recursive: true })
+
+  // Rewrite local loopback to public IP so the kubeconfig works from the outside
+  const kubeconfig = rawKubeconfig.replace(/https?:\/\/127\.0\.0\.1/g, `https://${masterPublicIp}`)
+
+  const kubeconfigPath = getKubeconfigPath(clusterName)
+  writeFileSync(kubeconfigPath, kubeconfig, { mode: 0o600 })
+
+  const meta: ClusterMeta = {
+    name: clusterName,
+    masterHost: masterPublicIp,
+    nodeCount,
+    createdAt: new Date().toISOString(),
+    kubeconfigPath,
+  }
+  writeFileSync(getMetaPath(clusterName), JSON.stringify(meta, null, 2), { mode: 0o600 })
+
+  return meta
+}
+
+// ─── Load ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Load the kubeconfig path for a named cluster.
+ * Throws if the cluster is not registered.
+ */
+export function loadKubeconfigPath(clusterName: string): string {
+  const path = getKubeconfigPath(clusterName)
+  if (!existsSync(path)) {
+    throw new Error(
+      `Cluster "${clusterName}" not found.\n` +
+        `Run: shadowob-cloud cluster init --config cluster.json`,
+    )
+  }
+  return path
+}
+
+/**
+ * Load metadata for a named cluster. Returns null if not found.
+ */
+export function loadClusterMeta(clusterName: string): ClusterMeta | null {
+  const path = getMetaPath(clusterName)
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as ClusterMeta
+  } catch {
+    return null
+  }
+}
+
+// ─── List ─────────────────────────────────────────────────────────────────────
+
+/**
+ * List all registered clusters (those with a stored kubeconfig).
+ */
+export function listRegisteredClusters(): ClusterMeta[] {
+  const dir = getClustersDir()
+  if (!existsSync(dir)) return []
+
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => {
+      try {
+        return JSON.parse(readFileSync(join(dir, f), 'utf8')) as ClusterMeta
+      } catch {
+        return null
+      }
+    })
+    .filter((m): m is ClusterMeta => m !== null)
+}
+
+// ─── Import ───────────────────────────────────────────────────────────────────
+
+/**
+ * Import a kubeconfig file from a given path and register it as a named cluster.
+ * Used when another machine has already bootstrapped the cluster and you want to
+ * register its kubeconfig locally (e.g. `cluster import --name prod --file ./prod.yaml`).
+ */
+export function importKubeconfig(clusterName: string, kubeconfigFilePath: string): ClusterMeta {
+  const dir = getClustersDir()
+  mkdirSync(dir, { recursive: true })
+
+  const raw = readFileSync(kubeconfigFilePath, 'utf8')
+
+  // Extract master host from server: entry in the kubeconfig YAML
+  // Handles IPv4, hostnames; strips port if present
+  const serverMatch = raw.match(/server:\s*https?:\/\/([^/\s]+)/)
+  const rawHost = serverMatch?.[1] ?? 'unknown'
+  // Remove port if present (e.g. "1.2.3.4:6443" → "1.2.3.4")
+  const masterHost = rawHost.replace(/:\d+$/, '')
+
+  const dest = getKubeconfigPath(clusterName)
+  writeFileSync(dest, raw, { mode: 0o600 })
+
+  const meta: ClusterMeta = {
+    name: clusterName,
+    masterHost,
+    nodeCount: 0, // unknown when importing
+    createdAt: new Date().toISOString(),
+    kubeconfigPath: dest,
+  }
+  writeFileSync(getMetaPath(clusterName), JSON.stringify(meta, null, 2), { mode: 0o600 })
+
+  return meta
+}
+
+// ─── Remove ───────────────────────────────────────────────────────────────────
+
+/**
+ * Remove stored kubeconfig and metadata for a cluster.
+ */
+export function removeClusterFiles(clusterName: string): void {
+  const kubeconfig = getKubeconfigPath(clusterName)
+  const meta = getMetaPath(clusterName)
+  if (existsSync(kubeconfig)) unlinkSync(kubeconfig)
+  if (existsSync(meta)) unlinkSync(meta)
+}

--- a/apps/cloud/src/cluster/parser.ts
+++ b/apps/cloud/src/cluster/parser.ts
@@ -1,0 +1,89 @@
+/**
+ * Cluster config parser — read, validate, and resolve cluster.json.
+ *
+ * Supports ${env:VAR} template syntax in password fields.
+ */
+
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { resolve } from 'node:path'
+import { type ClusterConfig, ClusterConfigSchema, type NodeConfig } from './schema.js'
+
+// ─── Template resolution ──────────────────────────────────────────────────────
+
+const ENV_TEMPLATE_RE = /\$\{env:([^}]+)\}/g
+
+function resolveEnvTemplate(value: string): string {
+  return value.replace(ENV_TEMPLATE_RE, (match, envKey: string) => {
+    const envVal = process.env[envKey]
+    if (envVal === undefined) {
+      throw new Error(`Environment variable "${envKey}" is not set (required by cluster.json)`)
+    }
+    return envVal
+  })
+}
+
+function expandHome(p: string): string {
+  return p.startsWith('~') ? resolve(homedir(), p.slice(2)) : p
+}
+
+// ─── Parser ───────────────────────────────────────────────────────────────────
+
+/**
+ * Read and validate cluster.json from the given path.
+ * Performs schema validation but does NOT resolve env vars yet
+ * (credentials are resolved lazily at connection time via resolveNodeCredentials).
+ */
+export function readClusterConfig(filePath: string): ClusterConfig {
+  const abs = resolve(filePath)
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(abs, 'utf8'))
+  } catch (err) {
+    throw new Error(`Failed to read cluster config at ${abs}: ${(err as Error).message}`)
+  }
+
+  const result = ClusterConfigSchema.safeParse(raw)
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `  • ${i.path.join('.')}: ${i.message}`)
+    throw new Error(`Invalid cluster.json:\n${issues.join('\n')}`)
+  }
+
+  return result.data
+}
+
+/**
+ * Resolve credentials for a single node at connection time.
+ * Expands ${env:VAR} in password and ~ in sshKeyPath.
+ */
+export function resolveNodeCredentials(node: NodeConfig): {
+  host: string
+  port: number
+  user: string
+  sshKeyPath?: string
+  password?: string
+} {
+  return {
+    host: node.host,
+    port: node.port,
+    user: node.user,
+    sshKeyPath: node.sshKeyPath ? expandHome(node.sshKeyPath) : undefined,
+    password: node.password ? resolveEnvTemplate(node.password) : undefined,
+  }
+}
+
+/**
+ * Get the master node from a cluster config (always exactly one).
+ */
+export function getMasterNode(config: ClusterConfig): NodeConfig {
+  const master = config.nodes.find((n) => n.role === 'master')
+  if (!master) throw new Error('No master node found in cluster config')
+  return master
+}
+
+/**
+ * Get all worker nodes from a cluster config.
+ */
+export function getWorkerNodes(config: ClusterConfig): NodeConfig[] {
+  return config.nodes.filter((n) => n.role === 'worker')
+}

--- a/apps/cloud/src/cluster/schema.ts
+++ b/apps/cloud/src/cluster/schema.ts
@@ -1,0 +1,69 @@
+/**
+ * Cluster config schema — defines the shape of cluster.json.
+ *
+ * cluster.json describes bare servers to bootstrap into a k3s cluster.
+ * Credentials use ${env:VAR} template syntax so secrets are never stored on disk.
+ */
+
+import { z } from 'zod'
+
+// ─── Node ────────────────────────────────────────────────────────────────────
+
+export const NodeRoleSchema = z.enum(['master', 'worker'])
+export type NodeRole = z.infer<typeof NodeRoleSchema>
+
+export const NodeConfigSchema = z
+  .object({
+    /** Node role in the cluster */
+    role: NodeRoleSchema,
+    /** Public IP or hostname */
+    host: z.string().min(1),
+    /** SSH port (default: 22) */
+    port: z.number().int().min(1).max(65535).default(22),
+    /** SSH username */
+    user: z.string().min(1),
+    /** Path to SSH private key (supports ~) — mutually inclusive with or exclusive of password */
+    sshKeyPath: z.string().optional(),
+    /** SSH password — use ${env:VAR} to avoid storing plaintext */
+    password: z.string().optional(),
+  })
+  .refine((n) => n.sshKeyPath !== undefined || n.password !== undefined, {
+    message: 'Each node must have either sshKeyPath or password',
+  })
+
+export type NodeConfig = z.infer<typeof NodeConfigSchema>
+
+// ─── Cluster ─────────────────────────────────────────────────────────────────
+
+export const ClusterProviderSchema = z.enum(['ssh'])
+export type ClusterProvider = z.infer<typeof ClusterProviderSchema>
+
+export const ClusterConfigSchema = z
+  .object({
+    $schema: z.string().optional(),
+    /** Cluster name — used as --cluster value */
+    name: z
+      .string()
+      .min(1)
+      .regex(/^[a-z0-9-]+$/, 'Cluster name must be lowercase alphanumeric with dashes'),
+    /** Provider type (default: ssh) */
+    provider: ClusterProviderSchema.default('ssh'),
+    /** List of nodes */
+    nodes: z.array(NodeConfigSchema).min(1),
+  })
+  .refine((c) => c.nodes.filter((n) => n.role === 'master').length === 1, {
+    message: 'Cluster must have exactly one master node',
+  })
+
+export type ClusterConfig = z.infer<typeof ClusterConfigSchema>
+
+// ─── Stored metadata ──────────────────────────────────────────────────────────
+
+/** Persisted to ~/.shadow-cloud/clusters/<name>.json after successful init */
+export interface ClusterMeta {
+  name: string
+  masterHost: string
+  nodeCount: number
+  createdAt: string
+  kubeconfigPath: string
+}

--- a/apps/cloud/src/cluster/ssh.ts
+++ b/apps/cloud/src/cluster/ssh.ts
@@ -1,0 +1,109 @@
+/**
+ * SSH client wrapper — thin abstraction over node-ssh.
+ *
+ * Each SSHClient instance manages a single connection to one node.
+ * Provides exec() with live stdout/stderr streaming.
+ */
+
+import { readFileSync } from 'node:fs'
+import { NodeSSH } from 'node-ssh'
+
+export interface SSHConnectOptions {
+  host: string
+  port: number
+  user: string
+  sshKeyPath?: string
+  password?: string
+}
+
+export interface ExecResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+export class SSHClient {
+  private ssh = new NodeSSH()
+  private connected = false
+
+  async connect(opts: SSHConnectOptions): Promise<void> {
+    await this.ssh.connect({
+      host: opts.host,
+      port: opts.port,
+      username: opts.user,
+      ...(opts.sshKeyPath
+        ? { privateKey: readFileSync(opts.sshKeyPath, 'utf8') }
+        : { password: opts.password }),
+      // Reasonable timeout for WAN SSH
+      readyTimeout: 30_000,
+    })
+    this.connected = true
+  }
+
+  /**
+   * Execute a command. Streams output to onStdout/onStderr callbacks if provided.
+   * Returns the combined result including exit code.
+   */
+  async exec(
+    command: string,
+    options?: {
+      onStdout?: (chunk: string) => void
+      onStderr?: (chunk: string) => void
+    },
+  ): Promise<ExecResult> {
+    if (!this.connected) throw new Error('SSH client not connected')
+
+    const result = await this.ssh.execCommand(command, {
+      onStdout: (chunk) => options?.onStdout?.(chunk.toString()),
+      onStderr: (chunk) => options?.onStderr?.(chunk.toString()),
+    })
+
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      code: result.code ?? 0,
+    }
+  }
+
+  /**
+   * Execute a command and throw if exit code is non-zero.
+   */
+  async execOrThrow(
+    command: string,
+    options?: {
+      onStdout?: (chunk: string) => void
+      onStderr?: (chunk: string) => void
+      errorMessage?: string
+    },
+  ): Promise<ExecResult> {
+    const result = await this.exec(command, options)
+    if (result.code !== 0) {
+      const msg = options?.errorMessage ?? `Command failed (exit ${result.code}): ${command}`
+      throw new Error(`${msg}\n${result.stderr}`)
+    }
+    return result
+  }
+
+  async dispose(): Promise<void> {
+    if (this.connected) {
+      this.ssh.dispose()
+      this.connected = false
+    }
+  }
+}
+
+/**
+ * Connect an SSHClient and auto-dispose after the callback.
+ */
+export async function withSSH<T>(
+  opts: SSHConnectOptions,
+  fn: (client: SSHClient) => Promise<T>,
+): Promise<T> {
+  const client = new SSHClient()
+  await client.connect(opts)
+  try {
+    return await fn(client)
+  } finally {
+    await client.dispose()
+  }
+}

--- a/apps/cloud/src/cluster/status.ts
+++ b/apps/cloud/src/cluster/status.ts
@@ -1,0 +1,59 @@
+/**
+ * Cluster status — check SSH connectivity and k3s service state for each node.
+ */
+
+import { resolveNodeCredentials } from './parser.js'
+import type { ClusterConfig, NodeConfig } from './schema.js'
+import { SSHClient } from './ssh.js'
+
+export interface NodeStatus {
+  host: string
+  role: NodeConfig['role']
+  reachable: boolean
+  k3sRunning?: boolean
+  k3sVersion?: string
+  error?: string
+}
+
+export interface ClusterStatus {
+  clusterName: string
+  nodes: NodeStatus[]
+}
+
+async function checkNode(node: NodeConfig): Promise<NodeStatus> {
+  const creds = resolveNodeCredentials(node)
+  const client = new SSHClient()
+
+  const base: NodeStatus = { host: creds.host, role: node.role, reachable: false }
+
+  try {
+    await client.connect(creds)
+    base.reachable = true
+
+    const serviceCmd =
+      node.role === 'master' ? 'k3s --version' : 'k3s agent --version 2>/dev/null || k3s --version'
+    const versionResult = await client.exec(serviceCmd)
+    if (versionResult.code === 0) {
+      base.k3sRunning = true
+      const match = versionResult.stdout.match(/k3s version\s+(\S+)/)
+      base.k3sVersion = match?.[1] ?? versionResult.stdout.split('\n')[0]?.trim()
+    } else {
+      base.k3sRunning = false
+    }
+  } catch (err) {
+    base.error = (err as Error).message
+  } finally {
+    await client.dispose()
+  }
+
+  return base
+}
+
+/**
+ * Check status of all nodes in the cluster.
+ * Runs checks in parallel.
+ */
+export async function getClusterStatus(config: ClusterConfig): Promise<ClusterStatus> {
+  const nodeStatuses = await Promise.all(config.nodes.map(checkNode))
+  return { clusterName: config.name, nodes: nodeStatuses }
+}

--- a/apps/cloud/src/infra/index.ts
+++ b/apps/cloud/src/infra/index.ts
@@ -36,6 +36,8 @@ export interface InfraOptions {
   shadowServerUrl?: string
   /** kubectl context for K8s provider — defaults to KUBECONFIG_CONTEXT or 'rancher-desktop' */
   kubeContext?: string
+  /** Path to a kubeconfig YAML file — takes precedence over kubeContext when set */
+  kubeConfigPath?: string
   /**
    * Image pull policy for all agent containers.
    * Default: 'IfNotPresent' — works for local Docker builds (Rancher Desktop).
@@ -58,6 +60,7 @@ export function createInfraProgram(options: InfraOptions) {
     const shared = createSharedResources({
       namespace,
       kubeContext: options.kubeContext,
+      kubeConfigPath: options.kubeConfigPath,
       workspace: config.workspace,
     })
     const { provider } = shared

--- a/apps/cloud/src/infra/shared.ts
+++ b/apps/cloud/src/infra/shared.ts
@@ -6,6 +6,7 @@
  * so Pulumi always targets the correct cluster context.
  */
 
+import { readFileSync } from 'node:fs'
 import * as k8s from '@pulumi/kubernetes'
 import type { SharedWorkspaceConfig } from '../config/schema.js'
 
@@ -20,17 +21,21 @@ export interface SharedResourcesOptions {
 }
 
 export function createSharedResources(options: SharedResourcesOptions) {
-  const context =
-    options.kubeContext ??
-    process.env.KUBECONFIG_CONTEXT ??
-    process.env.K8S_CONTEXT ??
-    'rancher-desktop'
+  // When a kubeconfig path is provided, read its content and let the
+  // kubeconfig's own current-context take effect (do NOT override context).
+  // When no path is given, fall back to named context in the default kubeconfig.
+  const providerConfig: ConstructorParameters<typeof k8s.Provider>[1] = options.kubeConfigPath
+    ? { kubeconfig: readFileSync(options.kubeConfigPath, 'utf8') }
+    : {
+        context:
+          options.kubeContext ??
+          process.env.KUBECONFIG_CONTEXT ??
+          process.env.K8S_CONTEXT ??
+          'rancher-desktop',
+      }
 
   // Explicit K8s provider — ensures we always hit the right cluster
-  const provider = new k8s.Provider('k8s-provider', {
-    context,
-    ...(options.kubeConfigPath ? { kubeconfig: options.kubeConfigPath } : {}),
-  })
+  const provider = new k8s.Provider('k8s-provider', providerConfig)
 
   const ns = new k8s.core.v1.Namespace(
     `${options.namespace}-ns`,

--- a/apps/cloud/src/interfaces/cli/cluster.command.ts
+++ b/apps/cloud/src/interfaces/cli/cluster.command.ts
@@ -1,0 +1,199 @@
+/**
+ * CLI: shadowob-cloud cluster — manage bare-server k3s clusters.
+ *
+ * Sub-commands:
+ *   cluster init     — bootstrap k3s on servers defined in cluster.json
+ *   cluster status   — check SSH + k3s health on all nodes
+ *   cluster list     — list all registered clusters
+ *   cluster kubeconfig — print kubeconfig path for a cluster
+ *   cluster destroy  — uninstall k3s and remove local files
+ */
+
+import chalk from 'chalk'
+import { Command } from 'commander'
+import { importKubeconfig } from '../../cluster/kubeconfig.js'
+import { readClusterConfig } from '../../cluster/parser.js'
+import type { ServiceContainer } from '../../services/container.js'
+
+export function createClusterCommand(container: ServiceContainer) {
+  const cluster = new Command('cluster').description(
+    'Manage bare-server k3s clusters (init, status, list, destroy)',
+  )
+
+  // ─── init ─────────────────────────────────────────────────────────────────
+  cluster
+    .command('init')
+    .description('Bootstrap a k3s cluster on bare servers')
+    .option('-c, --config <path>', 'Path to cluster.json', 'cluster.json')
+    .option('--force', 'Reinstall k3s even if already installed on nodes')
+    .action(async (options: { config: string; force?: boolean }) => {
+      try {
+        const config = readClusterConfig(options.config)
+        container.logger.info(`Initializing cluster "${config.name}"...`)
+
+        const meta = await container.cluster.init(
+          config,
+          (msg) => {
+            container.logger.dim(msg)
+          },
+          options.force,
+        )
+
+        container.logger.success(`Cluster "${meta.name}" ready! Kubeconfig: ${meta.kubeconfigPath}`)
+        container.logger.info(`Deploy agents: shadowob-cloud up --cluster ${meta.name}`)
+      } catch (err) {
+        container.logger.error((err as Error).message)
+        process.exit(1)
+      }
+    })
+
+  // ─── import ───────────────────────────────────────────────────────────────
+  cluster
+    .command('import')
+    .description('Register an existing kubeconfig as a named cluster (for sharing across machines)')
+    .requiredOption('-n, --name <name>', 'Cluster name to register as')
+    .requiredOption('-f, --file <path>', 'Path to kubeconfig YAML file')
+    .action((options: { name: string; file: string }) => {
+      try {
+        const meta = importKubeconfig(options.name, options.file)
+        container.logger.success(
+          `Cluster "${meta.name}" registered. Kubeconfig: ${meta.kubeconfigPath}`,
+        )
+        container.logger.info(`Deploy agents: shadowob-cloud up --cluster ${meta.name}`)
+      } catch (err) {
+        container.logger.error((err as Error).message)
+        process.exit(1)
+      }
+    })
+
+  // ─── status ───────────────────────────────────────────────────────────────
+  cluster
+    .command('status')
+    .description('Check SSH connectivity and k3s health on all nodes')
+    .option('-c, --config <path>', 'Path to cluster.json', 'cluster.json')
+    .action(async (options: { config: string }) => {
+      try {
+        const config = readClusterConfig(options.config)
+        const status = await container.cluster.status(config)
+
+        console.log()
+        console.log(chalk.bold(`Cluster: ${status.clusterName}`))
+        console.log()
+
+        for (const node of status.nodes) {
+          const roleLabel = chalk.cyan(`[${node.role}]`.padEnd(10))
+          const hostLabel = chalk.white(node.host.padEnd(20))
+
+          if (!node.reachable) {
+            console.log(
+              `  ${roleLabel} ${hostLabel} ${chalk.red('✗ unreachable')}${node.error ? chalk.dim(` — ${node.error}`) : ''}`,
+            )
+          } else if (!node.k3sRunning) {
+            console.log(
+              `  ${roleLabel} ${hostLabel} ${chalk.yellow('⚠ reachable, k3s not running')}`,
+            )
+          } else {
+            const version = node.k3sVersion ? chalk.dim(` (${node.k3sVersion})`) : ''
+            console.log(`  ${roleLabel} ${hostLabel} ${chalk.green('✓ running')}${version}`)
+          }
+        }
+        console.log()
+      } catch (err) {
+        container.logger.error((err as Error).message)
+        process.exit(1)
+      }
+    })
+
+  // ─── list ─────────────────────────────────────────────────────────────────
+  cluster
+    .command('list')
+    .description('List all registered clusters')
+    .action(() => {
+      try {
+        const clusters = container.cluster.listClusters()
+
+        if (clusters.length === 0) {
+          console.log(chalk.dim('No clusters registered yet.'))
+          console.log(chalk.dim('Run: shadowob-cloud cluster init --config cluster.json'))
+          return
+        }
+
+        console.log()
+        console.log(chalk.bold('Registered clusters:'))
+        console.log()
+        for (const c of clusters) {
+          console.log(
+            `  ${chalk.cyan(c.name.padEnd(20))} ` +
+              `master: ${chalk.white(c.masterHost.padEnd(18))} ` +
+              `nodes: ${c.nodeCount}  ` +
+              chalk.dim(`created: ${new Date(c.createdAt).toLocaleDateString()}`),
+          )
+          console.log(chalk.dim(`    kubeconfig: ${c.kubeconfigPath}`))
+        }
+        console.log()
+      } catch (err) {
+        container.logger.error((err as Error).message)
+        process.exit(1)
+      }
+    })
+
+  // ─── kubeconfig ───────────────────────────────────────────────────────────
+  cluster
+    .command('kubeconfig <name>')
+    .description('Print the kubeconfig file path for a registered cluster')
+    .action((name: string) => {
+      try {
+        const path = container.cluster.resolveKubeconfig(name)
+        console.log(path)
+      } catch (err) {
+        container.logger.error((err as Error).message)
+        process.exit(1)
+      }
+    })
+
+  // ─── destroy ──────────────────────────────────────────────────────────────
+  cluster
+    .command('destroy')
+    .description('Uninstall k3s from all nodes and remove local cluster files')
+    .option('-c, --config <path>', 'Path to cluster.json', 'cluster.json')
+    .option('--yes', 'Skip confirmation prompt')
+    .action(async (options: { config: string; yes?: boolean }) => {
+      try {
+        const config = readClusterConfig(options.config)
+
+        if (!options.yes) {
+          const readline = await import('node:readline')
+          const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          })
+          const confirmed = await new Promise<boolean>((resolve) => {
+            rl.question(
+              chalk.yellow(
+                `Destroy cluster "${config.name}"? This uninstalls k3s from all ${config.nodes.length} nodes. [y/N] `,
+              ),
+              (answer) => {
+                rl.close()
+                resolve(answer.trim().toLowerCase() === 'y')
+              },
+            )
+          })
+          if (!confirmed) {
+            console.log('Aborted.')
+            return
+          }
+        }
+
+        await container.cluster.destroy(config, (msg) => {
+          container.logger.dim(msg)
+        })
+
+        container.logger.success(`Cluster "${config.name}" destroyed.`)
+      } catch (err) {
+        container.logger.error((err as Error).message)
+        process.exit(1)
+      }
+    })
+
+  return cluster
+}

--- a/apps/cloud/src/interfaces/cli/index.ts
+++ b/apps/cloud/src/interfaces/cli/index.ts
@@ -13,6 +13,7 @@ import { Command } from 'commander'
 import type { ServiceContainer } from '../../services/container.js'
 import { loadEnvFiles } from '../../utils/env.js'
 import { createBuildCommand } from './build.command.js'
+import { createClusterCommand } from './cluster.command.js'
 import { createConsoleCommand } from './dashboard.command.js'
 import { createDoctorCommand } from './doctor.command.js'
 import { createDownCommand } from './down.command.js'
@@ -72,6 +73,7 @@ export function createCLI(container: ServiceContainer): Command {
   program.addCommand(createDoctorCommand(container))
   program.addCommand(createOnboardCommand(container))
   program.addCommand(createTemplatesCommand(container))
+  program.addCommand(createClusterCommand(container))
 
   return program
 }

--- a/apps/cloud/src/interfaces/cli/up.command.ts
+++ b/apps/cloud/src/interfaces/cli/up.command.ts
@@ -31,6 +31,10 @@ export function createUpCommand(container: ServiceContainer) {
       'Shadow server URL as seen from inside K8s pods (e.g. http://host.lima.internal:3002)',
     )
     .option('--local', 'Auto-create a local kind cluster if no K8s is available')
+    .option(
+      '--cluster <name>',
+      'Named cluster to deploy to (uses ~/.shadow-cloud/clusters/<name>.yaml)',
+    )
     .action(
       async (options: {
         file: string
@@ -46,6 +50,7 @@ export function createUpCommand(container: ServiceContainer) {
         imagePullPolicy?: string
         podShadowUrl?: string
         local?: boolean
+        cluster?: string
       }) => {
         try {
           await container.deploy.up({
@@ -62,6 +67,7 @@ export function createUpCommand(container: ServiceContainer) {
               (options.imagePullPolicy as 'Always' | 'IfNotPresent' | 'Never') ?? 'IfNotPresent',
             k8sShadowUrl: options.podShadowUrl,
             local: options.local,
+            cluster: options.cluster,
           })
         } catch (err) {
           container.logger.error((err as Error).message)

--- a/apps/cloud/src/services/cluster.service.ts
+++ b/apps/cloud/src/services/cluster.service.ts
@@ -1,0 +1,54 @@
+/**
+ * ClusterService — orchestrates cluster lifecycle operations.
+ *
+ * Thin service layer that delegates to cluster/* modules.
+ * Registered in the ServiceContainer for CLI command use.
+ */
+
+import { destroyCluster } from '../cluster/destroy.js'
+import { initCluster } from '../cluster/init.js'
+import { listRegisteredClusters, loadKubeconfigPath } from '../cluster/kubeconfig.js'
+import type { ClusterConfig, ClusterMeta } from '../cluster/schema.js'
+import { type ClusterStatus, getClusterStatus } from '../cluster/status.js'
+
+export class ClusterService {
+  /**
+   * Bootstrap a k3s cluster on bare servers.
+   */
+  async init(
+    config: ClusterConfig,
+    onLog?: (msg: string) => void,
+    force?: boolean,
+  ): Promise<ClusterMeta> {
+    return initCluster({ config, onLog, force })
+  }
+
+  /**
+   * Check SSH connectivity and k3s status on all nodes.
+   */
+  async status(config: ClusterConfig): Promise<ClusterStatus> {
+    return getClusterStatus(config)
+  }
+
+  /**
+   * Uninstall k3s from all nodes and clean up local files.
+   */
+  async destroy(config: ClusterConfig, onLog?: (msg: string) => void): Promise<void> {
+    return destroyCluster({ config, onLog })
+  }
+
+  /**
+   * List all clusters with stored kubeconfigs.
+   */
+  listClusters(): ClusterMeta[] {
+    return listRegisteredClusters()
+  }
+
+  /**
+   * Resolve the kubeconfig file path for a named cluster.
+   * Throws if the cluster is not registered.
+   */
+  resolveKubeconfig(clusterName: string): string {
+    return loadKubeconfigPath(clusterName)
+  }
+}

--- a/apps/cloud/src/services/container.ts
+++ b/apps/cloud/src/services/container.ts
@@ -12,6 +12,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { TemplateDao } from '../dao/template.dao.js'
 import { type Logger, log } from '../utils/logger.js'
+import { ClusterService } from './cluster.service.js'
 import { ConfigService } from './config.service.js'
 import { DeployService } from './deploy.service.js'
 import { ImageService } from './image.service.js'
@@ -38,6 +39,7 @@ export interface ServiceContainer {
   image: ImageService
   k8s: K8sService
   usageCost: UsageCostService
+  cluster: ClusterService
 }
 
 /**
@@ -60,6 +62,7 @@ export function createContainer(overrides?: Partial<ServiceContainer>): ServiceC
   const templateI18n = overrides?.templateI18n ?? new TemplateI18nService(template)
   const usageCost = overrides?.usageCost ?? new UsageCostService(k8s)
   const deploy = overrides?.deploy ?? new DeployService(config, manifest, provision, k8s, logger)
+  const cluster = overrides?.cluster ?? new ClusterService()
 
   return {
     logger,
@@ -73,9 +76,11 @@ export function createContainer(overrides?: Partial<ServiceContainer>): ServiceC
     image,
     k8s,
     usageCost,
+    cluster,
   }
 }
 
+export { ClusterService } from './cluster.service.js'
 // Re-export service classes for SDK use
 export { ConfigService } from './config.service.js'
 export { type DeployOptions, type DeployResult, DeployService } from './deploy.service.js'

--- a/apps/cloud/src/services/deploy.service.ts
+++ b/apps/cloud/src/services/deploy.service.ts
@@ -7,6 +7,7 @@
 
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
+import { loadKubeconfigPath } from '../cluster/kubeconfig.js'
 import type { CloudConfig } from '../config/schema.js'
 import type { ProvisionResult } from '../provisioning/index.js'
 import type { Logger } from '../utils/logger.js'
@@ -33,6 +34,10 @@ export interface DeployOptions {
   k8sShadowUrl?: string
   local?: boolean
   onOutput?: (out: string) => void
+  /** Named cluster — resolves to kubeconfig in ~/.shadow-cloud/clusters/<name>.yaml */
+  cluster?: string
+  /** Explicit path to a kubeconfig file (overrides cluster and k8sContext) */
+  kubeConfigPath?: string
 }
 
 export interface DeployResult {
@@ -77,6 +82,14 @@ export class DeployService {
       throw new Error(`Config file not found: ${filePath}`)
     }
 
+    // Resolve kubeconfig path: explicit > cluster name > none (use kubeContext / default)
+    const kubeConfigPath =
+      options.kubeConfigPath ?? (options.cluster ? loadKubeconfigPath(options.cluster) : undefined)
+
+    if (!existsSync(filePath)) {
+      throw new Error(`Config file not found: ${filePath}`)
+    }
+
     // The directory containing the config file is used as the working directory
     // for resolving relative paths (e.g. gitagent path) throughout the pipeline.
     // We pass it explicitly rather than mutating process.cwd() so concurrent
@@ -116,7 +129,7 @@ export class DeployService {
       } else {
         this.logger.dim('Kind cluster already exists')
       }
-    } else if (!this.k8s.isKubeReachable()) {
+    } else if (!kubeConfigPath && !this.k8s.isKubeReachable()) {
       this.logger.warn('kubectl cannot reach a cluster. Use --local to auto-create a kind cluster.')
     }
 
@@ -234,6 +247,7 @@ export class DeployService {
         provision,
         shadowServerUrl: k8sShadowUrl,
         kubeContext: options.k8sContext,
+        kubeConfigPath,
         imagePullPolicy: options.imagePullPolicy ?? 'IfNotPresent',
       })
     } catch (err) {
@@ -251,6 +265,7 @@ export class DeployService {
               provision,
               shadowServerUrl: k8sShadowUrl,
               kubeContext: options.k8sContext,
+              kubeConfigPath,
               imagePullPolicy: options.imagePullPolicy ?? 'IfNotPresent',
             })
             .catch(() => null)
@@ -283,6 +298,7 @@ export class DeployService {
           provision,
           shadowServerUrl: k8sShadowUrl,
           kubeContext: options.k8sContext,
+          kubeConfigPath,
           imagePullPolicy: options.imagePullPolicy ?? 'IfNotPresent',
         })
       } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
+      node-ssh:
+        specifier: ^13.2.1
+        version: 13.2.1
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
@@ -259,7 +262,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typia/unplugin':
         specifier: ^12.0.1
-        version: 12.0.1(rollup@4.60.1)(typia@12.0.1(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 12.0.1(rollup@4.60.1)(typia@12.0.1(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
@@ -283,7 +286,7 @@ importers:
         version: 0.67.1
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/desktop:
     dependencies:
@@ -2400,8 +2403,8 @@ packages:
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
 
-  '@electron/node-gyp@git+https://git@github.com:electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {commit: 06b29aafb7708acef8b3669835c8a7857ebc92d2, repo: git@github.com:electron/node-gyp.git, type: git}
+  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
+    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -7874,6 +7877,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
@@ -8093,6 +8099,9 @@ packages:
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
@@ -8240,6 +8249,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bun-only@0.0.1:
     resolution: {integrity: sha512-eQdy3eKF3MPcrwhvDq/7BykQ9kpl9Lu/zJ9IcL1AsjZ4vct68Du8reZisptp7YL8b65iImMf9j06xmGUNsc2rQ==}
@@ -8768,6 +8781,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -12637,6 +12654,10 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  node-ssh@13.2.1:
+    resolution: {integrity: sha512-rfl4GWMygQfzlExPkQ2LWyya5n2jOBm5vhEnup+4mdw7tQhNpJWbP5ldr09Jfj93k5SfY5lxcn8od5qrQ/6mBg==}
+    engines: {node: '>= 10'}
+
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
     engines: {node: '>=6'}
@@ -14374,6 +14395,14 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  sb-promise-queue@2.1.1:
+    resolution: {integrity: sha512-qXfdcJQMxMljxmPprn4Q4hl3pJmoljSCzUvvEBa9Kscewnv56n0KqrO6yWSrGLOL9E021wcGdPa39CHGKA6G0w==}
+    engines: {node: '>= 8'}
+
+  sb-scandir@3.1.1:
+    resolution: {integrity: sha512-Q5xiQMtoragW9z8YsVYTAZcew+cRzdVBefPbb9theaIKw6cBo34WonP9qOCTKgyAmn/Ch5gmtAxT/krUgMILpA==}
+    engines: {node: '>= 8'}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -14514,6 +14543,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-escape@0.2.0:
+    resolution: {integrity: sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw==}
 
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
@@ -14745,6 +14777,10 @@ packages:
   ssf@0.11.2:
     resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
     engines: {node: '>=0.8'}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   ssri@13.0.1:
     resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
@@ -15284,6 +15320,9 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -18049,7 +18088,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/node-gyp@git+https://git@github.com:electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2':
+  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
@@ -18112,7 +18151,7 @@ snapshots:
 
   '@electron/rebuild@3.7.2':
     dependencies:
-      '@electron/node-gyp': git+https://git@github.com:electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2
+      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
       debug: 4.4.3
@@ -23760,7 +23799,7 @@ snapshots:
       '@typia/interface': 12.0.1
       '@typia/utils': 12.0.1
 
-  '@typia/unplugin@12.0.1(rollup@4.60.1)(typia@12.0.1(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@typia/unplugin@12.0.1(rollup@4.60.1)(typia@12.0.1(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
       bun-only: 0.0.1
@@ -23775,7 +23814,7 @@ snapshots:
       typia: 12.0.1(@types/node@22.19.15)(typescript@5.9.3)
       unplugin: 2.3.11
     optionalDependencies:
-      vite: 8.0.8(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
 
@@ -23906,6 +23945,14 @@ snapshots:
       '@vitest/utils': 4.1.0
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.0(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -24277,6 +24324,10 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assert@2.1.0:
     dependencies:
       call-bind: 1.0.8
@@ -24533,6 +24584,10 @@ snapshots:
 
   bcp-47-match@2.0.3: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   bcryptjs@3.0.3: {}
 
   better-opn@3.0.2:
@@ -24712,6 +24767,9 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
 
   bun-only@0.0.1: {}
 
@@ -25257,6 +25315,12 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.25.0
+    optional: true
 
   crc-32@1.2.2: {}
 
@@ -30156,6 +30220,15 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  node-ssh@13.2.1:
+    dependencies:
+      is-stream: 2.0.1
+      make-dir: 3.1.0
+      sb-promise-queue: 2.1.1
+      sb-scandir: 3.1.1
+      shell-escape: 0.2.0
+      ssh2: 1.17.0
+
   nopt@5.0.0:
     dependencies:
       abbrev: 1.1.1
@@ -32290,6 +32363,12 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
+  sb-promise-queue@2.1.1: {}
+
+  sb-scandir@3.1.1:
+    dependencies:
+      sb-promise-queue: 2.1.1
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -32478,6 +32557,8 @@ snapshots:
   shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
+
+  shell-escape@0.2.0: {}
 
   shell-quote@1.8.3: {}
 
@@ -32769,6 +32850,14 @@ snapshots:
   ssf@0.11.2:
     dependencies:
       frac: 1.1.2
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.25.0
 
   ssri@13.0.1:
     dependencies:
@@ -33333,6 +33422,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  tweetnacl@0.14.5: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -33752,6 +33843,24 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
+  vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.15
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      sass: 1.99.0
+      sass-embedded: 1.99.0
+      terser: 5.46.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
   vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -33805,6 +33914,35 @@ snapshots:
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.8.3
+
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.19.15
+      jsdom: 28.1.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

Adds full lifecycle management for self-hosted k3s clusters via SSH, enabling agents to be deployed to bare servers without a cloud provider.

## New CLI Commands

| Command | Description |
|---|---|
| `cluster init` | Bootstrap k3s on bare servers via SSH |
| `cluster import` | Register existing kubeconfig (multi-machine sharing) |
| `cluster status` | Show node health |
| `cluster list` | List all configured clusters |
| `cluster kubeconfig` | Print kubeconfig |
| `cluster destroy` | Uninstall k3s from all nodes |
| `up --cluster <name>` | Deploy agents to a named cluster |

## Implementation

- **SSH-based provisioning**: installs k3s on master + workers, waits for nodes to be ready
- **`--force` flag**: reinstalls k3s if already present (idempotent by default — skips if installed)
- **`cluster import`**: merges an external kubeconfig into local store for multi-machine access
- **Pulumi KubernetesProvider**: wired through deploy/container services to target the cluster
- **27/27 unit tests pass**

## Security Fixes

- K3S_TOKEN is shell-escaped (single-quote wrapping) to prevent injection
- `provider` field defaults to `'ssh'` — no longer required in `cluster.json`
- Env template resolution supports partial substitution (`prefix-${env:VAR}`)
- Kubeconfig host extraction correctly strips `:port` suffix
- `vi.mock('node:os')` test fix uses `importOriginal` pattern

## Related

- CI workflow: `.github/workflows/publish-openclaw-runner.yml` (already on main)
- Deployed and validated on two bare servers: 3/3 agents Running