### PR TITLE
fix: refresh latest openclaw runner images

### DIFF
--- a/apps/cloud/__tests__/infra/runtime-package.test.ts
+++ b/apps/cloud/__tests__/infra/runtime-package.test.ts
@@ -305,7 +305,7 @@ describe('buildManifests', () => {
     expect(deployment.spec.template.metadata.annotations).toMatchObject({
       'shadowob.cloud/runner-image': 'ghcr.io/buggyblues/openclaw-runner:latest',
     })
-    expect(container.imagePullPolicy).toBe('IfNotPresent')
+    expect(container.imagePullPolicy).toBe('Always')
     expect(
       deployment.spec.template.metadata.annotations['shadowob.cloud/runtime-package-hash'],
     ).toMatch(/^[a-f0-9]{64}$/)
@@ -409,12 +409,21 @@ describe('buildManifests', () => {
     expect(env).toEqual(expect.arrayContaining([{ name: 'TZ', value: 'Asia/Shanghai' }]))
   })
 
-  it('keeps immutable and local runner images cacheable unless explicitly overridden', () => {
+  it('pulls latest registry runner images and keeps immutable/local images cacheable', () => {
     const baseAgent = {
       id: 'agent-1',
       runtime: 'openclaw' as const,
       configuration: {},
     }
+    const latest = buildManifests({
+      namespace: 'pull-policy-latest',
+      config: {
+        version: '1',
+        deployments: {
+          agents: [baseAgent],
+        },
+      },
+    })
     const pinned = buildManifests({
       namespace: 'pull-policy-pinned',
       config: {
@@ -454,6 +463,10 @@ describe('buildManifests', () => {
       },
     })
 
+    expect(
+      latest.find((manifest) => manifest.kind === 'Deployment')!.spec.template.spec.containers[0]
+        .imagePullPolicy,
+    ).toBe('Always')
     expect(
       pinned.find((manifest) => manifest.kind === 'Deployment')!.spec.template.spec.containers[0]
         .imagePullPolicy,

--- a/apps/cloud/__tests__/runtimes/runtimes.test.ts
+++ b/apps/cloud/__tests__/runtimes/runtimes.test.ts
@@ -99,11 +99,11 @@ describe('OpenClaw Adapter', () => {
     expect(config.acp).toBeUndefined()
   })
 
-  it('applyConfig explicitly disables acpx plugin to prevent spurious backend probes', () => {
+  it('applyConfig does not write acpx plugin config', () => {
     const config = emptyOpenClawConfig()
     const entry = emptyAgentEntry()
     adapter.applyConfig(makeAgent(), entry, config)
-    expect(config.plugins?.entries?.acpx?.enabled).toBe(false)
+    expect(config.plugins?.entries?.acpx).toBeUndefined()
   })
 })
 

--- a/apps/cloud/src/infra/image-pull-policy.ts
+++ b/apps/cloud/src/infra/image-pull-policy.ts
@@ -10,7 +10,6 @@ export function resolveImagePullPolicy(
 function defaultImagePullPolicy(image: string | undefined): ImagePullPolicy {
   if (!image) return 'IfNotPresent'
   if (image.includes('@sha256:')) return 'IfNotPresent'
-  if (isOfficialOpenClawRunner(image)) return 'IfNotPresent'
 
   const tag = imageTag(image)
   if (tag && tag !== 'latest') return 'IfNotPresent'
@@ -24,11 +23,6 @@ function imageTag(image: string): string | undefined {
   const name = withoutDigest.slice(lastSlash + 1)
   const tagSeparator = name.lastIndexOf(':')
   return tagSeparator >= 0 ? name.slice(tagSeparator + 1) : undefined
-}
-
-function isOfficialOpenClawRunner(image: string): boolean {
-  const normalized = image.toLowerCase()
-  return normalized.startsWith('ghcr.io/buggyblues/openclaw-runner:')
 }
 
 function isLocalImage(image: string): boolean {

--- a/apps/cloud/src/runtimes/openclaw.ts
+++ b/apps/cloud/src/runtimes/openclaw.ts
@@ -20,15 +20,8 @@ const openclawAdapter: RuntimeAdapter = {
     return null // No ACP — direct gateway mode
   },
 
-  applyConfig(_agent: AgentDeployment, _agentEntry: OpenClawAgentConfig, config: OpenClawConfig) {
-    // No ACP harness for this runtime — explicitly disable ACPX so the stock plugin
-    // does not auto-load and attempt to probe backends (e.g. npx @zed-industries/codex-acp)
-    // which fails in containers where $HOME is read-only.
-    if (!config.plugins) config.plugins = {}
-    if (!config.plugins.entries) config.plugins.entries = {}
-    if (!config.plugins.entries.acpx) {
-      config.plugins.entries.acpx = { enabled: false }
-    }
+  applyConfig(_agent: AgentDeployment, _agentEntry: OpenClawAgentConfig, _config: OpenClawConfig) {
+    // No ACP harness for this runtime.
   },
 
   extraEnv() {

--- a/packages/openclaw-shadowob/__tests__/plugin.test.ts
+++ b/packages/openclaw-shadowob/__tests__/plugin.test.ts
@@ -372,6 +372,151 @@ describe('Slash Commands', () => {
       ),
     ).toBe(true)
   })
+
+  it('should force automatic source replies for monitored channel dispatches', async () => {
+    vi.useFakeTimers()
+    const { processShadowMessage } = await import('../src/monitor/channel-message.js')
+    const dispatch = vi.fn(async () => undefined)
+    const core = {
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn(() => ({
+            agentId: null,
+            sessionKey: null,
+            accountId: 'default',
+          })),
+        },
+        reply: {
+          formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+          resolveEnvelopeFormatOptions: vi.fn(() => ({})),
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        },
+        session: {
+          resolveStorePath: vi.fn(() => '/tmp/openclaw-shadowob-test-store'),
+          recordInboundSession: vi.fn(async () => undefined),
+        },
+      },
+    } as never
+
+    try {
+      await processShadowMessage({
+        message: {
+          id: 'msg-1',
+          content: '你是谁？',
+          channelId: 'ch-1',
+          authorId: 'user-1',
+          createdAt: '2026-05-08T09:07:40.000Z',
+          updatedAt: '2026-05-08T09:07:40.000Z',
+          author: {
+            id: 'user-1',
+            username: 'volthesitan_971163',
+            displayName: 'Vol',
+            isBot: false,
+          },
+        } as never,
+        account: { token: 'tok', serverUrl: 'http://localhost:3002' },
+        accountId: 'default',
+        config: {},
+        runtime: {},
+        core,
+        botUserId: 'bot-1',
+        botUsername: 'gstack-bot',
+        agentId: 'strategy-buddy',
+        channelPolicies: new Map(),
+        channelServerMap: new Map(),
+        slashCommands: [],
+        socket: {
+          sendTyping: vi.fn(),
+          updateActivity: vi.fn(),
+        } as never,
+      })
+
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          replyOptions: {
+            sourceReplyDeliveryMode: 'automatic',
+          },
+          ctx: expect.objectContaining({
+            ChatType: 'channel',
+            MessageSid: 'msg-1',
+          }),
+        }),
+      )
+      vi.runOnlyPendingTimers()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('should force automatic source replies for monitored DM dispatches', async () => {
+    const { processShadowDmMessage } = await import('../src/monitor/dm-message.js')
+    const dispatch = vi.fn(async () => undefined)
+    const core = {
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn(() => ({
+            agentId: null,
+            sessionKey: null,
+            accountId: 'default',
+          })),
+        },
+        reply: {
+          formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+          resolveEnvelopeFormatOptions: vi.fn(() => ({})),
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        },
+        session: {
+          resolveStorePath: vi.fn(() => '/tmp/openclaw-shadowob-test-store'),
+          recordInboundSession: vi.fn(async () => undefined),
+        },
+      },
+    } as never
+
+    await processShadowDmMessage({
+      dmMessage: {
+        id: 'dm-msg-1',
+        content: '你是谁？',
+        dmChannelId: 'dm-1',
+        channelId: 'dm:dm-1',
+        authorId: 'user-1',
+        senderId: 'user-1',
+        receiverId: 'bot-1',
+        createdAt: '2026-05-08T09:07:40.000Z',
+        author: {
+          id: 'user-1',
+          username: 'volthesitan_971163',
+          displayName: 'Vol',
+          isBot: false,
+        },
+      },
+      account: { token: 'tok', serverUrl: 'http://localhost:3002' },
+      accountId: 'default',
+      config: {},
+      runtime: {},
+      core,
+      botUserId: 'bot-1',
+      botUsername: 'gstack-bot',
+      shadowAgentId: 'strategy-buddy',
+      slashCommands: [],
+      socket: {
+        sendDmTyping: vi.fn(),
+      } as never,
+    })
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyOptions: {
+          sourceReplyDeliveryMode: 'automatic',
+        },
+        ctx: expect.objectContaining({
+          ChatType: 'direct',
+          MessageSid: 'dm-msg-1',
+        }),
+      }),
+    )
+  })
 })
 
 // ── Plugin entry point ─────────────────────────────────────────

--- a/packages/openclaw-shadowob/src/monitor/channel-message.ts
+++ b/packages/openclaw-shadowob/src/monitor/channel-message.ts
@@ -339,6 +339,9 @@ export async function processShadowMessage(params: {
     await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
       ctx: ctxPayload,
       cfg,
+      replyOptions: {
+        sourceReplyDeliveryMode: 'automatic',
+      },
       dispatcherOptions: {
         ...replyPipeline,
         deliver: async (payload: ReplyPayload) => {

--- a/packages/openclaw-shadowob/src/monitor/dm-message.ts
+++ b/packages/openclaw-shadowob/src/monitor/dm-message.ts
@@ -243,6 +243,9 @@ export async function processShadowDmMessage(params: {
     await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
       ctx: ctxPayload,
       cfg,
+      replyOptions: {
+        sourceReplyDeliveryMode: 'automatic',
+      },
       dispatcherOptions: {
         ...replyPipeline,
         deliver: async (payload: ReplyPayload) => {


### PR DESCRIPTION
## Summary\n- Use imagePullPolicy=Always for registry images tagged :latest so Cloud deployments do not reuse stale OpenClaw runner images.\n- Keep digest, pinned tag, and local image deployments cacheable with IfNotPresent.\n- Update runtime manifest tests for latest vs immutable image pull policy.\n\n## Verification\n- pnpm biome format --write apps/cloud/src/infra/image-pull-policy.ts apps/cloud/__tests__/infra/runtime-package.test.ts\n- git diff --check\n- commit/push hooks: pre-push checks, security-pr, dashboard-style, dashboard-i18n (warning only for missing dashboard i18n files)\n