### PR TITLE
fix(cloud): publish runner image to writable registry

### DIFF
--- a/.github/workflows/publish-openclaw-runner.yml
+++ b/.github/workflows/publish-openclaw-runner.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: shadowob/openclaw-runner
+  IMAGE_NAME: buggyblues/openclaw-runner
 
 jobs:
   build-and-push:

--- a/apps/cloud/__tests__/infra/runtime-package.test.ts
+++ b/apps/cloud/__tests__/infra/runtime-package.test.ts
@@ -169,7 +169,7 @@ describe('buildManifests', () => {
     expect(container.startupProbe.httpGet).toMatchObject({ path: '/live', port: 3102 })
     expect(container.readinessProbe.httpGet).toMatchObject({ path: '/ready', port: 3102 })
     expect(deployment.spec.template.metadata.annotations).toMatchObject({
-      'shadowob.cloud/runner-image': 'ghcr.io/shadowob/openclaw-runner:latest',
+      'shadowob.cloud/runner-image': 'ghcr.io/buggyblues/openclaw-runner:latest',
     })
     expect(
       deployment.spec.template.metadata.annotations['shadowob.cloud/runtime-package-hash'],

--- a/apps/cloud/__tests__/runtimes/runtimes.test.ts
+++ b/apps/cloud/__tests__/runtimes/runtimes.test.ts
@@ -81,7 +81,7 @@ describe('OpenClaw Adapter', () => {
   })
 
   it('uses the current Shadow runner image by default', () => {
-    expect(adapter.defaultImage).toBe('ghcr.io/shadowob/openclaw-runner:latest')
+    expect(adapter.defaultImage).toBe('ghcr.io/buggyblues/openclaw-runner:latest')
   })
 
   it('acpRuntime returns null (no ACP harness)', () => {

--- a/apps/cloud/scripts/build-images.mjs
+++ b/apps/cloud/scripts/build-images.mjs
@@ -19,7 +19,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 const WORKSPACE_ROOT = join(ROOT, '..', '..')
 const IMAGES_DIR = join(ROOT, 'images')
-const REGISTRY = process.env.SHADOWOB_REGISTRY ?? process.env.SHADOW_REGISTRY ?? 'ghcr.io/shadowob'
+const REGISTRY = process.env.SHADOWOB_REGISTRY ?? process.env.SHADOW_REGISTRY ?? 'ghcr.io/buggyblues'
 
 const IMAGES = ['openclaw-runner', 'claude-runner']
 

--- a/apps/cloud/scripts/smoke-test-images.mjs
+++ b/apps/cloud/scripts/smoke-test-images.mjs
@@ -21,7 +21,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const REGISTRY = process.env.SHADOW_REGISTRY ?? 'ghcr.io/shadowob'
+const REGISTRY = process.env.SHADOW_REGISTRY ?? 'ghcr.io/buggyblues'
 
 const IMAGES = ['openclaw-runner', 'claude-runner']
 

--- a/apps/cloud/src/infra/constants.ts
+++ b/apps/cloud/src/infra/constants.ts
@@ -44,16 +44,16 @@ export const PULUMI_SKIP_AWAIT_ANNOTATIONS = {
 
 /** Default OpenClaw runner image.
  *
- * The repo image builder publishes/tags `ghcr.io/shadowob/openclaw-runner`.
+ * The repo image builder publishes/tags `ghcr.io/buggyblues/openclaw-runner`.
  * Keep this default aligned with the builder so cloud deployments do not
- * accidentally run the older `buggyblues` image that lacks newer plugin
+ * accidentally run an unpublishable or stale image that lacks newer plugin
  * actions such as Shadow interactive `message.send`.
  */
 export const DEFAULT_OPENCLAW_RUNNER_IMAGE =
   process.env.SHADOWOB_OPENCLAW_RUNNER_IMAGE ??
   process.env.SHADOW_OPENCLAW_RUNNER_IMAGE ??
   process.env.OPENCLAW_RUNNER_IMAGE ??
-  'ghcr.io/shadowob/openclaw-runner:latest'
+  'ghcr.io/buggyblues/openclaw-runner:latest'
 
 /** Default container images per runtime */
 export const DEFAULT_IMAGES: Record<string, string> = {

--- a/apps/cloud/src/services/image.service.ts
+++ b/apps/cloud/src/services/image.service.ts
@@ -46,7 +46,7 @@ export class ImageService {
 
   /** Get the container registry URL. */
   getRegistry(): string {
-    return process.env.SHADOWOB_REGISTRY ?? process.env.SHADOW_REGISTRY ?? 'ghcr.io/shadowob'
+    return process.env.SHADOWOB_REGISTRY ?? process.env.SHADOW_REGISTRY ?? 'ghcr.io/buggyblues'
   }
 
   /** Get all available image names. */


### PR DESCRIPTION
## Summary\n- align the default OpenClaw runner image with the GHCR namespace this repository can publish\n- align image builder/smoke scripts and the publish workflow with ghcr.io/buggyblues/openclaw-runner\n- update tests that assert the default runner image\n\n## Verification\n- remote PR checks only; no local lint/typecheck/test run per request\n\nFollow-up for failed publish run: https://github.com/buggyblues/shadow/actions/runs/25067516505