### PR TITLE
[codex] Fix play launch invite authorization

### DIFF
--- a/apps/server/__tests__/play-launch-service.test.ts
+++ b/apps/server/__tests__/play-launch-service.test.ts
@@ -66,6 +66,7 @@ describe('play launch orchestration', () => {
     },
     membershipService: {
       requireMember: vi.fn(),
+      redeemInviteCode: vi.fn(),
     },
     cloudTemplateDao: {
       findBySlug: vi.fn(),
@@ -121,6 +122,12 @@ describe('play launch orchestration', () => {
     deps.agentDao.findPlayCatalogBuddyByTemplateSlug.mockResolvedValue(null)
     deps.agentPolicyService.ensureServerDefault.mockResolvedValue(undefined)
     deps.messageService.getByChannelId.mockResolvedValue({ messages: [], hasMore: false })
+    deps.membershipService.requireMember.mockResolvedValue({
+      capabilities: ['cloud:deploy'],
+    })
+    deps.membershipService.redeemInviteCode.mockResolvedValue({
+      capabilities: ['cloud:deploy'],
+    })
     deps.cloudTemplateDao.findBySlug.mockResolvedValue({
       id: 'template-1',
       slug: 'gstack-buddy',
@@ -159,6 +166,16 @@ describe('play launch orchestration', () => {
     })
 
     expect(parsed.success).toBe(false)
+  })
+
+  it('accepts invite codes on play launch requests', () => {
+    const parsed = playLaunchSchema.safeParse({
+      playId: 'gstack-buddy',
+      launchSessionId: 'launch-session-1',
+      inviteCode: 'ABCD1234',
+    })
+
+    expect(parsed.success).toBe(true)
   })
 
   it('ships every default homepage play with a launchable action', () => {
@@ -473,6 +490,45 @@ describe('play launch orchestration', () => {
       if (previousModelProxyEnabled === undefined) delete process.env.SHADOW_MODEL_PROXY_ENABLED
       else process.env.SHADOW_MODEL_PROXY_ENABLED = previousModelProxyEnabled
     }
+  })
+
+  it('redeems an invite code during cloud launch authorization', async () => {
+    deps.membershipService.requireMember.mockRejectedValueOnce(
+      Object.assign(new Error('Invite code required'), {
+        status: 403,
+        code: 'INVITE_REQUIRED',
+      }),
+    )
+    deps.cloudDeploymentDao.findLatestCurrentInNamespace.mockResolvedValue({
+      id: 'deployment-1',
+      status: 'pending',
+      templateSlug: 'gstack-buddy',
+      configSnapshot: templateContent,
+    })
+    vi.spyOn(
+      service as unknown as { findPublishedPlay(playId: string): Promise<unknown> },
+      'findPublishedPlay',
+    ).mockResolvedValue({
+      id: 'gstack-buddy',
+      status: 'gated',
+      action: { kind: 'cloud_deploy', templateSlug: 'gstack-buddy', resourceTier: 'lightweight' },
+    })
+
+    const result = await service.launch('user-1', {
+      playId: 'gstack-buddy',
+      launchSessionId: 'launch-session-redeem',
+      inviteCode: ' abc123 ',
+      locale: 'zh-CN',
+    })
+
+    expect(deps.membershipService.redeemInviteCode).toHaveBeenCalledWith('user-1', 'abc123')
+    expect(deps.membershipService.requireMember).toHaveBeenCalledTimes(1)
+    expect(deps.cloudDeploymentDao.create).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      status: 'deploying',
+      deploymentId: 'deployment-1',
+      templateSlug: 'gstack-buddy',
+    })
   })
 
   it('surfaces a wallet paywall before queueing a cloud deployment without the first hourly unit', async () => {

--- a/apps/server/src/services/play-launch.service.ts
+++ b/apps/server/src/services/play-launch.service.ts
@@ -54,6 +54,7 @@ type CloudDeployPlayAction = Extract<PlayAction, { kind: 'cloud_deploy' }> & {
 export interface PlayLaunchInput {
   playId?: string
   launchSessionId?: string
+  inviteCode?: string
   locale?: string
 }
 
@@ -656,6 +657,27 @@ export class PlayLaunchService {
     }
   }
 
+  private async requireCloudDeployMember(userId: string, inviteCode?: string) {
+    try {
+      return await this.deps.membershipService.requireMember(userId, 'cloud:deploy')
+    } catch (err) {
+      const appError = err as { code?: string }
+      const normalizedInviteCode = inviteCode?.trim()
+      if (appError.code !== 'INVITE_REQUIRED' || !normalizedInviteCode) {
+        throw err
+      }
+
+      const membership = await this.deps.membershipService.redeemInviteCode(
+        userId,
+        normalizedInviteCode,
+      )
+      if (membership.capabilities.includes('cloud:deploy')) {
+        return membership
+      }
+      return this.deps.membershipService.requireMember(userId, 'cloud:deploy')
+    }
+  }
+
   private async launchCloudDeploy(
     userId: string,
     input: PlayLaunchInput,
@@ -663,7 +685,7 @@ export class PlayLaunchService {
     action: CloudDeployPlayAction,
     context: LaunchRequestContext,
   ) {
-    await this.deps.membershipService.requireMember(userId, 'cloud:deploy')
+    await this.requireCloudDeployMember(userId, input.inviteCode)
     const launchUser = await this.getLaunchUserProfile(userId)
     const template = await this.deps.cloudTemplateDao.findBySlug(action.templateSlug)
     if (!template || !canUseCloudTemplate(template, userId)) {

--- a/apps/server/src/validators/play.schema.ts
+++ b/apps/server/src/validators/play.schema.ts
@@ -49,6 +49,7 @@ export const playLaunchSchema = z
       .max(128)
       .regex(/^[A-Za-z0-9._:-]+$/)
       .optional(),
+    inviteCode: z.string().min(1).max(64).optional(),
     locale: z.string().max(16).optional(),
   })
   .strict()

--- a/apps/web/src/pages/play-launch.tsx
+++ b/apps/web/src/pages/play-launch.tsx
@@ -18,7 +18,6 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ApiError, fetchApi } from '../lib/api'
 import { getApiErrorMessage } from '../lib/api-errors'
-import { useAuthStore } from '../stores/auth.store'
 
 type PlayAvailability = 'available' | 'gated' | 'coming_soon' | 'misconfigured'
 
@@ -71,6 +70,10 @@ type ServerMeta = {
 
 type LaunchPhase = 'loading' | 'ready' | 'launching' | 'gate' | 'wallet' | 'error'
 
+type LaunchOptions = {
+  inviteCode?: string
+}
+
 function resolveAppUrl(redirectUrl: string) {
   if (/^https?:\/\//.test(redirectUrl)) return redirectUrl
   if (redirectUrl.startsWith('/app/')) return redirectUrl
@@ -112,8 +115,6 @@ function playKind(play: PlayCatalogItem | null) {
 export function PlayLaunchPage() {
   const { t, i18n } = useTranslation()
   const search = useSearch({ strict: false }) as { play?: string }
-  const user = useAuthStore((s) => s.user)
-  const setUser = useAuthStore((s) => s.setUser)
   const launchSessionIdRef = useRef(createLaunchSessionId())
   const stepIndexRef = useRef(0)
   const [play, setPlay] = useState<PlayCatalogItem | null>(null)
@@ -234,8 +235,9 @@ export function PlayLaunchPage() {
     return () => window.clearInterval(interval)
   }, [activeStep, phase])
 
-  const launch = async () => {
+  const launch = async (options: LaunchOptions = {}) => {
     if (!play || !canLaunchPlay(play)) return
+    const normalizedInviteCode = options.inviteCode?.trim()
     setError('')
     setMembershipGate(null)
     setWalletGate(null)
@@ -250,6 +252,7 @@ export function PlayLaunchPage() {
           playId: play.id,
           launchSessionId: launchSessionIdRef.current,
           locale: i18n.language,
+          ...(normalizedInviteCode ? { inviteCode: normalizedInviteCode } : {}),
         }),
       })
       if (result.status === 'deploying') {
@@ -273,6 +276,11 @@ export function PlayLaunchPage() {
       if (err instanceof ApiError && err.code === 'INVITE_REQUIRED') {
         setMembershipGate({ capability: err.capability, message: err.message })
         setPhase('gate')
+        return
+      }
+      if (err instanceof ApiError && err.code === 'INVALID_INVITE_CODE') {
+        setPhase('gate')
+        setError(getApiErrorMessage(err, t, 'settings.membershipRedeemFailed'))
         return
       }
       if (
@@ -310,24 +318,13 @@ export function PlayLaunchPage() {
   }
 
   const redeemInviteAndRetry = async () => {
-    if (!inviteCode.trim()) return
+    const normalizedInviteCode = inviteCode.trim()
+    if (!normalizedInviteCode || redeeming) return
     setError('')
     setRedeeming(true)
     try {
-      const membership = await fetchApi<NonNullable<typeof user>['membership']>(
-        '/api/membership/redeem-invite',
-        {
-          method: 'POST',
-          body: JSON.stringify({ code: inviteCode.trim() }),
-        },
-      )
-      if (user && membership) setUser({ ...user, membership })
-      setInviteCode('')
       setMembershipGate(null)
-      await launch()
-    } catch (err) {
-      setError(getApiErrorMessage(err, t, 'settings.membershipRedeemFailed'))
-      setPhase('gate')
+      await launch({ inviteCode: normalizedInviteCode })
     } finally {
       setRedeeming(false)
     }
@@ -563,7 +560,7 @@ export function PlayLaunchPage() {
                   type="button"
                   className="h-12 w-full rounded-full text-base font-black"
                   disabled={phase === 'loading' || !canLaunchPlay(play)}
-                  onClick={launch}
+                  onClick={() => void launch()}
                 >
                   <Play size={17} fill="currentColor" />
                   {phase === 'loading'

--- a/docs/product/play-launch-orchestration.md
+++ b/docs/product/play-launch-orchestration.md
@@ -125,7 +125,7 @@ See `docs/product/membership-tiers.md` for the extensibility rules.
 ### Play Launch
 
 - `GET /api/play/catalog`: returns the public homepage play catalog.
-- `POST /api/play/launch`: launches a configured play by `playId`. Clients may send `launchSessionId` for retry/idempotency. Cloud plays return `deploymentId` while the real template deployment is pending and may return `redirectUrl` immediately if the template has already provisioned a Shadow server. The public API does not accept raw action objects; actions must come from published admin config. Website/app clients should call it only after the landing page start action, not automatically on page load.
+- `POST /api/play/launch`: launches a configured play by `playId`. Clients may send `launchSessionId` for retry/idempotency and `inviteCode` when the launch is gated by membership. Cloud plays redeem the invite code server-side before checking `cloud:deploy`, return `deploymentId` while the real template deployment is pending, and may return `redirectUrl` immediately if the template has already provisioned a Shadow server. The public API does not accept raw action objects; actions must come from published admin config. Website/app clients should call it only after the landing page start action, not automatically on page load.
 
 ### Official Model Proxy
 

--- a/docs/wiki/en/API-Reference.md
+++ b/docs/wiki/en/API-Reference.md
@@ -64,12 +64,14 @@ templates. Every homepage play has a matching git-tracked template under
 `apps/cloud/templates/*.template.json`; the app presents them through a unified landing page and keeps
 internal setup out of the customer-facing flow.
 
-`POST /api/play/launch` accepts a published `playId` and optional `launchSessionId`:
+`POST /api/play/launch` accepts a published `playId`, optional `launchSessionId`, and an
+optional `inviteCode` when member capabilities are required:
 
 ```json
 {
   "playId": "daily-brief",
-  "launchSessionId": "launch-session-1"
+  "launchSessionId": "launch-session-1",
+  "inviteCode": "INVITE-CODE"
 }
 ```
 
@@ -78,6 +80,9 @@ admin-managed website play config or the git-backed catalog. Missing actions ret
 codes such as `PLAY_NOT_CONFIGURED`, `PLAY_COMING_SOON`, `PLAY_MISCONFIGURED`, or
 `PLAY_TARGET_UNAVAILABLE`; launch no longer falls back to Discover. Cloud template plays queue a real
 Cloud SaaS deployment from the approved template content and return `deploymentId` while provisioning.
+If a Cloud play needs the `cloud:deploy` capability, the server checks membership inside the same
+launch request. When `inviteCode` is supplied, the server redeems it before continuing authorization;
+clients do not need to call the membership endpoint first.
 Once the deployment status is `deployed` and exposes `shadowServerId` plus `shadowChannelId`, clients
 should redirect directly into that channel. Public channel and private room plays must point to an
 already configured server; private rooms must also configure deployed `buddyUserIds`. The launcher

--- a/docs/wiki/en/SDK-Usage.md
+++ b/docs/wiki/en/SDK-Usage.md
@@ -91,13 +91,10 @@ await authedClient.updateNotificationChannelPreference({
 const membership = await authedClient.getMembership()
 const plays = await authedClient.getPlayCatalog()
 
-if (!membership.capabilities.includes("cloud:deploy")) {
-  await authedClient.redeemInviteCode("INVITE-CODE")
-}
-
 const launch = await authedClient.launchPlay({
   playId: plays.find((play) => play.template?.slug === "gstack-buddy")?.id ?? "gstack-buddy",
   launchSessionId: "launch-session-1",
+  inviteCode: membership.capabilities.includes("cloud:deploy") ? undefined : "INVITE-CODE",
 })
 
 if (launch.redirectUrl) {
@@ -172,12 +169,10 @@ authed_client.send_message("channel-uuid", "Hello from Python!")
 ```python
 membership = authed_client.get_membership()
 
-if "cloud:deploy" not in membership["capabilities"]:
-    authed_client.redeem_invite_code("INVITE-CODE")
-
 launch = authed_client.launch_play(
     play_id="daily-brief",
     launch_session_id="launch-session-1",
+    invite_code=None if "cloud:deploy" in membership["capabilities"] else "INVITE-CODE",
 )
 
 models = authed_client.list_official_model_proxy_models()

--- a/docs/wiki/zh/API-Reference.md
+++ b/docs/wiki/zh/API-Reference.md
@@ -60,12 +60,14 @@ Authorization: Bearer <token>
 `GET /api/play/catalog` 返回玩法卡片、启动状态、门禁、动作元数据和关联的 git 模板。每个首页玩法
 都有对应的 `apps/cloud/templates/*.template.json` 模板；app 会通过统一落地页呈现，客户侧不需要接触内部准备过程。
 
-`POST /api/play/launch` 接收已发布的 `playId` 和可选 `launchSessionId`：
+`POST /api/play/launch` 接收已发布的 `playId`、可选 `launchSessionId`，以及需要会员能力时可选的
+`inviteCode`：
 
 ```json
 {
   "playId": "daily-brief",
-  "launchSessionId": "launch-session-1"
+  "launchSessionId": "launch-session-1",
+  "inviteCode": "INVITE-CODE"
 }
 ```
 
@@ -74,6 +76,8 @@ git-backed catalog 发布。缺失 action 会返回 `PLAY_NOT_CONFIGURED`、`PLA
 `PLAY_MISCONFIGURED` 或 `PLAY_TARGET_UNAVAILABLE` 等结构化 code；启动不再 fallback 到探索页。
 Cloud 模板玩法会从已审核 template content 创建真实 Cloud SaaS deployment，并在 provisioning
 期间返回 `deploymentId`。当 deployment 状态为 `deployed` 且暴露 `shadowServerId` 与 `shadowChannelId` 后，客户端应直接跳入对应频道。
+如果 Cloud 玩法需要 `cloud:deploy` 能力，服务端会在同一次 launch 请求里校验会员状态；请求带有
+`inviteCode` 时，会先兑换邀请码再继续授权，不要求客户端先单独调用会员接口。
 公开频道和私有房间玩法必须由配置指定已有 `serverSlug` / `serverId`，私有房间还必须指定已部署 Buddy 的 `buddyUserIds`。启动器只负责入服、建私有频道、拉 Buddy 和发送欢迎消息，不会为这类玩法创建假服务器或假 Buddy。Cloud 部署玩法会在部署完成后由已 provision 的 Buddy 发送一次欢迎消息。
 Cloud 部署按运行时间计费，价格为 1 虾币 / 小时，计费精度为 15 分钟。API 在排队前会检查钱包是否能覆盖首个小时单位，
 worker 会在运行时真正变为 live 时扣除这首个小时单位。如果钱包余额不足，API 返回

--- a/docs/wiki/zh/SDK-Usage.md
+++ b/docs/wiki/zh/SDK-Usage.md
@@ -91,13 +91,10 @@ await authedClient.updateNotificationChannelPreference({
 const membership = await authedClient.getMembership()
 const plays = await authedClient.getPlayCatalog()
 
-if (!membership.capabilities.includes("cloud:deploy")) {
-  await authedClient.redeemInviteCode("INVITE-CODE")
-}
-
 const launch = await authedClient.launchPlay({
   playId: plays.find((play) => play.template?.slug === "gstack-buddy")?.id ?? "gstack-buddy",
   launchSessionId: "launch-session-1",
+  inviteCode: membership.capabilities.includes("cloud:deploy") ? undefined : "INVITE-CODE",
 })
 
 if (launch.redirectUrl) {
@@ -167,12 +164,10 @@ authed_client.send_message("channel-uuid", "来自 Python 的消息！")
 ```python
 membership = authed_client.get_membership()
 
-if "cloud:deploy" not in membership["capabilities"]:
-    authed_client.redeem_invite_code("INVITE-CODE")
-
 launch = authed_client.launch_play(
     play_id="daily-brief",
     launch_session_id="launch-session-1",
+    invite_code=None if "cloud:deploy" in membership["capabilities"] else "INVITE-CODE",
 )
 
 models = authed_client.list_official_model_proxy_models()

--- a/packages/sdk-python/shadowob_sdk/client.py
+++ b/packages/sdk-python/shadowob_sdk/client.py
@@ -211,6 +211,7 @@ class ShadowClient:
         *,
         play_id: str | None = None,
         launch_session_id: str | None = None,
+        invite_code: str | None = None,
         locale: str | None = None,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {}
@@ -218,6 +219,8 @@ class ShadowClient:
             payload["playId"] = play_id
         if launch_session_id:
             payload["launchSessionId"] = launch_session_id
+        if invite_code:
+            payload["inviteCode"] = invite_code
         if locale:
             payload["locale"] = locale
         return self._post("/api/play/launch", json=payload)

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -46,6 +46,7 @@ def test_launch_play_posts_launch_session_id(monkeypatch):
     result = client.launch_play(
         play_id="daily-brief",
         launch_session_id="launch-session-1",
+        invite_code="ABCD1234",
     )
 
     assert captured == {
@@ -53,6 +54,7 @@ def test_launch_play_posts_launch_session_id(monkeypatch):
         "json": {
             "playId": "daily-brief",
             "launchSessionId": "launch-session-1",
+            "inviteCode": "ABCD1234",
         },
     }
     assert result["ok"] is True

--- a/packages/sdk/__tests__/client.test.ts
+++ b/packages/sdk/__tests__/client.test.ts
@@ -311,7 +311,11 @@ describe('ShadowClient', () => {
 
       await client.getMembership()
       await client.redeemInviteCode('ABCD1234')
-      await client.launchPlay({ playId: 'daily-brief', launchSessionId: 'launch-session-1' })
+      await client.launchPlay({
+        playId: 'daily-brief',
+        launchSessionId: 'launch-session-1',
+        inviteCode: 'ABCD1234',
+      })
       await client.getPlayCatalog()
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -329,7 +333,11 @@ describe('ShadowClient', () => {
         'https://api.example.com/api/play/launch',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ playId: 'daily-brief', launchSessionId: 'launch-session-1' }),
+          body: JSON.stringify({
+            playId: 'daily-brief',
+            launchSessionId: 'launch-session-1',
+            inviteCode: 'ABCD1234',
+          }),
         }),
       )
       expect(mockFetch).toHaveBeenCalledWith(

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -278,6 +278,7 @@ export class ShadowClient {
   async launchPlay(data: {
     playId?: string
     launchSessionId?: string
+    inviteCode?: string
     locale?: string
   }): Promise<ShadowPlayLaunchResult> {
     return this.request('/api/play/launch', {


### PR DESCRIPTION
## Summary
- Let `POST /api/play/launch` accept an optional `inviteCode` for gated Cloud plays.
- Redeem invite codes server-side inside the Cloud launch authorization path before continuing the `cloud:deploy` capability check.
- Remove the homepage launch page's separate membership redemption request and pass the code as part of launch instead.
- Sync TypeScript SDK, Python SDK, tests, and API/SDK docs.

## Root Cause
The homepage gated launch flow redeemed the invite code in a separate frontend request, refreshed frontend membership state, then retried `/api/play/launch`. Authorization itself still happened server-side, but the two-request client state machine made first-time local onboarding fragile and could surface a 403 during the launch timing window.

## Validation
- Pre-commit hook passed: Drizzle migration guard, Biome staged check, staged typecheck.
- Pre-push hook passed: repository pre-push checks, `check:security-pr`, dashboard style check, dashboard i18n check.
- `git diff --cached --check` passed before commit.

Note: I did not start local services or run docker-compose tests manually.