### PR TITLE
fix(cloud): keep openclaw runner image publish stable

### DIFF
--- a/apps/cloud/images/openclaw-runner/Dockerfile
+++ b/apps/cloud/images/openclaw-runner/Dockerfile
@@ -20,7 +20,7 @@ FROM node:22-alpine AS builder
 
 WORKDIR /build
 
-ARG OPENCLAW_VERSION=latest
+ARG OPENCLAW_VERSION=2026.4.24
 ARG SHADOWOB_OPENCLAW_PLUGIN_VERSION=latest
 
 # git is required by some npm packages during install

--- a/apps/cloud/images/openclaw-runner/warm-runtime-deps.mjs
+++ b/apps/cloud/images/openclaw-runner/warm-runtime-deps.mjs
@@ -31,7 +31,7 @@ function findRuntimeDepsChunk() {
     (name) => name.startsWith('bundled-runtime-deps-') && name.endsWith('.js'),
   )
   if (!chunk) {
-    throw new Error(`OpenClaw bundled runtime deps chunk not found in ${distDir}`)
+    return null
   }
   return join(distDir, chunk)
 }
@@ -42,7 +42,18 @@ async function main() {
     mkdirSync(stageDir, { recursive: true })
   }
 
-  const runtimeDeps = await import(pathToFileURL(findRuntimeDepsChunk()).href)
+  const runtimeDepsChunk = findRuntimeDepsChunk()
+  if (!runtimeDepsChunk) {
+    console.warn(
+      `[runtime-deps] OpenClaw bundled runtime deps chunk not found in ${join(
+        packageRoot,
+        'dist',
+      )}; skipping build-time prewarm`,
+    )
+    return
+  }
+
+  const runtimeDeps = await import(pathToFileURL(runtimeDepsChunk).href)
   const config = loadConfig()
   const scan = runtimeDeps.c({
     packageRoot,


### PR DESCRIPTION
## Summary\n- pin the openclaw-runner image build to the OpenClaw version currently locked and validated by the repo\n- make build-time runtime dependency prewarming best-effort so upstream OpenClaw internals cannot block image publication\n\n## Verification\n- remote PR checks only; no local lint/typecheck/test run per request\n\nFollow-up for failed publish run: https://github.com/buggyblues/shadow/actions/runs/25066202766