### PR TITLE
feat: add community economy settlement flow across web/mobile/server

### DIFF
--- a/apps/admin/src/pages/dashboard.tsx
+++ b/apps/admin/src/pages/dashboard.tsx
@@ -332,9 +332,14 @@ function getPaginationWindow(page: number, totalPages: number, maxWindow = 5): n
   return Array.from({ length: end - start + 1 }, (_, i) => start + i)
 }
 
-function formatTooltipValue(value?: number) {
+function formatTooltipValue(value?: unknown) {
   if (value === undefined || value === null) return '0'
-  return value.toLocaleString()
+
+  const normalized =
+    typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN
+
+  if (!Number.isFinite(normalized)) return String(value)
+  return normalized.toLocaleString()
 }
 
 function formatPercent(value: number | null | undefined): string {
@@ -1225,8 +1230,8 @@ function DashboardContent() {
                               />
                               <YAxis stroke="var(--color-text-secondary)" />
                               <Tooltip
-                                formatter={(value: number) => formatTooltipValue(value)}
-                                labelFormatter={(value: string) => value}
+                                formatter={(value: unknown) => formatTooltipValue(value)}
+                                labelFormatter={(value: unknown) => formatTooltipValue(value)}
                                 contentStyle={{
                                   backgroundColor: 'var(--color-bg-tertiary)',
                                   borderColor: 'var(--color-border-subtle)',
@@ -1276,8 +1281,8 @@ function DashboardContent() {
                                 stroke="var(--color-text-secondary)"
                               />
                               <Tooltip
-                                formatter={(value: number) => formatTooltipValue(value)}
-                                labelFormatter={(value: string) => value}
+                                formatter={(value: unknown) => formatTooltipValue(value)}
+                                labelFormatter={(value: unknown) => formatTooltipValue(value)}
                                 contentStyle={{
                                   backgroundColor: 'var(--color-bg-tertiary)',
                                   borderColor: 'var(--color-border-subtle)',

--- a/apps/mobile/app/(main)/servers/[serverSlug]/shop.tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/shop.tsx
@@ -40,6 +40,10 @@ import { showToast } from '../../../../src/lib/toast'
 import { useAuthStore } from '../../../../src/stores/auth.store'
 import { fontSize, radius, spacing, useColors } from '../../../../src/theme'
 
+function createIdempotencyKey(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
 const SCREEN_WIDTH = Dimensions.get('window').width
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -307,6 +311,7 @@ export default function ShopScreen() {
       fetchApi(`/api/servers/${server!.id}/shop/orders`, {
         method: 'POST',
         body: JSON.stringify({
+          idempotencyKey: createIdempotencyKey('shop-order'),
           items: cartItems.map((c) => ({
             productId: c.productId,
             skuId: c.skuId,

--- a/apps/mobile/src/components/chat/message-bubble.tsx
+++ b/apps/mobile/src/components/chat/message-bubble.tsx
@@ -724,7 +724,7 @@ function MessageBubbleInner({
           })}
 
           {message.metadata?.commerceCards?.map((card) => (
-            <CommerceCardView key={card.id} card={card} messageId={message.id} />
+            <CommerceCardView key={card.id} card={card} messageId={message.id} variant={variant} />
           ))}
 
           {/* Phase 2 — interactive block (buttons / select) */}
@@ -899,7 +899,15 @@ function MessageBubbleInner({
   )
 }
 
-function CommerceCardView({ card, messageId }: { card: CommerceProductCard; messageId: string }) {
+function CommerceCardView({
+  card,
+  messageId,
+  variant,
+}: {
+  card: CommerceProductCard
+  messageId: string
+  variant: 'channel' | 'dm'
+}) {
   const { t } = useTranslation()
   const colors = useColors()
   const [isBuying, setIsBuying] = useState(false)
@@ -910,7 +918,11 @@ function CommerceCardView({ card, messageId }: { card: CommerceProductCard; mess
   const buy = async () => {
     setIsBuying(true)
     try {
-      await fetchApi(`/api/messages/${messageId}/commerce-cards/${card.id}/purchase`, {
+      const path =
+        variant === 'dm'
+          ? `/api/dm/messages/${messageId}/commerce-cards/${card.id}/purchase`
+          : `/api/messages/${messageId}/commerce-cards/${card.id}/purchase`
+      await fetchApi(path, {
         method: 'POST',
         body: JSON.stringify({
           skuId: card.skuId,

--- a/apps/mobile/src/hooks/use-community-economy.ts
+++ b/apps/mobile/src/hooks/use-community-economy.ts
@@ -1,0 +1,175 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchApi } from '../lib/api'
+
+export interface CommunityAssetDefinition {
+  id: string
+  assetType: string
+  name: string
+  description?: string | null
+  imageUrl?: string | null
+  giftable: boolean
+  consumable: boolean
+  status: string
+}
+
+export interface CommunityAssetGrant {
+  id: string
+  definitionId: string
+  ownerUserId: string
+  quantity: number
+  remainingQuantity: number
+  status: string
+  expiresAt?: string | null
+}
+
+export interface CommunityAsset {
+  grant: CommunityAssetGrant
+  definition: CommunityAssetDefinition
+}
+
+export interface SettlementLine {
+  id: string
+  sellerUserId: string
+  sourceType: string
+  sourceId: string
+  grossAmount: number
+  platformFee: number
+  netAmount: number
+  status: string
+  availableAt?: string | null
+  settledAt?: string | null
+}
+
+export function useCommunityAssets() {
+  return useQuery({
+    queryKey: ['community-assets'],
+    queryFn: () => fetchApi<{ assets: CommunityAsset[] }>('/api/economy/assets'),
+  })
+}
+
+export function useConsumeCommunityAsset() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { grantId: string; idempotencyKey: string }) =>
+      fetchApi<{ grant: CommunityAssetGrant }>(`/api/economy/assets/${input.grantId}/consume`, {
+        method: 'POST',
+        body: JSON.stringify({ idempotencyKey: input.idempotencyKey }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+    },
+  })
+}
+
+export function useLockCommunityAsset() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { grantId: string; idempotencyKey: string }) =>
+      fetchApi<{ grant: CommunityAssetGrant }>(`/api/economy/assets/${input.grantId}/lock`, {
+        method: 'POST',
+        body: JSON.stringify({ idempotencyKey: input.idempotencyKey }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+    },
+  })
+}
+
+export function useUnlockCommunityAsset() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { grantId: string; idempotencyKey: string }) =>
+      fetchApi<{ grant: CommunityAssetGrant }>(`/api/economy/assets/${input.grantId}/unlock`, {
+        method: 'POST',
+        body: JSON.stringify({ idempotencyKey: input.idempotencyKey }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+    },
+  })
+}
+
+export function useRevokeCommunityAsset() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { grantId: string; idempotencyKey: string; reason?: string }) =>
+      fetchApi<{ grant: CommunityAssetGrant }>(`/api/economy/assets/${input.grantId}/revoke`, {
+        method: 'POST',
+        body: JSON.stringify({ idempotencyKey: input.idempotencyKey, reason: input.reason }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+    },
+  })
+}
+
+export function useSendTip() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: {
+      recipientUserId: string
+      amount: number
+      message?: string
+      context?: { kind: string; id: string }
+      idempotencyKey: string
+    }) =>
+      fetchApi('/api/economy/tips', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['wallet'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet-transactions'] })
+    },
+  })
+}
+
+export function useSendGift() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: {
+      recipientUserId: string
+      assets?: Array<{ assetGrantId: string; quantity?: number }>
+      currencies?: Array<{ currencyCode: 'shrimp_coin'; amount: number }>
+      message?: string
+      idempotencyKey: string
+    }) =>
+      fetchApi('/api/economy/gifts', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet-transactions'] })
+    },
+  })
+}
+
+export function useSettlementLines(params?: { limit?: number; offset?: number }) {
+  return useQuery({
+    queryKey: ['community-settlements', params?.limit ?? 50, params?.offset ?? 0],
+    queryFn: () => {
+      const qs = new URLSearchParams()
+      if (params?.limit != null) qs.set('limit', String(params.limit))
+      if (params?.offset != null) qs.set('offset', String(params.offset))
+      const suffix = qs.toString() ? `?${qs}` : ''
+      return fetchApi<{ settlements: SettlementLine[] }>(`/api/economy/settlements${suffix}`)
+    },
+  })
+}
+
+export function useSettleAvailableLines() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      fetchApi<{ settlements: SettlementLine[] }>('/api/economy/settlements/settle', {
+        method: 'POST',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-settlements'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet-transactions'] })
+    },
+  })
+}

--- a/apps/server/__tests__/commerce-entitlement-service.test.ts
+++ b/apps/server/__tests__/commerce-entitlement-service.test.ts
@@ -4,6 +4,7 @@ import {
   agents,
   commerceDeliverables,
   commerceFulfillmentJobs,
+  commerceFulfillmentRecords,
   commerceIdempotencyKeys,
   entitlements,
   orders,
@@ -434,6 +435,9 @@ describe('EntitlementPurchaseService', () => {
       credit: vi.fn(async () => undefined),
       debit: vi.fn(async () => undefined),
     }
+    const settlementService = {
+      createLine: vi.fn(async () => ({ id: 'settlement-line-1' })),
+    }
     const commerceFulfillmentService = {
       processJobs: vi.fn(async () => [{ id: fulfillmentJobId, status: 'sent' }]),
     }
@@ -470,6 +474,13 @@ describe('EntitlementPurchaseService', () => {
         listDeliverablesForOffer: vi.fn(async () => [deliverable]),
       } as any,
       commerceFulfillmentService: commerceFulfillmentService as any,
+      economyPolicyService: {
+        authorize: vi.fn(async () => ({ ok: true })),
+      } as any,
+      economyAuditService: {
+        record: vi.fn(async () => undefined),
+      } as any,
+      settlementService: settlementService as any,
     })
 
     const result = await service.purchaseOffer({
@@ -488,16 +499,17 @@ describe('EntitlementPurchaseService', () => {
       }),
       expect.anything(),
     )
-    expect(ledgerService.credit).toHaveBeenCalledWith(
+    expect(settlementService.createLine).toHaveBeenCalledWith(
       expect.objectContaining({
-        userId: ownerId,
-        amount: 900,
-        type: 'settlement',
-        referenceId: orderId,
-        referenceType: 'order',
+        sellerUserId: ownerId,
+        shopId,
+        sourceType: 'order',
+        sourceId: orderId,
+        grossAmount: 900,
       }),
       expect.anything(),
     )
+    expect(ledgerService.credit).not.toHaveBeenCalled()
     expect(db.inserts.find((entry) => entry.table === entitlements)?.data).toMatchObject({
       userId: buyerId,
       productId,
@@ -630,14 +642,14 @@ describe('PaidFileService', () => {
     })
 
     const opened = await service.openPaidFile(buyerId, fileId)
-    const viewerUrl = new URL(opened.viewerUrl, 'http://shadow.test')
     const read = await service.readGrantFile({
       fileId,
       grantId: opened.grant.id,
-      token: viewerUrl.searchParams.get('token'),
+      token: opened.grantToken,
     })
 
     expect(opened.viewerUrl).toContain(`/api/paid-files/${fileId}/view/${opened.grant.id}`)
+    expect(opened.viewerUrl).not.toContain('token=')
     expect(read.file).toMatchObject({ id: fileId, mime: 'text/html' })
     expect(read.buffer.toString('utf8')).toBe('<html>match</html>')
   })
@@ -674,13 +686,12 @@ describe('PaidFileService', () => {
       } as any,
     })
     const opened = await service.openPaidFile(buyerId, fileId)
-    const viewerUrl = new URL(opened.viewerUrl, 'http://shadow.test')
 
     await expect(
       service.readGrantFile({
         fileId,
         grantId: opened.grant.id,
-        token: viewerUrl.searchParams.get('token'),
+        token: opened.grantToken,
       }),
     ).rejects.toMatchObject({ code: 'PAID_FILE_ENTITLEMENT_REQUIRED' })
   })
@@ -705,7 +716,9 @@ describe('paid file routes', () => {
       },
     } as any)
 
-    const response = await app.request(`/api/paid-files/${fileId}/view/grant-1?token=grant-token`)
+    const response = await app.request(`/api/paid-files/${fileId}/view/grant-1`, {
+      headers: { 'x-paid-file-grant-token': 'grant-token' },
+    })
 
     expect(response.status).toBe(200)
     expect(response.headers.get('content-security-policy')).toContain("default-src 'none'")
@@ -764,7 +777,9 @@ function createFileNode(overrides: Record<string, unknown> = {}) {
 }
 
 function createFulfillmentDb(job: Record<string, unknown>, deliverable: Record<string, unknown>) {
+  const records: Record<string, unknown>[] = []
   return {
+    records,
     select: () => ({
       table: null as unknown,
       from(table: unknown) {
@@ -777,7 +792,20 @@ function createFulfillmentDb(job: Record<string, unknown>, deliverable: Record<s
       limit() {
         if (this.table === commerceFulfillmentJobs) return Promise.resolve([job])
         if (this.table === commerceDeliverables) return Promise.resolve([deliverable])
+        if (this.table === commerceFulfillmentRecords) return Promise.resolve(records.slice(0, 1))
         return Promise.resolve([])
+      },
+    }),
+    insert: (table: unknown) => ({
+      values(data: Record<string, unknown>) {
+        if (table === commerceFulfillmentRecords) records.push(data)
+        return this
+      },
+      onConflictDoNothing() {
+        return this
+      },
+      then(resolve: (value: unknown) => void) {
+        return Promise.resolve(undefined).then(resolve)
       },
     }),
     update: (table: unknown) => createUpdateBuilder(table, { job }),

--- a/apps/server/__tests__/community-economy-phase1.test.ts
+++ b/apps/server/__tests__/community-economy-phase1.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ProductService } from '../src/services/product.service'
+
+describe('Community economy phase 1 catalog invariants', () => {
+  it('updates existing SKUs, inserts new SKUs, and soft-deactivates omitted SKUs', async () => {
+    const productDao = {
+      update: vi.fn(async () => ({ id: 'product-1' })),
+      findById: vi.fn(async () => ({ id: 'product-1', shopId: 'shop-1' })),
+    }
+    const productMediaDao = {
+      findByProductId: vi.fn(async () => []),
+    }
+    const skuDao = {
+      findByProductId: vi.fn(async () => []),
+      findById: vi.fn(async (id: string) => ({ id, productId: 'product-1' })),
+      update: vi.fn(async () => ({ id: 'sku-1' })),
+      create: vi.fn(async () => ({ id: 'sku-2' })),
+      deactivateMissing: vi.fn(async () => undefined),
+    }
+    const service = new ProductService({
+      productDao: productDao as any,
+      productMediaDao: productMediaDao as any,
+      skuDao: skuDao as any,
+    })
+
+    await service.updateProduct('product-1', {
+      skus: [
+        { id: 'sku-1', price: 100, stock: 5, specValues: ['red'] },
+        { price: 120, stock: 3, specValues: ['blue'] },
+      ],
+    })
+
+    expect(skuDao.update).toHaveBeenCalledWith(
+      'sku-1',
+      expect.objectContaining({ price: 100, stock: 5, isActive: true }),
+    )
+    expect(skuDao.create).toHaveBeenCalledWith(
+      expect.objectContaining({ productId: 'product-1', price: 120, isActive: true }),
+    )
+    expect(skuDao.deactivateMissing).toHaveBeenCalledWith('product-1', ['sku-1', 'sku-2'])
+  })
+
+  it('archives products instead of physically deleting them', async () => {
+    const productDao = {
+      delete: vi.fn(async () => undefined),
+    }
+    const service = new ProductService({
+      productDao: productDao as any,
+      productMediaDao: {} as any,
+      skuDao: {} as any,
+    })
+
+    await service.deleteProduct('product-1')
+
+    expect(productDao.delete).toHaveBeenCalledWith('product-1')
+  })
+})
+
+describe('Community economy phase 1 recharge idempotency', () => {
+  it('uses the client idempotency key for Stripe and stores the completed response', async () => {
+    vi.resetModules()
+    const createPaymentIntent = vi.fn(async () => ({
+      id: 'pi_1',
+      client_secret: 'secret_1',
+    }))
+    vi.doMock('../src/lib/stripe', () => ({
+      stripe: { paymentIntents: { create: createPaymentIntent } },
+      STRIPE_WEBHOOK_SECRET: 'whsec_test',
+      RECHARGE_TIERS: {
+        '1000': { shrimpCoins: 1000, usdCents: 1000, label: 'Starter' },
+        '3000': { shrimpCoins: 3000, usdCents: 2999, label: 'Best Value' },
+        '5000': { shrimpCoins: 5000, usdCents: 4999, label: 'Premium' },
+      },
+      CUSTOM_AMOUNT_MIN: 100,
+      CUSTOM_AMOUNT_MAX: 10_000_000,
+      shrimpCoinsToUsdCents: (coins: number) => coins,
+      generateOrderNo: () => 'RC-TEST',
+    }))
+    const { RechargeService } = await import('../src/services/recharge.service')
+    const economyIdempotencyService = {
+      getCompleted: vi.fn(async () => null),
+      begin: vi.fn(async () => ({ id: 'idem-row-1' })),
+      complete: vi.fn(async () => undefined),
+      fail: vi.fn(async () => undefined),
+    }
+    const service = new RechargeService({
+      rechargeDao: {
+        createPaymentOrder: vi.fn(async () => ({
+          id: 'payment-order-1',
+          orderNo: 'RC-TEST',
+        })),
+      },
+      db: {} as any,
+      ledgerService: {} as any,
+      economyPolicyService: { authorize: vi.fn(async () => ({ ok: true })) },
+      economyAuditService: { record: vi.fn(async () => undefined) },
+      economyIdempotencyService,
+      notificationTriggerService: {} as any,
+    } as any)
+
+    const result = await service.createPaymentIntent(
+      'user-1',
+      '1000',
+      undefined,
+      'usd',
+      { kind: 'user', userId: 'user-1', authMethod: 'jwt', scopes: [] },
+      'recharge-key-1',
+    )
+
+    expect(createPaymentIntent).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 1000, currency: 'usd' }),
+      { idempotencyKey: 'recharge-user-1-recharge-key-1' },
+    )
+    expect(economyIdempotencyService.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId: 'user-1',
+        key: 'recharge-key-1',
+        action: 'recharge.create-intent',
+        referenceId: 'payment-order-1',
+        response: result,
+      }),
+    )
+
+    vi.doUnmock('../src/lib/stripe')
+    vi.resetModules()
+  })
+})

--- a/apps/server/__tests__/community-economy-phase2.test.ts
+++ b/apps/server/__tests__/community-economy-phase2.test.ts
@@ -1,0 +1,554 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  communityAssetGrants,
+  communityAssetTransferLogs,
+  economyGiftItems,
+  economyGifts,
+  economyTips,
+  settlementAccounts,
+  settlementLines,
+} from '../src/db/schema'
+import { CommunityAssetService } from '../src/services/community-asset.service'
+import { GiftService } from '../src/services/gift.service'
+import { SettlementService } from '../src/services/settlement.service'
+import { TipService } from '../src/services/tip.service'
+
+function createTx(returningByTable: Map<unknown, unknown[]>, inserts: unknown[]) {
+  return {
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn((data: unknown) => {
+        inserts.push({ table, data })
+        return {
+          returning: vi.fn(async () => returningByTable.get(table) ?? []),
+        }
+      }),
+    })),
+  }
+}
+
+describe('Community economy phase 2 tips', () => {
+  it('debits the sender, creates a settlement line, audits, and completes idempotency', async () => {
+    const tip = {
+      id: '11111111-1111-4111-8111-111111111111',
+      senderUserId: 'sender-1',
+      recipientUserId: 'recipient-1',
+      amount: 100,
+      sellerNet: 100,
+      status: 'succeeded',
+    }
+    const inserts: unknown[] = []
+    const tx = createTx(new Map([[economyTips, [tip]]]), inserts)
+    const db = {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: vi.fn(async () => [{ count: 0, amount: 0 }]),
+        }),
+      })),
+      transaction: vi.fn(async (fn: (txArg: unknown) => Promise<unknown>) => fn(tx)),
+    }
+    const ledgerService = { debit: vi.fn(async () => undefined) }
+    const settlementService = { createLine: vi.fn(async () => ({ id: 'settlement-line-1' })) }
+    const economyIdempotencyService = {
+      getCompleted: vi.fn(async () => null),
+      begin: vi.fn(async () => undefined),
+      complete: vi.fn(async () => undefined),
+    }
+    const economyAuditService = { record: vi.fn(async () => undefined) }
+    const economyPolicyService = { authorize: vi.fn(async () => ({ ok: true })) }
+    const service = new TipService({
+      db: db as any,
+      ledgerService: ledgerService as any,
+      settlementService: settlementService as any,
+      economyPolicyService: economyPolicyService as any,
+      economyAuditService: economyAuditService as any,
+      economyIdempotencyService: economyIdempotencyService as any,
+    })
+
+    const result = await service.sendTip({
+      senderUserId: 'sender-1',
+      recipientUserId: 'recipient-1',
+      amount: 100,
+      idempotencyKey: 'tip-idempotency-key',
+    })
+
+    expect(result).toEqual({ tip })
+    expect(economyPolicyService.authorize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'tip.send',
+        dataClass: 'financial',
+        targetUserId: 'sender-1',
+      }),
+    )
+    expect(ledgerService.debit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'sender-1',
+        amount: 100,
+        referenceId: tip.id,
+        referenceType: 'tip',
+      }),
+      tx,
+    )
+    expect(settlementService.createLine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sellerUserId: 'recipient-1',
+        sourceType: 'tip',
+        sourceId: tip.id,
+        grossAmount: 100,
+      }),
+      tx,
+    )
+    expect(economyIdempotencyService.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId: 'sender-1',
+        key: 'tip-idempotency-key',
+        action: 'economy.tip.send',
+        referenceId: tip.id,
+      }),
+      tx,
+    )
+  })
+
+  it('rejects self tips before mutating state', async () => {
+    const db = { transaction: vi.fn() }
+    const service = new TipService({
+      db: db as any,
+      ledgerService: {} as any,
+      settlementService: {} as any,
+      economyPolicyService: {} as any,
+      economyAuditService: {} as any,
+      economyIdempotencyService: {} as any,
+    })
+
+    await expect(
+      service.sendTip({
+        senderUserId: 'user-1',
+        recipientUserId: 'user-1',
+        amount: 1,
+        idempotencyKey: 'tip-idempotency-key',
+      }),
+    ).rejects.toMatchObject({ code: 'TIP_SELF_NOT_ALLOWED' })
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects tips that exceed daily service-layer limits', async () => {
+    const previous = process.env.SHADOW_TIP_DAILY_COUNT_LIMIT
+    process.env.SHADOW_TIP_DAILY_COUNT_LIMIT = '1'
+    const db = {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: vi.fn(async () => [{ count: 1, amount: 0 }]),
+        }),
+      })),
+      transaction: vi.fn(),
+    }
+    const service = new TipService({
+      db: db as any,
+      ledgerService: {} as any,
+      settlementService: {} as any,
+      economyPolicyService: { authorize: vi.fn(async () => ({ ok: true })) } as any,
+      economyAuditService: {} as any,
+      economyIdempotencyService: {
+        getCompleted: vi.fn(async () => null),
+      } as any,
+    })
+
+    await expect(
+      service.sendTip({
+        senderUserId: 'sender-1',
+        recipientUserId: 'recipient-1',
+        amount: 1,
+        idempotencyKey: 'tip-idempotency-key',
+      }),
+    ).rejects.toMatchObject({ code: 'TIP_DAILY_COUNT_LIMIT_EXCEEDED' })
+    expect(db.transaction).not.toHaveBeenCalled()
+    if (previous == null) delete process.env.SHADOW_TIP_DAILY_COUNT_LIMIT
+    else process.env.SHADOW_TIP_DAILY_COUNT_LIMIT = previous
+  })
+})
+
+describe('Community economy phase 2 gifts', () => {
+  it('moves currency and assets in one idempotent gift transaction', async () => {
+    const gift = {
+      id: '22222222-2222-4222-8222-222222222222',
+      senderUserId: 'sender-1',
+      recipientUserId: 'recipient-1',
+      status: 'succeeded',
+    }
+    const assetGrant = {
+      id: '33333333-3333-4333-8333-333333333333',
+      definitionId: '44444444-4444-4444-8444-444444444444',
+    }
+    const inserts: unknown[] = []
+    const tx = createTx(new Map([[economyGifts, [gift]]]), inserts)
+    const db = {
+      select: vi
+        .fn()
+        .mockReturnValueOnce({
+          from: () => ({
+            where: () => ({
+              limit: vi.fn(async () => [{ economyStatus: 'normal' }]),
+            }),
+          }),
+        })
+        .mockReturnValueOnce({
+          from: () => ({
+            where: vi.fn(async () => [{ count: 0 }]),
+          }),
+        }),
+      transaction: vi.fn(async (fn: (txArg: unknown) => Promise<unknown>) => fn(tx)),
+    }
+    const ledgerService = {
+      debit: vi.fn(async () => undefined),
+    }
+    const settlementService = { createLine: vi.fn(async () => ({ id: 'gift-settlement-1' })) }
+    const communityAssetService = {
+      transferGrant: vi.fn(async () => assetGrant),
+    }
+    const economyIdempotencyService = {
+      getCompleted: vi.fn(async () => null),
+      begin: vi.fn(async () => undefined),
+      complete: vi.fn(async () => undefined),
+    }
+    const service = new GiftService({
+      db: db as any,
+      ledgerService: ledgerService as any,
+      communityAssetService: communityAssetService as any,
+      economyPolicyService: { authorize: vi.fn(async () => ({ ok: true })) } as any,
+      economyAuditService: { record: vi.fn(async () => undefined) } as any,
+      economyIdempotencyService: economyIdempotencyService as any,
+      settlementService: settlementService as any,
+    })
+
+    const result = await service.sendGift({
+      senderUserId: 'sender-1',
+      recipientUserId: 'recipient-1',
+      currencies: [{ currencyCode: 'shrimp_coin', amount: 25 }],
+      assets: [{ assetGrantId: 'source-grant-1', quantity: 2 }],
+      idempotencyKey: 'gift-idempotency-key',
+    })
+
+    expect(result).toEqual({ gift })
+    expect(ledgerService.debit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'sender-1',
+        amount: 25,
+        referenceId: gift.id,
+        referenceType: 'gift',
+      }),
+      tx,
+    )
+    expect(settlementService.createLine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sellerUserId: 'recipient-1',
+        sourceType: 'gift',
+        sourceId: gift.id,
+        grossAmount: 25,
+      }),
+      tx,
+    )
+    expect(communityAssetService.transferGrant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId: 'sender-1',
+        recipientUserId: 'recipient-1',
+        grantId: 'source-grant-1',
+        quantity: 2,
+        referenceId: gift.id,
+        idempotencyKey: 'gift-idempotency-key:asset:0',
+        actor: expect.objectContaining({ kind: 'user' }),
+      }),
+      tx,
+    )
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: economyGiftItems,
+        data: expect.objectContaining({
+          giftId: gift.id,
+          itemKind: 'asset',
+          assetGrantId: assetGrant.id,
+          assetDefinitionId: assetGrant.definitionId,
+        }),
+      }),
+    )
+    expect(economyIdempotencyService.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId: 'sender-1',
+        key: 'gift-idempotency-key',
+        action: 'economy.gift.send',
+        referenceId: gift.id,
+      }),
+      tx,
+    )
+  })
+
+  it('rejects gifts to economy-restricted recipients before mutating state', async () => {
+    const db = {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            limit: vi.fn(async () => [{ economyStatus: 'economy_restricted' }]),
+          }),
+        }),
+      })),
+      transaction: vi.fn(),
+    }
+    const service = new GiftService({
+      db: db as any,
+      ledgerService: {} as any,
+      communityAssetService: {} as any,
+      economyPolicyService: { authorize: vi.fn(async () => ({ ok: true })) } as any,
+      economyAuditService: {} as any,
+      economyIdempotencyService: {
+        getCompleted: vi.fn(async () => null),
+      } as any,
+      settlementService: {} as any,
+    })
+
+    await expect(
+      service.sendGift({
+        senderUserId: 'sender-1',
+        recipientUserId: 'recipient-1',
+        currencies: [{ currencyCode: 'shrimp_coin', amount: 1 }],
+        idempotencyKey: 'gift-idempotency-key',
+      }),
+    ).rejects.toMatchObject({ code: 'GIFT_RECIPIENT_ECONOMY_RESTRICTED' })
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+})
+
+describe('Community economy phase 2 settlements', () => {
+  function createSettlementUpdateDb(line: Record<string, unknown>, updatedStatus: string) {
+    const updates: Array<{ table: unknown; data: unknown }> = []
+    const db = {
+      update: vi.fn((table: unknown) => ({
+        set: vi.fn((data: unknown) => {
+          updates.push({ table, data })
+          return {
+            where: vi.fn(() => {
+              if (table === settlementLines) {
+                return {
+                  returning: vi.fn(async () => [{ ...line, status: updatedStatus }]),
+                }
+              }
+              return undefined
+            }),
+          }
+        }),
+      })),
+    }
+    return { db, updates }
+  }
+
+  it('moves due pending settlement lines into available balance', async () => {
+    const line = {
+      id: 'settlement-line-1',
+      sellerUserId: 'seller-1',
+      sourceType: 'tip',
+      sourceId: 'tip-1',
+      netAmount: 90,
+      status: 'pending',
+    }
+    const { db, updates } = createSettlementUpdateDb(line, 'available')
+    Object.assign(db, {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            limit: vi.fn(async () => [line]),
+          }),
+        }),
+      })),
+    })
+    const service = new SettlementService({ db: db as any, ledgerService: {} as any })
+
+    const released = await service.makePendingAvailableForUser('seller-1')
+
+    expect(released).toHaveLength(1)
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: settlementLines,
+          data: expect.objectContaining({ status: 'available' }),
+        }),
+        expect.objectContaining({ table: settlementAccounts }),
+      ]),
+    )
+  })
+
+  it('reverses unsettled settlement lines and removes them from held balance', async () => {
+    const line = {
+      id: 'settlement-line-1',
+      sellerUserId: 'seller-1',
+      sourceType: 'order',
+      sourceId: 'order-1',
+      netAmount: 90,
+      status: 'held',
+    }
+    const { db, updates } = createSettlementUpdateDb(line, 'reversed')
+    Object.assign(db, {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: vi.fn(async () => [line]),
+        }),
+      })),
+    })
+    const service = new SettlementService({ db: db as any, ledgerService: {} as any })
+
+    const reversed = await service.reverseLinesForSource({
+      sourceType: 'order',
+      sourceId: 'order-1',
+      reason: 'refund',
+    })
+
+    expect(reversed).toHaveLength(1)
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: settlementLines,
+          data: expect.objectContaining({ status: 'reversed', refundAmount: 90 }),
+        }),
+        expect.objectContaining({ table: settlementAccounts }),
+      ]),
+    )
+  })
+})
+
+describe('Community economy phase 2 assets', () => {
+  it('returns the recipient grant for duplicate asset transfer idempotency keys', async () => {
+    const recipientGrant = {
+      id: '55555555-5555-4555-8555-555555555555',
+      definitionId: '44444444-4444-4444-8444-444444444444',
+      ownerUserId: 'recipient-1',
+    }
+    const db = {
+      select: vi
+        .fn()
+        .mockReturnValueOnce({
+          from: (table: unknown) => {
+            expect(table).toBe(communityAssetTransferLogs)
+            return {
+              where: () => ({
+                limit: vi.fn(async () => [{ grantId: recipientGrant.id }]),
+              }),
+            }
+          },
+        })
+        .mockReturnValueOnce({
+          from: (table: unknown) => {
+            expect(table).toBe(communityAssetGrants)
+            return {
+              where: () => ({
+                limit: vi.fn(async () => [recipientGrant]),
+              }),
+            }
+          },
+        }),
+      update: vi.fn(),
+    }
+    const service = new CommunityAssetService({
+      db: db as any,
+      economyPolicyService: {} as any,
+      economyAuditService: {} as any,
+    })
+
+    const result = await service.transferGrant({
+      actorUserId: 'sender-1',
+      recipientUserId: 'recipient-1',
+      grantId: 'source-grant-1',
+      referenceType: 'gift',
+      referenceId: 'gift-1',
+      idempotencyKey: 'gift-idempotency-key:asset:0',
+    })
+
+    expect(result).toBe(recipientGrant)
+    expect(db.update).not.toHaveBeenCalled()
+  })
+
+  it('locks active grants through policy, transfer log, and audit', async () => {
+    const sourceGrant = {
+      id: '55555555-5555-4555-8555-555555555555',
+      definitionId: '44444444-4444-4444-8444-444444444444',
+      ownerUserId: 'sender-1',
+      remainingQuantity: 1,
+      status: 'active',
+    }
+    const definition = {
+      id: sourceGrant.definitionId,
+      giftable: true,
+      consumable: true,
+    }
+    const lockedGrant = { ...sourceGrant, status: 'locked' }
+    const inserts: unknown[] = []
+    const db = {
+      select: vi
+        .fn()
+        .mockReturnValueOnce({
+          from: () => ({
+            where: () => ({
+              limit: vi.fn(async () => []),
+            }),
+          }),
+        })
+        .mockReturnValueOnce({
+          from: () => ({
+            innerJoin: () => ({
+              where: () => ({
+                limit: vi.fn(async () => [{ grant: sourceGrant, definition }]),
+              }),
+            }),
+          }),
+        }),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(async () => [lockedGrant]),
+          })),
+        })),
+      })),
+      insert: vi.fn((table: unknown) => ({
+        values: vi.fn((data: unknown) => {
+          inserts.push({ table, data })
+          return {}
+        }),
+      })),
+    }
+    const economyPolicyService = { authorize: vi.fn(async () => ({ ok: true })) }
+    const economyAuditService = { record: vi.fn(async () => undefined) }
+    const service = new CommunityAssetService({
+      db: db as any,
+      economyPolicyService: economyPolicyService as any,
+      economyAuditService: economyAuditService as any,
+    })
+
+    const result = await service.lockGrant({
+      actorUserId: 'sender-1',
+      grantId: sourceGrant.id,
+      idempotencyKey: 'asset-lock-idempotency-key',
+    })
+
+    expect(result).toEqual(lockedGrant)
+    expect(economyPolicyService.authorize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'asset.lock',
+        requiredScope: 'economy:assets:write',
+        targetUserId: 'sender-1',
+      }),
+    )
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: communityAssetTransferLogs,
+        data: expect.objectContaining({
+          grantId: sourceGrant.id,
+          action: 'lock',
+          idempotencyKey: 'asset-lock-idempotency-key',
+        }),
+      }),
+    )
+    expect(economyAuditService.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'asset.lock',
+        idempotencyKey: 'asset-lock-idempotency-key',
+        result: 'succeeded',
+      }),
+      db,
+    )
+  })
+})

--- a/apps/server/__tests__/mobile-e2e.test.ts
+++ b/apps/server/__tests__/mobile-e2e.test.ts
@@ -89,6 +89,15 @@ async function json<T = unknown>(res: Response): Promise<T> {
   return res.json() as Promise<T>
 }
 
+function orderBody(input: {
+  items: Array<{ productId: string; skuId?: string; quantity: number }>
+}) {
+  return {
+    idempotencyKey: `mobile-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    ...input,
+  }
+}
+
 /* ── Setup & Teardown ── */
 
 beforeAll(async () => {
@@ -365,9 +374,9 @@ describe('Shop order lifecycle (mobile)', () => {
   it('create order from cart', async () => {
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: memberToken,
-      body: {
+      body: orderBody({
         items: [{ productId, skuId, quantity: 1 }],
-      },
+      }),
     })
     expect(res.status).toBe(201)
     const order = await json<{ id: string; status: string; totalAmount: number }>(res)

--- a/apps/server/__tests__/security-hardening.test.ts
+++ b/apps/server/__tests__/security-hardening.test.ts
@@ -8,6 +8,7 @@ import {
   DIY_CLOUD_MAX_ESTIMATED_TOKENS,
   estimateDiyCloudInputBudget,
 } from '../src/services/diy-cloud.service'
+import { EconomyPolicyService } from '../src/services/economy-policy.service'
 import { PolicyService } from '../src/services/policy.service'
 import { RentalService } from '../src/services/rental.service'
 import { ReviewService } from '../src/services/review.service'
@@ -270,6 +271,79 @@ describe('Actor and PolicyService', () => {
     await expect(policy.requireChannelRead('user-1', 'channel-1')).resolves.toMatchObject({
       channel: { id: 'channel-1' },
     })
+  })
+})
+
+describe('EconomyPolicyService', () => {
+  function createPolicy(user: { economyStatus: string; isAdmin: boolean }) {
+    return new EconomyPolicyService({
+      db: {
+        select: () => ({
+          from() {
+            return this
+          },
+          where() {
+            return this
+          },
+          limit() {
+            return Promise.resolve([user])
+          },
+        }),
+      } as any,
+    })
+  }
+
+  it('requires explicit economy scopes for PAT write operations', async () => {
+    const policy = createPolicy({ economyStatus: 'normal', isAdmin: false })
+
+    await expect(
+      policy.authorize({
+        actor: { kind: 'pat', userId: 'user-1', tokenId: 'pat-1', scopes: ['user:write'] },
+        action: 'order.purchase',
+        resource: { kind: 'order' },
+        dataClass: 'financial',
+      }),
+    ).rejects.toMatchObject({ code: 'ECONOMY_SCOPE_REQUIRED' })
+
+    await expect(
+      policy.authorize({
+        actor: {
+          kind: 'pat',
+          userId: 'user-1',
+          tokenId: 'pat-1',
+          scopes: ['economy:orders:write'],
+        },
+        action: 'order.purchase',
+        resource: { kind: 'order' },
+        dataClass: 'financial',
+      }),
+    ).resolves.toMatchObject({ ok: true })
+  })
+
+  it('requires explicit economy scopes for agent write operations', async () => {
+    const policy = createPolicy({ economyStatus: 'normal', isAdmin: false })
+
+    await expect(
+      policy.authorize({
+        actor: { kind: 'agent', userId: 'user-1', agentId: 'agent-1', scopes: [] },
+        action: 'offer.purchase',
+        resource: { kind: 'offer', id: 'offer-1' },
+        dataClass: 'financial',
+      }),
+    ).rejects.toMatchObject({ code: 'ECONOMY_SCOPE_REQUIRED' })
+  })
+
+  it('blocks wallet outflows for economy restricted users', async () => {
+    const policy = createPolicy({ economyStatus: 'economy_restricted', isAdmin: false })
+
+    await expect(
+      policy.authorize({
+        actor: { kind: 'user', userId: 'user-1', authMethod: 'jwt', scopes: [] },
+        action: 'offer.purchase',
+        resource: { kind: 'offer', id: 'offer-1' },
+        dataClass: 'financial',
+      }),
+    ).rejects.toMatchObject({ code: 'ECONOMY_USER_RESTRICTED' })
   })
 })
 

--- a/apps/server/__tests__/shop-e2e.test.ts
+++ b/apps/server/__tests__/shop-e2e.test.ts
@@ -94,6 +94,16 @@ async function json<T = unknown>(res: Response): Promise<T> {
   return res.json() as Promise<T>
 }
 
+function orderBody(input: {
+  items: Array<{ productId: string; skuId?: string; quantity: number }>
+  buyerNote?: string
+}) {
+  return {
+    idempotencyKey: `shop-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    ...input,
+  }
+}
+
 /* ── Setup & Teardown ── */
 
 beforeAll(async () => {
@@ -684,10 +694,10 @@ describe('Order — creation & payment', () => {
 
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerToken,
-      body: {
+      body: orderBody({
         items: [{ productId: productId1, skuId: skuId1, quantity: 2 }],
         buyerNote: '请尽快发货',
-      },
+      }),
     })
     expect(res.status).toBe(201)
     const order = await json<{
@@ -717,7 +727,7 @@ describe('Order — creation & payment', () => {
   it('create order for entitlement product', async () => {
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerToken,
-      body: { items: [{ productId: productId2, quantity: 1 }] },
+      body: orderBody({ items: [{ productId: productId2, quantity: 1 }] }),
     })
     expect(res.status).toBe(201)
     const order = await json<{ id: string; status: string; totalAmount: number }>(res)
@@ -767,7 +777,7 @@ describe('Order — creation & payment', () => {
 
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerToken,
-      body: { items: [{ productId: expensiveProduct.id, quantity: 1 }] },
+      body: orderBody({ items: [{ productId: expensiveProduct.id, quantity: 1 }] }),
     })
     expect(res.status).toBe(402)
 
@@ -880,7 +890,7 @@ describe('Order status management', () => {
     await container.resolve('walletService').topUp(buyerUserId, 500, 'Test balance seed')
     const createRes = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerToken,
-      body: { items: [{ productId: productId1, skuId: skuId1, quantity: 1 }] },
+      body: orderBody({ items: [{ productId: productId1, skuId: skuId1, quantity: 1 }] }),
     })
     expect(createRes.status).toBe(201)
     const created = await json<{ id: string; status: string }>(createRes)
@@ -914,7 +924,7 @@ describe('Order cancellation & refund', () => {
 
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerToken,
-      body: { items: [{ productId: productId1, skuId: skuId2, quantity: 1 }] },
+      body: orderBody({ items: [{ productId: productId1, skuId: skuId2, quantity: 1 }] }),
     })
     expect(res.status).toBe(201)
     const order = await json<{ id: string; status: string; totalAmount: number }>(res)
@@ -956,7 +966,7 @@ describe('Order cancellation & refund', () => {
     await container.resolve('walletService').topUp(buyerUserId, 500, 'Test balance seed')
     const createRes = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerToken,
-      body: { items: [{ productId: productId1, skuId: skuId1, quantity: 1 }] },
+      body: orderBody({ items: [{ productId: productId1, skuId: skuId1, quantity: 1 }] }),
     })
     const newOrder = await json<{ id: string }>(createRes)
 
@@ -1170,7 +1180,7 @@ describe('Edge cases & validation', () => {
   it('empty order items rejected', async () => {
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerToken,
-      body: { items: [] },
+      body: orderBody({ items: [] }),
     })
     expect(res.status).toBe(400)
   })
@@ -1178,7 +1188,9 @@ describe('Edge cases & validation', () => {
   it('order with non-existent product fails', async () => {
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerToken,
-      body: { items: [{ productId: '00000000-0000-0000-0000-000000000000', quantity: 1 }] },
+      body: orderBody({
+        items: [{ productId: '00000000-0000-0000-0000-000000000000', quantity: 1 }],
+      }),
     })
     expect(res.status).toBeGreaterThanOrEqual(400)
   })

--- a/apps/server/__tests__/shop-multiuser-e2e.test.ts
+++ b/apps/server/__tests__/shop-multiuser-e2e.test.ts
@@ -105,6 +105,16 @@ async function json<T = unknown>(res: Response): Promise<T> {
   return res.json() as Promise<T>
 }
 
+function orderBody(input: {
+  items: Array<{ productId: string; skuId?: string; quantity: number }>
+  buyerNote?: string
+}) {
+  return {
+    idempotencyKey: `shop-multiuser-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    ...input,
+  }
+}
+
 /* ── Setup & Teardown ── */
 
 beforeAll(async () => {
@@ -750,13 +760,13 @@ describe('7. Order creation — multi-user purchases', () => {
 
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerAToken,
-      body: {
+      body: orderBody({
         items: [
           { productId: prodPhoneId, skuId: phoneSku128Id, quantity: 1 },
           { productId: prodBundleId, skuId: bundleSkuId, quantity: 1 },
         ],
         buyerNote: '请包装好，容易碎',
-      },
+      }),
     })
     expect(res.status).toBe(201)
     const order = await json<{
@@ -793,13 +803,13 @@ describe('7. Order creation — multi-user purchases', () => {
 
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerBToken,
-      body: {
+      body: orderBody({
         items: [
           { productId: prodPhoneId, skuId: phoneSku256Id, quantity: 1 },
           { productId: prodCaseId, skuId: caseSku, quantity: 2 },
         ],
         buyerNote: '急用',
-      },
+      }),
     })
     expect(res.status).toBe(201)
     const order = await json<{ id: string; totalAmount: number; status: string }>(res)
@@ -822,7 +832,7 @@ describe('7. Order creation — multi-user purchases', () => {
   it('buyer A places entitlement order (VIP)', async () => {
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerAToken,
-      body: { items: [{ productId: prodVipId, skuId: vipSkuId, quantity: 1 }] },
+      body: orderBody({ items: [{ productId: prodVipId, skuId: vipSkuId, quantity: 1 }] }),
     })
     expect(res.status).toBe(201)
     const order = await json<{ id: string; totalAmount: number; status: string }>(res)
@@ -862,7 +872,7 @@ describe('7. Order creation — multi-user purchases', () => {
   it('buyer A fails to buy more limited cases than stock', async () => {
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerAToken,
-      body: { items: [{ productId: prodCaseId, skuId: caseSku, quantity: 2 }] },
+      body: orderBody({ items: [{ productId: prodCaseId, skuId: caseSku, quantity: 2 }] }),
     })
     expect(res.status).toBe(400) // Only 1 left in stock
   })
@@ -870,7 +880,7 @@ describe('7. Order creation — multi-user purchases', () => {
   it('buyer A can still buy 1 remaining case', async () => {
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerAToken,
-      body: { items: [{ productId: prodCaseId, skuId: caseSku, quantity: 1 }] },
+      body: orderBody({ items: [{ productId: prodCaseId, skuId: caseSku, quantity: 1 }] }),
     })
     expect(res.status).toBe(201)
     const order = await json<{ totalAmount: number }>(res)
@@ -887,7 +897,7 @@ describe('7. Order creation — multi-user purchases', () => {
 
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerBToken,
-      body: { items: [{ productId: expProduct.id, quantity: 1 }] },
+      body: orderBody({ items: [{ productId: expProduct.id, quantity: 1 }] }),
     })
     expect(res.status).toBe(402)
 
@@ -1160,7 +1170,7 @@ describe('11. Order cancellation & refund', () => {
 
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerBToken,
-      body: { items: [{ productId: prodBundleId, skuId: bundleSkuId, quantity: 1 }] },
+      body: orderBody({ items: [{ productId: prodBundleId, skuId: bundleSkuId, quantity: 1 }] }),
     })
     expect(res.status).toBe(201)
     const order = await json<{ id: string; status: string; totalAmount: number }>(res)
@@ -1397,7 +1407,7 @@ describe('15. Edge cases & validation', () => {
   it('empty order rejected', async () => {
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerAToken,
-      body: { items: [] },
+      body: orderBody({ items: [] }),
     })
     expect(res.status).toBe(400)
   })
@@ -1405,7 +1415,9 @@ describe('15. Edge cases & validation', () => {
   it('order with non-existent product fails', async () => {
     const res = await req('POST', `/api/servers/${serverId}/shop/orders`, {
       token: buyerAToken,
-      body: { items: [{ productId: '00000000-0000-0000-0000-000000000000', quantity: 1 }] },
+      body: orderBody({
+        items: [{ productId: '00000000-0000-0000-0000-000000000000', quantity: 1 }],
+      }),
     })
     expect(res.status).toBeGreaterThanOrEqual(400)
   })

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -15,6 +15,7 @@ import { createCloudSaasHandler } from './handlers/cloud-saas.handler'
 import { createConfigHandler } from './handlers/config.handler'
 import { createDiscoverHandler } from './handlers/discover.handler'
 import { createDmHandler } from './handlers/dm.handler'
+import { createEconomyHandler } from './handlers/economy.handler'
 import { createFeatureFlagsHandler } from './handlers/feature-flags.handler'
 import { createFriendshipHandler } from './handlers/friendship.handler'
 import { createInviteHandler } from './handlers/invite.handler'
@@ -209,6 +210,7 @@ export function createApp(container: AppContainer) {
   app.route('/api/admin', createAdminHandler(container))
   app.route('/api', createTaskCenterHandler(container))
   app.route('/api', createShopHandler(container))
+  app.route('/api/economy', createEconomyHandler(container))
   app.route('/api', createRentalHandler(container))
   app.route('/api/profile-comments', createProfileCommentHandler(container))
   app.route('/api/voice', createVoiceEnhanceHandler(container))

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -58,8 +58,12 @@ import { CommerceCardService } from './services/commerce-card.service'
 import { CommerceCheckoutService } from './services/commerce-checkout.service'
 import { CommerceFulfillmentService } from './services/commerce-fulfillment.service'
 import { CommerceOfferService } from './services/commerce-offer.service'
+import { CommunityAssetService } from './services/community-asset.service'
 import { DiyCloudRunService } from './services/diy-cloud-run.service'
 import { DmService } from './services/dm.service'
+import { EconomyAuditService } from './services/economy-audit.service'
+import { EconomyIdempotencyService } from './services/economy-idempotency.service'
+import { EconomyPolicyService } from './services/economy-policy.service'
 import { EntitlementService } from './services/entitlement.service'
 import { EntitlementAccessService } from './services/entitlement-access.service'
 import { EntitlementCancellationService } from './services/entitlement-cancellation.service'
@@ -68,6 +72,7 @@ import { EntitlementPurchaseService } from './services/entitlement-purchase.serv
 import { EntitlementRenewalService } from './services/entitlement-renewal.service'
 import { ExternalOAuthService } from './services/external-oauth.service'
 import { FriendshipService } from './services/friendship.service'
+import { GiftService } from './services/gift.service'
 import { LedgerService } from './services/ledger.service'
 import { MediaService } from './services/media.service'
 import { MembershipService } from './services/membership.service'
@@ -91,9 +96,11 @@ import { RentalService } from './services/rental.service'
 import { ReviewService } from './services/review.service'
 import { SearchService } from './services/search.service'
 import { ServerService } from './services/server.service'
+import { SettlementService } from './services/settlement.service'
 import { ShopService } from './services/shop.service'
 import { ShopScopeService } from './services/shop-scope.service'
 import { TaskCenterService } from './services/task-center.service'
+import { TipService } from './services/tip.service'
 import { VoiceEnhanceService } from './services/voice-enhance.service'
 import { WalletService } from './services/wallet.service'
 import { WorkspaceService } from './services/workspace.service'
@@ -188,6 +195,13 @@ export interface Cradle {
   commerceCheckoutService: CommerceCheckoutService
   commerceOfferService: CommerceOfferService
   commerceFulfillmentService: CommerceFulfillmentService
+  communityAssetService: CommunityAssetService
+  economyAuditService: EconomyAuditService
+  economyIdempotencyService: EconomyIdempotencyService
+  economyPolicyService: EconomyPolicyService
+  giftService: GiftService
+  settlementService: SettlementService
+  tipService: TipService
   permissionService: PermissionService
   policyService: PolicyService
   dmService: DmService
@@ -316,6 +330,13 @@ export function createAppContainer(db: Database): AppContainer {
     commerceCheckoutService: asClass(CommerceCheckoutService).singleton(),
     commerceOfferService: asClass(CommerceOfferService).singleton(),
     commerceFulfillmentService: asClass(CommerceFulfillmentService).singleton(),
+    communityAssetService: asClass(CommunityAssetService).singleton(),
+    economyAuditService: asClass(EconomyAuditService).singleton(),
+    economyIdempotencyService: asClass(EconomyIdempotencyService).singleton(),
+    economyPolicyService: asClass(EconomyPolicyService).singleton(),
+    giftService: asClass(GiftService).singleton(),
+    settlementService: asClass(SettlementService).singleton(),
+    tipService: asClass(TipService).singleton(),
     permissionService: asClass(PermissionService).singleton(),
     policyService: asClass(PolicyService).singleton(),
     dmService: asClass(DmService).singleton(),

--- a/apps/server/src/dao/entitlement.dao.ts
+++ b/apps/server/src/dao/entitlement.dao.ts
@@ -2,6 +2,8 @@ import { and, desc, eq, inArray, lte, sql } from 'drizzle-orm'
 import type { Database } from '../db'
 import { commerceOffers, entitlements, products, shops, users, workspaceNodes } from '../db/schema'
 
+type DbLike = Database | Parameters<Parameters<Database['transaction']>[0]>[0]
+
 export class EntitlementDao {
   constructor(private deps: { db: Database }) {}
   private get db() {
@@ -278,8 +280,9 @@ export class EntitlementDao {
       revocationReason: string | null
       metadata: Record<string, unknown>
     }>,
+    db: DbLike = this.db,
   ) {
-    const r = await this.db
+    const r = await db
       .update(entitlements)
       .set({ ...data, updatedAt: new Date() })
       .where(eq(entitlements.id, id))

--- a/apps/server/src/dao/product.dao.ts
+++ b/apps/server/src/dao/product.dao.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ilike, sql } from 'drizzle-orm'
+import { and, desc, eq, ilike, notInArray, sql } from 'drizzle-orm'
 import type { Database } from '../db'
 import { productMedia, products, skus } from '../db/schema'
 
@@ -123,7 +123,10 @@ export class ProductDao {
   }
 
   async delete(id: string) {
-    await this.db.delete(products).where(eq(products.id, id))
+    await this.db
+      .update(products)
+      .set({ status: 'archived', updatedAt: new Date() })
+      .where(eq(products.id, id))
   }
 }
 
@@ -187,6 +190,7 @@ export class SkuDao {
     stock?: number
     imageUrl?: string
     skuCode?: string
+    isActive?: boolean
   }) {
     const r = await this.db.insert(skus).values(data).returning()
     return r[0] ?? null
@@ -222,5 +226,14 @@ export class SkuDao {
 
   async deleteByProductId(productId: string) {
     await this.db.delete(skus).where(eq(skus.productId, productId))
+  }
+
+  async deactivateMissing(productId: string, activeIds: string[]) {
+    const filters = [eq(skus.productId, productId)]
+    if (activeIds.length > 0) filters.push(notInArray(skus.id, activeIds))
+    await this.db
+      .update(skus)
+      .set({ isActive: false, updatedAt: new Date() })
+      .where(and(...filters))
   }
 }

--- a/apps/server/src/dao/wallet.dao.ts
+++ b/apps/server/src/dao/wallet.dao.ts
@@ -44,46 +44,6 @@ export class WalletDao {
     return wallet!
   }
 
-  async updateBalance(id: string, balance: number) {
-    const r = await this.db
-      .update(wallets)
-      .set({ balance, updatedAt: new Date() })
-      .where(eq(wallets.id, id))
-      .returning()
-    return r[0] ?? null
-  }
-
-  async debit(id: string, amount: number) {
-    const r = await this.db
-      .update(wallets)
-      .set({ balance: sql`${wallets.balance} - ${amount}`, updatedAt: new Date() })
-      .where(and(eq(wallets.id, id), sql`${wallets.balance} >= ${amount}`))
-      .returning()
-    return r[0] ?? null
-  }
-
-  async credit(id: string, amount: number) {
-    const r = await this.db
-      .update(wallets)
-      .set({ balance: sql`${wallets.balance} + ${amount}`, updatedAt: new Date() })
-      .where(eq(wallets.id, id))
-      .returning()
-    return r[0] ?? null
-  }
-
-  async addTransaction(data: {
-    walletId: string
-    type: 'topup' | 'purchase' | 'refund' | 'reward' | 'transfer' | 'adjustment' | 'settlement'
-    amount: number
-    balanceAfter: number
-    referenceId?: string
-    referenceType?: string
-    note?: string
-  }) {
-    const r = await this.db.insert(walletTransactions).values(data).returning()
-    return r[0] ?? null
-  }
-
   async getTransactions(
     walletId: string,
     limit = 50,

--- a/apps/server/src/db/migrations/0058_community_economy_foundation.sql
+++ b/apps/server/src/db/migrations/0058_community_economy_foundation.sql
@@ -1,0 +1,140 @@
+-- Community economy phase 1: audit, provider event idempotency, risk cases, and fulfillment records.
+
+DO $$ BEGIN
+  CREATE TYPE "user_economy_status" AS ENUM ('normal', 'economy_restricted', 'frozen', 'banned');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "economy_status" "user_economy_status" DEFAULT 'normal' NOT NULL;
+
+ALTER TYPE "commerce_deliverable_kind" ADD VALUE IF NOT EXISTS 'entitlement';
+ALTER TYPE "commerce_deliverable_kind" ADD VALUE IF NOT EXISTS 'community_asset';
+ALTER TYPE "commerce_deliverable_kind" ADD VALUE IF NOT EXISTS 'currency';
+
+DO $$ BEGIN
+  CREATE TYPE "economy_audit_result" AS ENUM ('started', 'succeeded', 'failed', 'denied');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "payment_provider_event_status" AS ENUM (
+    'received',
+    'processing',
+    'processed',
+    'failed',
+    'ignored'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "risk_case_kind" AS ENUM (
+    'payment_dispute',
+    'chargeback',
+    'economy_restricted',
+    'fraud_signal'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "risk_case_status" AS ENUM ('open', 'reviewing', 'resolved', 'dismissed');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "commerce_fulfillment_record_status" AS ENUM ('succeeded', 'failed', 'skipped');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "economy_audit_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "actor_kind" varchar(40) NOT NULL,
+  "actor_id" text,
+  "actor_token_kind" varchar(40),
+  "action" varchar(120) NOT NULL,
+  "resource_kind" varchar(80) NOT NULL,
+  "resource_id" text,
+  "scope_kind" varchar(80),
+  "scope_id" text,
+  "idempotency_key" varchar(200),
+  "request_hash" varchar(128),
+  "result" "economy_audit_result" NOT NULL,
+  "error_code" varchar(120),
+  "ip_hash" varchar(128),
+  "user_agent_hash" varchar(128),
+  "metadata" jsonb DEFAULT '{}'::jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "economy_audit_events_actor_idx"
+  ON "economy_audit_events" ("actor_kind", "actor_id");
+CREATE INDEX IF NOT EXISTS "economy_audit_events_action_idx"
+  ON "economy_audit_events" ("action");
+CREATE INDEX IF NOT EXISTS "economy_audit_events_resource_idx"
+  ON "economy_audit_events" ("resource_kind", "resource_id");
+CREATE INDEX IF NOT EXISTS "economy_audit_events_created_at_idx"
+  ON "economy_audit_events" ("created_at");
+
+CREATE TABLE IF NOT EXISTS "payment_provider_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "provider" varchar(40) NOT NULL,
+  "provider_event_id" varchar(255) NOT NULL,
+  "event_type" varchar(120) NOT NULL,
+  "payload_hash" varchar(128) NOT NULL,
+  "payment_order_id" uuid REFERENCES "payment_orders"("id") ON DELETE set null,
+  "status" "payment_provider_event_status" DEFAULT 'received' NOT NULL,
+  "processed_at" timestamp with time zone,
+  "error_code" varchar(120),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "payment_provider_events_unique" UNIQUE ("provider", "provider_event_id")
+);
+CREATE INDEX IF NOT EXISTS "payment_provider_events_order_idx"
+  ON "payment_provider_events" ("payment_order_id");
+CREATE INDEX IF NOT EXISTS "payment_provider_events_status_idx"
+  ON "payment_provider_events" ("status");
+
+CREATE TABLE IF NOT EXISTS "risk_cases" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid REFERENCES "users"("id") ON DELETE set null,
+  "resource_type" varchar(80) NOT NULL,
+  "resource_id" text,
+  "kind" "risk_case_kind" NOT NULL,
+  "status" "risk_case_status" DEFAULT 'open' NOT NULL,
+  "severity" varchar(40) DEFAULT 'medium' NOT NULL,
+  "metadata" jsonb DEFAULT '{}'::jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "risk_cases_user_idx" ON "risk_cases" ("user_id");
+CREATE INDEX IF NOT EXISTS "risk_cases_kind_status_idx" ON "risk_cases" ("kind", "status");
+CREATE INDEX IF NOT EXISTS "risk_cases_resource_idx" ON "risk_cases" ("resource_type", "resource_id");
+
+CREATE TABLE IF NOT EXISTS "commerce_fulfillment_records" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "job_id" uuid REFERENCES "commerce_fulfillment_jobs"("id") ON DELETE set null,
+  "order_id" uuid REFERENCES "orders"("id") ON DELETE set null,
+  "order_item_id" uuid REFERENCES "order_items"("id") ON DELETE set null,
+  "deliverable_id" uuid REFERENCES "commerce_deliverables"("id") ON DELETE set null,
+  "recipient_user_id" uuid REFERENCES "users"("id") ON DELETE set null,
+  "idempotency_key" varchar(240) NOT NULL,
+  "result_type" varchar(80) NOT NULL,
+  "result_id" text,
+  "status" "commerce_fulfillment_record_status" DEFAULT 'succeeded' NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "commerce_fulfillment_records_unique_delivery"
+    UNIQUE ("order_item_id", "deliverable_id", "recipient_user_id"),
+  CONSTRAINT "commerce_fulfillment_records_idempotency_unique"
+    UNIQUE ("idempotency_key")
+);
+CREATE INDEX IF NOT EXISTS "commerce_fulfillment_records_job_idx"
+  ON "commerce_fulfillment_records" ("job_id");
+CREATE INDEX IF NOT EXISTS "commerce_fulfillment_records_order_idx"
+  ON "commerce_fulfillment_records" ("order_id");

--- a/apps/server/src/db/migrations/0059_community_assets_and_settlement.sql
+++ b/apps/server/src/db/migrations/0059_community_assets_and_settlement.sql
@@ -1,0 +1,232 @@
+-- Community economy phase 2: assets, tips, gifts, settlement, and destination-less fulfillment.
+
+ALTER TABLE "commerce_fulfillment_jobs"
+  ALTER COLUMN "destination_kind" DROP NOT NULL,
+  ALTER COLUMN "destination_id" DROP NOT NULL;
+
+DO $$ BEGIN
+  CREATE TYPE "community_asset_issuer_kind" AS ENUM ('platform', 'server', 'user', 'shop');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "community_asset_type" AS ENUM (
+    'badge',
+    'gift',
+    'coupon',
+    'service_ticket',
+    'collectible',
+    'content_pass',
+    'reward'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "community_asset_definition_status" AS ENUM ('draft', 'active', 'paused', 'archived');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "community_asset_grant_status" AS ENUM ('active', 'locked', 'consumed', 'revoked', 'expired');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "community_asset_transfer_action" AS ENUM ('grant', 'lock', 'gift', 'consume', 'revoke', 'expire', 'unlock');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "economy_tip_status" AS ENUM ('succeeded', 'failed', 'reversed', 'held');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "economy_gift_status" AS ENUM ('succeeded', 'failed', 'reversed', 'held');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "economy_gift_item_kind" AS ENUM ('currency', 'asset');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "settlement_owner_kind" AS ENUM ('user', 'shop', 'platform');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "settlement_line_status" AS ENUM (
+    'pending',
+    'available',
+    'settled',
+    'failed',
+    'held',
+    'reversed'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "community_asset_definitions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "issuer_kind" "community_asset_issuer_kind" NOT NULL,
+  "issuer_id" text,
+  "shop_id" uuid REFERENCES "shops"("id") ON DELETE set null,
+  "asset_type" "community_asset_type" NOT NULL,
+  "name" varchar(160) NOT NULL,
+  "description" text,
+  "image_url" text,
+  "metadata" jsonb DEFAULT '{}'::jsonb,
+  "giftable" boolean DEFAULT false NOT NULL,
+  "transferable" boolean DEFAULT false NOT NULL,
+  "consumable" boolean DEFAULT false NOT NULL,
+  "revocable" boolean DEFAULT true NOT NULL,
+  "expires_after_days" integer,
+  "status" "community_asset_definition_status" DEFAULT 'draft' NOT NULL,
+  "created_by" uuid REFERENCES "users"("id") ON DELETE set null,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "community_asset_definitions_shop_idx"
+  ON "community_asset_definitions" ("shop_id");
+CREATE INDEX IF NOT EXISTS "community_asset_definitions_issuer_idx"
+  ON "community_asset_definitions" ("issuer_kind", "issuer_id");
+CREATE INDEX IF NOT EXISTS "community_asset_definitions_status_idx"
+  ON "community_asset_definitions" ("status");
+
+CREATE TABLE IF NOT EXISTS "community_asset_grants" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "definition_id" uuid NOT NULL REFERENCES "community_asset_definitions"("id") ON DELETE cascade,
+  "owner_user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE cascade,
+  "source_kind" varchar(80) NOT NULL,
+  "source_id" text,
+  "quantity" integer DEFAULT 1 NOT NULL,
+  "remaining_quantity" integer DEFAULT 1 NOT NULL,
+  "status" "community_asset_grant_status" DEFAULT 'active' NOT NULL,
+  "expires_at" timestamp with time zone,
+  "metadata" jsonb DEFAULT '{}'::jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "community_asset_grants_remaining_nonnegative" CHECK ("remaining_quantity" >= 0)
+);
+CREATE INDEX IF NOT EXISTS "community_asset_grants_definition_idx"
+  ON "community_asset_grants" ("definition_id");
+CREATE INDEX IF NOT EXISTS "community_asset_grants_owner_status_idx"
+  ON "community_asset_grants" ("owner_user_id", "status");
+
+CREATE TABLE IF NOT EXISTS "community_asset_transfer_logs" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "definition_id" uuid REFERENCES "community_asset_definitions"("id") ON DELETE set null,
+  "grant_id" uuid REFERENCES "community_asset_grants"("id") ON DELETE set null,
+  "from_user_id" uuid REFERENCES "users"("id") ON DELETE set null,
+  "to_user_id" uuid REFERENCES "users"("id") ON DELETE set null,
+  "quantity" integer DEFAULT 1 NOT NULL,
+  "action" "community_asset_transfer_action" NOT NULL,
+  "reference_type" varchar(80),
+  "reference_id" text,
+  "idempotency_key" varchar(240) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "community_asset_transfer_logs_idempotency_unique" UNIQUE ("idempotency_key")
+);
+CREATE INDEX IF NOT EXISTS "community_asset_transfer_logs_grant_idx"
+  ON "community_asset_transfer_logs" ("grant_id");
+CREATE INDEX IF NOT EXISTS "community_asset_transfer_logs_definition_idx"
+  ON "community_asset_transfer_logs" ("definition_id");
+
+CREATE TABLE IF NOT EXISTS "economy_tips" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "sender_user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE cascade,
+  "recipient_user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE cascade,
+  "amount" integer NOT NULL,
+  "currency_code" varchar(40) DEFAULT 'shrimp_coin' NOT NULL,
+  "context_kind" varchar(80),
+  "context_id" text,
+  "message" text,
+  "platform_fee" integer DEFAULT 0 NOT NULL,
+  "seller_net" integer DEFAULT 0 NOT NULL,
+  "status" "economy_tip_status" DEFAULT 'succeeded' NOT NULL,
+  "idempotency_key" varchar(200) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "economy_tips_sender_idempotency_unique" UNIQUE ("sender_user_id", "idempotency_key")
+);
+CREATE INDEX IF NOT EXISTS "economy_tips_recipient_idx"
+  ON "economy_tips" ("recipient_user_id");
+CREATE INDEX IF NOT EXISTS "economy_tips_context_idx"
+  ON "economy_tips" ("context_kind", "context_id");
+
+CREATE TABLE IF NOT EXISTS "economy_gifts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "sender_user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE cascade,
+  "recipient_user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE cascade,
+  "message" text,
+  "status" "economy_gift_status" DEFAULT 'succeeded' NOT NULL,
+  "idempotency_key" varchar(200) NOT NULL,
+  "metadata" jsonb DEFAULT '{}'::jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "economy_gifts_sender_idempotency_unique" UNIQUE ("sender_user_id", "idempotency_key")
+);
+CREATE INDEX IF NOT EXISTS "economy_gifts_recipient_idx"
+  ON "economy_gifts" ("recipient_user_id");
+
+CREATE TABLE IF NOT EXISTS "economy_gift_items" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "gift_id" uuid NOT NULL REFERENCES "economy_gifts"("id") ON DELETE cascade,
+  "item_kind" "economy_gift_item_kind" NOT NULL,
+  "asset_grant_id" uuid REFERENCES "community_asset_grants"("id") ON DELETE set null,
+  "asset_definition_id" uuid REFERENCES "community_asset_definitions"("id") ON DELETE set null,
+  "quantity" integer DEFAULT 1 NOT NULL,
+  "currency_code" varchar(40),
+  "amount" integer,
+  "status" "economy_gift_status" DEFAULT 'succeeded' NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "economy_gift_items_gift_idx"
+  ON "economy_gift_items" ("gift_id");
+
+CREATE TABLE IF NOT EXISTS "settlement_accounts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "owner_kind" "settlement_owner_kind" NOT NULL,
+  "owner_id" text NOT NULL,
+  "currency_code" varchar(40) DEFAULT 'shrimp_coin' NOT NULL,
+  "available_balance" integer DEFAULT 0 NOT NULL,
+  "pending_balance" integer DEFAULT 0 NOT NULL,
+  "held_balance" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "settlement_accounts_owner_unique" UNIQUE ("owner_kind", "owner_id", "currency_code")
+);
+
+CREATE TABLE IF NOT EXISTS "settlement_lines" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "seller_user_id" uuid REFERENCES "users"("id") ON DELETE set null,
+  "shop_id" uuid REFERENCES "shops"("id") ON DELETE set null,
+  "source_type" varchar(80) NOT NULL,
+  "source_id" text NOT NULL,
+  "gross_amount" integer NOT NULL,
+  "platform_fee" integer DEFAULT 0 NOT NULL,
+  "refund_amount" integer DEFAULT 0 NOT NULL,
+  "held_amount" integer DEFAULT 0 NOT NULL,
+  "net_amount" integer NOT NULL,
+  "status" "settlement_line_status" DEFAULT 'pending' NOT NULL,
+  "available_at" timestamp with time zone,
+  "settled_at" timestamp with time zone,
+  "error_code" varchar(120),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "settlement_lines_seller_status_idx"
+  ON "settlement_lines" ("seller_user_id", "status");
+CREATE INDEX IF NOT EXISTS "settlement_lines_source_idx"
+  ON "settlement_lines" ("source_type", "source_id");

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -407,6 +407,20 @@
       "when": 1778504400000,
       "tag": "0057_private_server_join_requests",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1778590800000,
+      "tag": "0058_community_economy_foundation",
+      "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1778677200000,
+      "tag": "0059_community_assets_and_settlement",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/economy.ts
+++ b/apps/server/src/db/schema/economy.ts
@@ -1,0 +1,458 @@
+import {
+  boolean,
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core'
+import { paymentOrders } from './recharge'
+import { commerceDeliverables, commerceFulfillmentJobs, orderItems, orders, shops } from './shops'
+import { users } from './users'
+
+export const economyAuditResultEnum = pgEnum('economy_audit_result', [
+  'started',
+  'succeeded',
+  'failed',
+  'denied',
+])
+
+export const paymentProviderEventStatusEnum = pgEnum('payment_provider_event_status', [
+  'received',
+  'processing',
+  'processed',
+  'failed',
+  'ignored',
+])
+
+export const riskCaseKindEnum = pgEnum('risk_case_kind', [
+  'payment_dispute',
+  'chargeback',
+  'economy_restricted',
+  'fraud_signal',
+])
+
+export const riskCaseStatusEnum = pgEnum('risk_case_status', [
+  'open',
+  'reviewing',
+  'resolved',
+  'dismissed',
+])
+
+export const commerceFulfillmentRecordStatusEnum = pgEnum('commerce_fulfillment_record_status', [
+  'succeeded',
+  'failed',
+  'skipped',
+])
+
+export const communityAssetIssuerKindEnum = pgEnum('community_asset_issuer_kind', [
+  'platform',
+  'server',
+  'user',
+  'shop',
+])
+
+export const communityAssetTypeEnum = pgEnum('community_asset_type', [
+  'badge',
+  'gift',
+  'coupon',
+  'service_ticket',
+  'collectible',
+  'content_pass',
+  'reward',
+])
+
+export const communityAssetDefinitionStatusEnum = pgEnum('community_asset_definition_status', [
+  'draft',
+  'active',
+  'paused',
+  'archived',
+])
+
+export const communityAssetGrantStatusEnum = pgEnum('community_asset_grant_status', [
+  'active',
+  'locked',
+  'consumed',
+  'revoked',
+  'expired',
+])
+
+export const communityAssetTransferActionEnum = pgEnum('community_asset_transfer_action', [
+  'grant',
+  'lock',
+  'gift',
+  'consume',
+  'revoke',
+  'expire',
+  'unlock',
+])
+
+export const economyTipStatusEnum = pgEnum('economy_tip_status', [
+  'succeeded',
+  'failed',
+  'reversed',
+  'held',
+])
+
+export const economyGiftStatusEnum = pgEnum('economy_gift_status', [
+  'succeeded',
+  'failed',
+  'reversed',
+  'held',
+])
+
+export const economyGiftItemKindEnum = pgEnum('economy_gift_item_kind', ['currency', 'asset'])
+
+export const settlementOwnerKindEnum = pgEnum('settlement_owner_kind', ['user', 'shop', 'platform'])
+
+export const settlementLineStatusEnum = pgEnum('settlement_line_status', [
+  'pending',
+  'available',
+  'settled',
+  'failed',
+  'held',
+  'reversed',
+])
+
+export const economyAuditEvents = pgTable(
+  'economy_audit_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    actorKind: varchar('actor_kind', { length: 40 }).notNull(),
+    actorId: text('actor_id'),
+    actorTokenKind: varchar('actor_token_kind', { length: 40 }),
+    action: varchar('action', { length: 120 }).notNull(),
+    resourceKind: varchar('resource_kind', { length: 80 }).notNull(),
+    resourceId: text('resource_id'),
+    scopeKind: varchar('scope_kind', { length: 80 }),
+    scopeId: text('scope_id'),
+    idempotencyKey: varchar('idempotency_key', { length: 200 }),
+    requestHash: varchar('request_hash', { length: 128 }),
+    result: economyAuditResultEnum('result').notNull(),
+    errorCode: varchar('error_code', { length: 120 }),
+    ipHash: varchar('ip_hash', { length: 128 }),
+    userAgentHash: varchar('user_agent_hash', { length: 128 }),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    economyAuditEventsActorIdx: index('economy_audit_events_actor_idx').on(t.actorKind, t.actorId),
+    economyAuditEventsActionIdx: index('economy_audit_events_action_idx').on(t.action),
+    economyAuditEventsResourceIdx: index('economy_audit_events_resource_idx').on(
+      t.resourceKind,
+      t.resourceId,
+    ),
+    economyAuditEventsCreatedAtIdx: index('economy_audit_events_created_at_idx').on(t.createdAt),
+  }),
+)
+
+export const paymentProviderEvents = pgTable(
+  'payment_provider_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    provider: varchar('provider', { length: 40 }).notNull(),
+    providerEventId: varchar('provider_event_id', { length: 255 }).notNull(),
+    eventType: varchar('event_type', { length: 120 }).notNull(),
+    payloadHash: varchar('payload_hash', { length: 128 }).notNull(),
+    paymentOrderId: uuid('payment_order_id').references(() => paymentOrders.id, {
+      onDelete: 'set null',
+    }),
+    status: paymentProviderEventStatusEnum('status').default('received').notNull(),
+    processedAt: timestamp('processed_at', { withTimezone: true }),
+    errorCode: varchar('error_code', { length: 120 }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    paymentProviderEventsUnique: unique('payment_provider_events_unique').on(
+      t.provider,
+      t.providerEventId,
+    ),
+    paymentProviderEventsOrderIdx: index('payment_provider_events_order_idx').on(t.paymentOrderId),
+    paymentProviderEventsStatusIdx: index('payment_provider_events_status_idx').on(t.status),
+  }),
+)
+
+export const riskCases = pgTable(
+  'risk_cases',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id').references(() => users.id, { onDelete: 'set null' }),
+    resourceType: varchar('resource_type', { length: 80 }).notNull(),
+    resourceId: text('resource_id'),
+    kind: riskCaseKindEnum('kind').notNull(),
+    status: riskCaseStatusEnum('status').default('open').notNull(),
+    severity: varchar('severity', { length: 40 }).default('medium').notNull(),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    riskCasesUserIdx: index('risk_cases_user_idx').on(t.userId),
+    riskCasesKindStatusIdx: index('risk_cases_kind_status_idx').on(t.kind, t.status),
+    riskCasesResourceIdx: index('risk_cases_resource_idx').on(t.resourceType, t.resourceId),
+  }),
+)
+
+export const commerceFulfillmentRecords = pgTable(
+  'commerce_fulfillment_records',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    jobId: uuid('job_id').references(() => commerceFulfillmentJobs.id, { onDelete: 'set null' }),
+    orderId: uuid('order_id').references(() => orders.id, { onDelete: 'set null' }),
+    orderItemId: uuid('order_item_id').references(() => orderItems.id, { onDelete: 'set null' }),
+    deliverableId: uuid('deliverable_id').references(() => commerceDeliverables.id, {
+      onDelete: 'set null',
+    }),
+    recipientUserId: uuid('recipient_user_id').references(() => users.id, { onDelete: 'set null' }),
+    idempotencyKey: varchar('idempotency_key', { length: 240 }).notNull(),
+    resultType: varchar('result_type', { length: 80 }).notNull(),
+    resultId: text('result_id'),
+    status: commerceFulfillmentRecordStatusEnum('status').default('succeeded').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    commerceFulfillmentRecordsUniqueDelivery: unique(
+      'commerce_fulfillment_records_unique_delivery',
+    ).on(t.orderItemId, t.deliverableId, t.recipientUserId),
+    commerceFulfillmentRecordsIdempotencyUnique: unique(
+      'commerce_fulfillment_records_idempotency_unique',
+    ).on(t.idempotencyKey),
+    commerceFulfillmentRecordsJobIdx: index('commerce_fulfillment_records_job_idx').on(t.jobId),
+    commerceFulfillmentRecordsOrderIdx: index('commerce_fulfillment_records_order_idx').on(
+      t.orderId,
+    ),
+  }),
+)
+
+export const communityAssetDefinitions = pgTable(
+  'community_asset_definitions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    issuerKind: communityAssetIssuerKindEnum('issuer_kind').notNull(),
+    issuerId: text('issuer_id'),
+    shopId: uuid('shop_id').references(() => shops.id, { onDelete: 'set null' }),
+    assetType: communityAssetTypeEnum('asset_type').notNull(),
+    name: varchar('name', { length: 160 }).notNull(),
+    description: text('description'),
+    imageUrl: text('image_url'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}),
+    giftable: boolean('giftable').default(false).notNull(),
+    transferable: boolean('transferable').default(false).notNull(),
+    consumable: boolean('consumable').default(false).notNull(),
+    revocable: boolean('revocable').default(true).notNull(),
+    expiresAfterDays: integer('expires_after_days'),
+    status: communityAssetDefinitionStatusEnum('status').default('draft').notNull(),
+    createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    communityAssetDefinitionsShopIdx: index('community_asset_definitions_shop_idx').on(t.shopId),
+    communityAssetDefinitionsIssuerIdx: index('community_asset_definitions_issuer_idx').on(
+      t.issuerKind,
+      t.issuerId,
+    ),
+    communityAssetDefinitionsStatusIdx: index('community_asset_definitions_status_idx').on(
+      t.status,
+    ),
+  }),
+)
+
+export const communityAssetGrants = pgTable(
+  'community_asset_grants',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    definitionId: uuid('definition_id')
+      .notNull()
+      .references(() => communityAssetDefinitions.id, { onDelete: 'cascade' }),
+    ownerUserId: uuid('owner_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    sourceKind: varchar('source_kind', { length: 80 }).notNull(),
+    sourceId: text('source_id'),
+    quantity: integer('quantity').default(1).notNull(),
+    remainingQuantity: integer('remaining_quantity').default(1).notNull(),
+    status: communityAssetGrantStatusEnum('status').default('active').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    communityAssetGrantsDefinitionIdx: index('community_asset_grants_definition_idx').on(
+      t.definitionId,
+    ),
+    communityAssetGrantsOwnerStatusIdx: index('community_asset_grants_owner_status_idx').on(
+      t.ownerUserId,
+      t.status,
+    ),
+  }),
+)
+
+export const communityAssetTransferLogs = pgTable(
+  'community_asset_transfer_logs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    definitionId: uuid('definition_id').references(() => communityAssetDefinitions.id, {
+      onDelete: 'set null',
+    }),
+    grantId: uuid('grant_id').references(() => communityAssetGrants.id, { onDelete: 'set null' }),
+    fromUserId: uuid('from_user_id').references(() => users.id, { onDelete: 'set null' }),
+    toUserId: uuid('to_user_id').references(() => users.id, { onDelete: 'set null' }),
+    quantity: integer('quantity').default(1).notNull(),
+    action: communityAssetTransferActionEnum('action').notNull(),
+    referenceType: varchar('reference_type', { length: 80 }),
+    referenceId: text('reference_id'),
+    idempotencyKey: varchar('idempotency_key', { length: 240 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    communityAssetTransferLogsGrantIdx: index('community_asset_transfer_logs_grant_idx').on(
+      t.grantId,
+    ),
+    communityAssetTransferLogsDefinitionIdx: index(
+      'community_asset_transfer_logs_definition_idx',
+    ).on(t.definitionId),
+    communityAssetTransferLogsIdempotencyUnique: unique(
+      'community_asset_transfer_logs_idempotency_unique',
+    ).on(t.idempotencyKey),
+  }),
+)
+
+export const economyTips = pgTable(
+  'economy_tips',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    senderUserId: uuid('sender_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    recipientUserId: uuid('recipient_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    amount: integer('amount').notNull(),
+    currencyCode: varchar('currency_code', { length: 40 }).default('shrimp_coin').notNull(),
+    contextKind: varchar('context_kind', { length: 80 }),
+    contextId: text('context_id'),
+    message: text('message'),
+    platformFee: integer('platform_fee').default(0).notNull(),
+    sellerNet: integer('seller_net').default(0).notNull(),
+    status: economyTipStatusEnum('status').default('succeeded').notNull(),
+    idempotencyKey: varchar('idempotency_key', { length: 200 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    economyTipsSenderIdempotencyUnique: unique('economy_tips_sender_idempotency_unique').on(
+      t.senderUserId,
+      t.idempotencyKey,
+    ),
+    economyTipsRecipientIdx: index('economy_tips_recipient_idx').on(t.recipientUserId),
+    economyTipsContextIdx: index('economy_tips_context_idx').on(t.contextKind, t.contextId),
+  }),
+)
+
+export const economyGifts = pgTable(
+  'economy_gifts',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    senderUserId: uuid('sender_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    recipientUserId: uuid('recipient_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    message: text('message'),
+    status: economyGiftStatusEnum('status').default('succeeded').notNull(),
+    idempotencyKey: varchar('idempotency_key', { length: 200 }).notNull(),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    economyGiftsSenderIdempotencyUnique: unique('economy_gifts_sender_idempotency_unique').on(
+      t.senderUserId,
+      t.idempotencyKey,
+    ),
+    economyGiftsRecipientIdx: index('economy_gifts_recipient_idx').on(t.recipientUserId),
+  }),
+)
+
+export const economyGiftItems = pgTable(
+  'economy_gift_items',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    giftId: uuid('gift_id')
+      .notNull()
+      .references(() => economyGifts.id, { onDelete: 'cascade' }),
+    itemKind: economyGiftItemKindEnum('item_kind').notNull(),
+    assetGrantId: uuid('asset_grant_id').references(() => communityAssetGrants.id, {
+      onDelete: 'set null',
+    }),
+    assetDefinitionId: uuid('asset_definition_id').references(() => communityAssetDefinitions.id, {
+      onDelete: 'set null',
+    }),
+    quantity: integer('quantity').default(1).notNull(),
+    currencyCode: varchar('currency_code', { length: 40 }),
+    amount: integer('amount'),
+    status: economyGiftStatusEnum('status').default('succeeded').notNull(),
+  },
+  (t) => ({
+    economyGiftItemsGiftIdx: index('economy_gift_items_gift_idx').on(t.giftId),
+  }),
+)
+
+export const settlementAccounts = pgTable(
+  'settlement_accounts',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    ownerKind: settlementOwnerKindEnum('owner_kind').notNull(),
+    ownerId: text('owner_id').notNull(),
+    currencyCode: varchar('currency_code', { length: 40 }).default('shrimp_coin').notNull(),
+    availableBalance: integer('available_balance').default(0).notNull(),
+    pendingBalance: integer('pending_balance').default(0).notNull(),
+    heldBalance: integer('held_balance').default(0).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    settlementAccountsOwnerUnique: unique('settlement_accounts_owner_unique').on(
+      t.ownerKind,
+      t.ownerId,
+      t.currencyCode,
+    ),
+  }),
+)
+
+export const settlementLines = pgTable(
+  'settlement_lines',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    sellerUserId: uuid('seller_user_id').references(() => users.id, { onDelete: 'set null' }),
+    shopId: uuid('shop_id').references(() => shops.id, { onDelete: 'set null' }),
+    sourceType: varchar('source_type', { length: 80 }).notNull(),
+    sourceId: text('source_id').notNull(),
+    grossAmount: integer('gross_amount').notNull(),
+    platformFee: integer('platform_fee').default(0).notNull(),
+    refundAmount: integer('refund_amount').default(0).notNull(),
+    heldAmount: integer('held_amount').default(0).notNull(),
+    netAmount: integer('net_amount').notNull(),
+    status: settlementLineStatusEnum('status').default('pending').notNull(),
+    availableAt: timestamp('available_at', { withTimezone: true }),
+    settledAt: timestamp('settled_at', { withTimezone: true }),
+    errorCode: varchar('error_code', { length: 120 }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    settlementLinesSellerStatusIdx: index('settlement_lines_seller_status_idx').on(
+      t.sellerUserId,
+      t.status,
+    ),
+    settlementLinesSourceIdx: index('settlement_lines_source_idx').on(t.sourceType, t.sourceId),
+  }),
+)

--- a/apps/server/src/db/schema/index.ts
+++ b/apps/server/src/db/schema/index.ts
@@ -35,6 +35,35 @@ export { dmAttachments } from './dm-attachments'
 export { dmChannels } from './dm-channels'
 export { dmMessages } from './dm-messages'
 export { dmReactions } from './dm-reactions'
+export {
+  commerceFulfillmentRecordStatusEnum,
+  commerceFulfillmentRecords,
+  communityAssetDefinitionStatusEnum,
+  communityAssetDefinitions,
+  communityAssetGrantStatusEnum,
+  communityAssetGrants,
+  communityAssetIssuerKindEnum,
+  communityAssetTransferActionEnum,
+  communityAssetTransferLogs,
+  communityAssetTypeEnum,
+  economyAuditEvents,
+  economyAuditResultEnum,
+  economyGiftItemKindEnum,
+  economyGiftItems,
+  economyGiftStatusEnum,
+  economyGifts,
+  economyTipStatusEnum,
+  economyTips,
+  paymentProviderEventStatusEnum,
+  paymentProviderEvents,
+  riskCaseKindEnum,
+  riskCaseStatusEnum,
+  riskCases,
+  settlementAccounts,
+  settlementLineStatusEnum,
+  settlementLines,
+  settlementOwnerKindEnum,
+} from './economy'
 export { friendshipStatusEnum, friendships } from './friendships'
 export { inviteCodes } from './invite-codes'
 export { memberRoleEnum, members } from './members'
@@ -124,5 +153,5 @@ export {
 } from './shops'
 export { userRewardLogs, userTaskClaims } from './task-center'
 export { threads } from './threads'
-export { userStatusEnum, users } from './users'
+export { userEconomyStatusEnum, userStatusEnum, users } from './users'
 export { workspaceNodeKindEnum, workspaceNodes, workspaces } from './workspaces'

--- a/apps/server/src/db/schema/shops.ts
+++ b/apps/server/src/db/schema/shops.ts
@@ -81,6 +81,9 @@ export const commerceOfferStatusEnum = pgEnum('commerce_offer_status', [
 ])
 
 export const commerceDeliverableKindEnum = pgEnum('commerce_deliverable_kind', [
+  'entitlement',
+  'community_asset',
+  'currency',
   'paid_file',
   'message',
   'external',
@@ -620,8 +623,8 @@ export const commerceFulfillmentJobs = pgTable(
     buyerId: uuid('buyer_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
-    destinationKind: commerceFulfillmentDestinationKindEnum('destination_kind').notNull(),
-    destinationId: text('destination_id').notNull(),
+    destinationKind: commerceFulfillmentDestinationKindEnum('destination_kind'),
+    destinationId: text('destination_id'),
     senderBuddyUserId: uuid('sender_buddy_user_id').references(() => users.id, {
       onDelete: 'set null',
     }),

--- a/apps/server/src/db/schema/users.ts
+++ b/apps/server/src/db/schema/users.ts
@@ -1,6 +1,12 @@
 import { boolean, pgEnum, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core'
 
 export const userStatusEnum = pgEnum('user_status', ['online', 'idle', 'dnd', 'offline'])
+export const userEconomyStatusEnum = pgEnum('user_economy_status', [
+  'normal',
+  'economy_restricted',
+  'frozen',
+  'banned',
+])
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -10,6 +16,7 @@ export const users = pgTable('users', {
   avatarUrl: text('avatar_url'),
   passwordHash: text('password_hash').notNull(),
   status: userStatusEnum('status').default('offline').notNull(),
+  economyStatus: userEconomyStatusEnum('economy_status').default('normal').notNull(),
   isBot: boolean('is_bot').default(false).notNull(),
   isAdmin: boolean('is_admin').default(false).notNull(),
   oauthAppId: uuid('oauth_app_id'),

--- a/apps/server/src/handlers/dm.handler.ts
+++ b/apps/server/src/handlers/dm.handler.ts
@@ -6,6 +6,7 @@ import type { AppContainer } from '../container'
 import { relayDmToBot } from '../lib/dm-relay'
 import { logger } from '../lib/logger'
 import { authMiddleware } from '../middleware/auth.middleware'
+import { sendMessageSchema } from '../validators/message.schema'
 
 export function createDmHandler(container: AppContainer) {
   const dmHandler = new Hono()
@@ -60,97 +61,76 @@ export function createDmHandler(container: AppContainer) {
   })
 
   // POST /api/dm/channels/:id/messages
-  dmHandler.post(
-    '/channels/:id/messages',
-    zValidator(
-      'json',
-      z.object({
-        content: z.string().min(1).max(LIMITS.MESSAGE_CONTENT_MAX),
-        replyToId: z.string().uuid().optional(),
-        metadata: z.record(z.unknown()).optional(),
-        attachments: z
-          .array(
-            z.object({
-              filename: z.string(),
-              url: z.string(),
-              contentType: z.string(),
-              size: z.number(),
-            }),
-          )
-          .optional(),
-      }),
-    ),
-    async (c) => {
-      const dmService = container.resolve('dmService')
-      const id = c.req.param('id')
-      const { content, replyToId, attachments, metadata } = c.req.valid('json')
-      const user = c.get('user')
+  dmHandler.post('/channels/:id/messages', zValidator('json', sendMessageSchema), async (c) => {
+    const dmService = container.resolve('dmService')
+    const id = c.req.param('id')
+    const { content, replyToId, attachments, metadata } = c.req.valid('json')
+    const user = c.get('user')
 
-      // Verify participant
-      const isParticipant = await dmService.isParticipant(id, user.userId)
-      if (!isParticipant) {
-        return c.json({ ok: false, error: 'Not a participant of this DM channel' }, 403)
-      }
-      const commerceCardService = container.resolve('commerceCardService')
-      const normalizedMetadata = await commerceCardService.inferMessageMetadata({
-        metadata,
-        target: { kind: 'dm', dmChannelId: id },
-        authorId: user.userId,
-        content,
-      })
+    // Verify participant
+    const isParticipant = await dmService.isParticipant(id, user.userId)
+    if (!isParticipant) {
+      return c.json({ ok: false, error: 'Not a participant of this DM channel' }, 403)
+    }
+    const commerceCardService = container.resolve('commerceCardService')
+    const normalizedMetadata = await commerceCardService.inferMessageMetadata({
+      metadata,
+      target: { kind: 'dm', dmChannelId: id },
+      authorId: user.userId,
+      content,
+    })
 
-      const message = await dmService.sendMessage(
-        id,
-        user.userId,
-        content,
-        replyToId,
-        attachments,
-        normalizedMetadata,
-      )
+    const message = await dmService.sendMessage(
+      id,
+      user.userId,
+      content,
+      replyToId,
+      attachments,
+      normalizedMetadata,
+    )
 
-      // Broadcast to DM room via WebSocket
-      const io = container.resolve('io')
-      io.to(`dm:${id}`).emit('dm:message', message)
+    // Broadcast to DM room via WebSocket
+    const io = container.resolve('io')
+    io.to(`dm:${id}`).emit('dm:message', message)
 
-      // Relay to bot user if recipient is a bot (for AI processing)
-      try {
-        const channel = await dmService.getChannelById(id)
-        if (channel) {
-          const otherUserId = channel.userAId === user.userId ? channel.userBId : channel.userAId
-          const notificationTriggerService = container.resolve('notificationTriggerService')
-          const senderName = message.author?.displayName ?? message.author?.username ?? 'Someone'
-          await notificationTriggerService.triggerDm({
-            userId: otherUserId,
-            actorId: user.userId,
-            actorName: senderName,
-            dmChannelId: id,
-            preview: content.substring(0, 200),
-          })
+    // Relay to bot user if recipient is a bot (for AI processing)
+    try {
+      const channel = await dmService.getChannelById(id)
+      if (channel) {
+        const otherUserId = channel.userAId === user.userId ? channel.userBId : channel.userAId
+        const notificationTriggerService = container.resolve('notificationTriggerService')
+        const senderName = message.author?.displayName ?? message.author?.username ?? 'Someone'
+        await notificationTriggerService.triggerDm({
+          userId: otherUserId,
+          actorId: user.userId,
+          actorName: senderName,
+          dmChannelId: id,
+          preview: content.substring(0, 200),
+        })
 
-          await relayDmToBot(io, container, id, user.userId, otherUserId, {
-            id: message.id!,
-            content: message.content!,
-            author: message.author,
-            createdAt: message.createdAt,
-            replyToId: message.replyToId,
-            attachments: message.attachments,
-          })
+        await relayDmToBot(io, container, id, user.userId, otherUserId, {
+          id: message.id!,
+          content: message.content!,
+          author: message.author,
+          createdAt: message.createdAt,
+          replyToId: message.replyToId,
+          attachments: message.attachments,
+        })
 
-          // Record rental message for billing (fire-and-forget)
-          try {
-            const rentalService = container.resolve('rentalService')
-            await rentalService.recordRentalMessage(user.userId, otherUserId)
-          } catch {
-            /* non-critical */
-          }
+        // Record rental message for billing (fire-and-forget)
+        try {
+          const rentalService = container.resolve('rentalService')
+          await rentalService.recordRentalMessage(user.userId, otherUserId)
+        } catch {
+          /* non-critical */
         }
-      } catch (err) {
-        logger.error({ err, dmChannelId: id }, 'REST: Bot DM relay failed')
       }
+    } catch (err) {
+      logger.error({ err, dmChannelId: id }, 'REST: Bot DM relay failed')
+    }
 
-      return c.json(message, 201)
-    },
-  )
+    return c.json(message, 201)
+  })
 
   // PATCH /api/dm/channels/:channelId/messages/:messageId — edit a DM message
   dmHandler.patch(

--- a/apps/server/src/handlers/economy.handler.ts
+++ b/apps/server/src/handlers/economy.handler.ts
@@ -1,0 +1,201 @@
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import type { AppContainer } from '../container'
+import { apiError } from '../lib/api-error'
+import { authMiddleware } from '../middleware/auth.middleware'
+
+const idempotencyKeySchema = z.string().min(8).max(200)
+
+const tipSchema = z.object({
+  recipientUserId: z.string().uuid(),
+  amount: z.number().int().positive().max(100_000_000),
+  message: z.string().max(1000).optional(),
+  context: z
+    .object({
+      kind: z.string().min(1).max(80),
+      id: z.string().min(1).max(160),
+    })
+    .optional(),
+  idempotencyKey: idempotencyKeySchema,
+})
+
+const giftSchema = z.object({
+  recipientUserId: z.string().uuid(),
+  assets: z
+    .array(
+      z.object({
+        assetGrantId: z.string().uuid(),
+        quantity: z.number().int().positive().max(1000).optional(),
+      }),
+    )
+    .max(20)
+    .optional(),
+  currencies: z
+    .array(
+      z.object({
+        currencyCode: z.literal('shrimp_coin'),
+        amount: z.number().int().positive().max(100_000_000),
+      }),
+    )
+    .max(5)
+    .optional(),
+  message: z.string().max(1000).optional(),
+  idempotencyKey: idempotencyKeySchema,
+})
+
+const consumeAssetSchema = z.object({
+  idempotencyKey: idempotencyKeySchema,
+})
+
+const assetLifecycleSchema = z.object({
+  idempotencyKey: idempotencyKeySchema,
+  reason: z.string().max(300).optional(),
+})
+
+export function createEconomyHandler(container: AppContainer) {
+  const h = new Hono()
+  h.use('*', authMiddleware)
+
+  h.get('/assets', async (c) => {
+    const user = c.get('user')
+    const communityAssetService = container.resolve('communityAssetService')
+    return c.json({ assets: await communityAssetService.listUserAssets(user.userId) })
+  })
+
+  h.get('/assets/:grantId', async (c) => {
+    const user = c.get('user')
+    const communityAssetService = container.resolve('communityAssetService')
+    const row = await communityAssetService.getGrant(c.req.param('grantId'))
+    if (!row) throw apiError('COMMUNITY_ASSET_GRANT_NOT_FOUND', 404)
+    if (row.grant.ownerUserId !== user.userId) {
+      throw apiError('COMMUNITY_ASSET_OWNER_MISMATCH', 403)
+    }
+    return c.json(row)
+  })
+
+  h.post('/assets/:grantId/consume', zValidator('json', consumeAssetSchema), async (c) => {
+    const user = c.get('user')
+    const communityAssetService = container.resolve('communityAssetService')
+    const input = c.req.valid('json')
+    return c.json({
+      grant: await communityAssetService.consume({
+        actorUserId: user.userId,
+        grantId: c.req.param('grantId'),
+        idempotencyKey: input.idempotencyKey,
+        actor: c.get('actor'),
+      }),
+    })
+  })
+
+  h.post('/assets/:grantId/lock', zValidator('json', assetLifecycleSchema), async (c) => {
+    const user = c.get('user')
+    const communityAssetService = container.resolve('communityAssetService')
+    const input = c.req.valid('json')
+    return c.json({
+      grant: await communityAssetService.lockGrant({
+        actorUserId: user.userId,
+        grantId: c.req.param('grantId'),
+        idempotencyKey: input.idempotencyKey,
+        actor: c.get('actor'),
+      }),
+    })
+  })
+
+  h.post('/assets/:grantId/unlock', zValidator('json', assetLifecycleSchema), async (c) => {
+    const user = c.get('user')
+    const communityAssetService = container.resolve('communityAssetService')
+    const input = c.req.valid('json')
+    return c.json({
+      grant: await communityAssetService.unlockGrant({
+        actorUserId: user.userId,
+        grantId: c.req.param('grantId'),
+        idempotencyKey: input.idempotencyKey,
+        actor: c.get('actor'),
+      }),
+    })
+  })
+
+  h.post('/assets/:grantId/revoke', zValidator('json', assetLifecycleSchema), async (c) => {
+    const user = c.get('user')
+    const communityAssetService = container.resolve('communityAssetService')
+    const input = c.req.valid('json')
+    return c.json({
+      grant: await communityAssetService.revokeGrant({
+        actorUserId: user.userId,
+        grantId: c.req.param('grantId'),
+        idempotencyKey: input.idempotencyKey,
+        reason: input.reason,
+        actor: c.get('actor'),
+      }),
+    })
+  })
+
+  h.post('/tips', zValidator('json', tipSchema), async (c) => {
+    const user = c.get('user')
+    const tipService = container.resolve('tipService')
+    const input = c.req.valid('json')
+    return c.json(
+      await tipService.sendTip({
+        senderUserId: user.userId,
+        recipientUserId: input.recipientUserId,
+        amount: input.amount,
+        message: input.message,
+        context: input.context,
+        idempotencyKey: input.idempotencyKey,
+        actor: c.get('actor'),
+      }),
+      201,
+    )
+  })
+
+  h.get('/tips', async (c) => {
+    const user = c.get('user')
+    const tipService = container.resolve('tipService')
+    return c.json({ tips: await tipService.listForUser(user.userId) })
+  })
+
+  h.post('/gifts', zValidator('json', giftSchema), async (c) => {
+    const user = c.get('user')
+    const giftService = container.resolve('giftService')
+    const input = c.req.valid('json')
+    return c.json(
+      await giftService.sendGift({
+        senderUserId: user.userId,
+        recipientUserId: input.recipientUserId,
+        assets: input.assets,
+        currencies: input.currencies,
+        message: input.message,
+        idempotencyKey: input.idempotencyKey,
+        actor: c.get('actor'),
+      }),
+      201,
+    )
+  })
+
+  h.get('/gifts', async (c) => {
+    const user = c.get('user')
+    const giftService = container.resolve('giftService')
+    return c.json({ gifts: await giftService.listForUser(user.userId) })
+  })
+
+  h.get('/settlements', async (c) => {
+    const user = c.get('user')
+    const settlementService = container.resolve('settlementService')
+    return c.json({
+      settlements: await settlementService.listForUser(
+        user.userId,
+        Number(c.req.query('limit')) || 50,
+        Number(c.req.query('offset')) || 0,
+      ),
+    })
+  })
+
+  h.post('/settlements/settle', async (c) => {
+    const user = c.get('user')
+    const settlementService = container.resolve('settlementService')
+    return c.json({ settlements: await settlementService.settleAvailableForUser(user.userId) })
+  })
+
+  return h
+}

--- a/apps/server/src/handlers/message.handler.ts
+++ b/apps/server/src/handlers/message.handler.ts
@@ -544,11 +544,18 @@ export function createMessageHandler(container: AppContainer) {
       user.userId,
       input,
     )
+    const commerceCardService = container.resolve('commerceCardService')
+    const normalizedMetadata = await commerceCardService.inferMessageMetadata({
+      metadata: preparedInput.metadata as Record<string, unknown> | undefined,
+      target: { kind: 'channel', channelId: thread.channelId },
+      authorId: user.userId,
+      content: preparedInput.content,
+    })
     const message = await messageService.sendToThread(id, user.userId, {
       content: preparedInput.content,
       replyToId: preparedInput.replyToId,
       mentions: preparedInput.mentions,
-      metadata: preparedInput.metadata,
+      metadata: normalizedMetadata,
     })
     const messageId = message.id
     const messageContent = message.content ?? preparedInput.content

--- a/apps/server/src/handlers/paid-file.handler.ts
+++ b/apps/server/src/handlers/paid-file.handler.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { getCookie, setCookie } from 'hono/cookie'
 import { lookup } from 'mime-types'
 import type { AppContainer } from '../container'
 import { authMiddleware } from '../middleware/auth.middleware'
@@ -19,7 +20,18 @@ export function createPaidFileHandler(container: AppContainer) {
     const fileId = c.req.param('fileId')
     if (!fileId) return c.json({ ok: false, error: 'PAID_FILE_NOT_FOUND' }, 404)
     const paidFileService = container.resolve('paidFileService')
-    return c.json(await paidFileService.openPaidFile(user.userId, fileId), 201)
+    const opened = await paidFileService.openPaidFile(user.userId, fileId)
+    setCookie(c, paidFileGrantCookie(opened.grant.id), opened.grantToken, {
+      httpOnly: true,
+      sameSite: 'Lax',
+      secure: c.req.url.startsWith('https://'),
+      path: `/api/paid-files/${fileId}/view/${opened.grant.id}`,
+      maxAge: Math.max(
+        1,
+        Math.floor((new Date(opened.grant.expiresAt).getTime() - Date.now()) / 1000),
+      ),
+    })
+    return c.json(opened, 201)
   })
 
   h.get('/paid-files/:fileId/view/:grantId', async (c) => {
@@ -30,7 +42,10 @@ export function createPaidFileHandler(container: AppContainer) {
     const result = await paidFileService.readGrantFile({
       fileId,
       grantId,
-      token: c.req.query('token'),
+      token:
+        c.req.header('x-paid-file-grant-token') ??
+        getCookie(c, paidFileGrantCookie(grantId)) ??
+        c.req.query('token'),
     })
     const contentType = result.file.mime || lookup(result.file.name) || 'application/octet-stream'
     const headers: Record<string, string> = {
@@ -55,4 +70,8 @@ export function createPaidFileHandler(container: AppContainer) {
   })
 
   return h
+}
+
+function paidFileGrantCookie(grantId: string) {
+  return `shadow_paid_file_grant_${grantId.replaceAll('-', '_')}`
 }

--- a/apps/server/src/handlers/recharge.handler.ts
+++ b/apps/server/src/handlers/recharge.handler.ts
@@ -7,7 +7,8 @@ import { authMiddleware } from '../middleware/auth.middleware'
 const createIntentSchema = z.object({
   tier: z.enum(['1000', '3000', '5000', 'custom']),
   customAmount: z.number().int().optional(),
-  currency: z.string().default('usd'),
+  currency: z.string().length(3).optional(),
+  idempotencyKey: z.string().min(8).max(200),
 })
 
 export function createRechargeHandler(container: AppContainer) {
@@ -23,13 +24,15 @@ export function createRechargeHandler(container: AppContainer) {
   /** POST /api/v1/recharge/create-intent — Create Stripe PaymentIntent */
   h.post('/create-intent', zValidator('json', createIntentSchema), async (c) => {
     const user = c.get('user')
-    const { tier, customAmount, currency } = c.req.valid('json')
+    const { tier, customAmount, currency, idempotencyKey } = c.req.valid('json')
     const rechargeService = container.resolve('rechargeService')
     const result = await rechargeService.createPaymentIntent(
       user.userId,
       tier,
       customAmount,
       currency,
+      c.get('actor'),
+      idempotencyKey,
     )
     return c.json(result, 201)
   })

--- a/apps/server/src/handlers/shop.handler.ts
+++ b/apps/server/src/handlers/shop.handler.ts
@@ -56,13 +56,44 @@ const createOfferSchema = z.object({
 })
 
 const createDeliverableSchema = z.object({
-  kind: z.enum(['paid_file', 'message', 'external']).optional(),
+  kind: z
+    .enum(['paid_file', 'message', 'external', 'entitlement', 'community_asset', 'currency'])
+    .optional(),
   resourceType: z.string().min(1).max(80).optional(),
   resourceId: z.string().min(1),
   senderBuddyUserId: z.string().uuid().nullable().optional(),
   messageTemplateKey: z.string().max(120).nullable().optional(),
   metadata: z.record(z.unknown()).optional(),
 })
+
+const createAssetDefinitionSchema = z.object({
+  assetType: z.enum([
+    'badge',
+    'gift',
+    'coupon',
+    'service_ticket',
+    'collectible',
+    'content_pass',
+    'reward',
+  ]),
+  name: z.string().min(1).max(120),
+  description: z.string().max(2000).nullable().optional(),
+  imageUrl: z.string().url().nullable().optional(),
+  giftable: z.boolean().optional(),
+  transferable: z.boolean().optional(),
+  consumable: z.boolean().optional(),
+  revocable: z.boolean().optional(),
+  expiresAfterDays: z.number().int().min(1).max(3650).nullable().optional(),
+  status: z.enum(['draft', 'active', 'paused']).optional(),
+  metadata: z.record(z.unknown()).optional(),
+})
+
+const updateAssetDefinitionSchema = createAssetDefinitionSchema
+  .omit({ assetType: true })
+  .partial()
+  .extend({
+    status: z.enum(['draft', 'active', 'paused', 'archived']).optional(),
+  })
 
 const createPersonalShopSchema = z.object({
   name: z.string().min(1).max(100).optional(),
@@ -215,6 +246,45 @@ export function createShopHandler(container: AppContainer) {
     })
   })
 
+  h.get('/shops/:shopId/assets', async (c) => {
+    const user = c.get('user')
+    const shopScopeService = container.resolve('shopScopeService')
+    const communityAssetService = container.resolve('communityAssetService')
+    await shopScopeService.requireShopManager(c.req.param('shopId'), user.userId)
+    return c.json({
+      assets: await communityAssetService.listDefinitionsForShop(c.req.param('shopId')),
+    })
+  })
+
+  h.post('/shops/:shopId/assets', zValidator('json', createAssetDefinitionSchema), async (c) => {
+    const user = c.get('user')
+    const shopScopeService = container.resolve('shopScopeService')
+    const communityAssetService = container.resolve('communityAssetService')
+    const shop = await shopScopeService.requireShopManager(c.req.param('shopId'), user.userId)
+    const input = c.req.valid('json')
+    return c.json(
+      await communityAssetService.createDefinition({
+        actor: c.get('actor'),
+        createdBy: user.userId,
+        issuerKind: 'shop',
+        issuerId: shop.id,
+        shopId: shop.id,
+        assetType: input.assetType,
+        name: input.name,
+        description: input.description,
+        imageUrl: input.imageUrl,
+        giftable: input.giftable,
+        transferable: input.transferable,
+        consumable: input.consumable,
+        revocable: input.revocable,
+        expiresAfterDays: input.expiresAfterDays,
+        status: input.status,
+        metadata: input.metadata,
+      }),
+      201,
+    )
+  })
+
   h.get('/products/:productId', async (c) => {
     const user = c.get('user')
     return c.json(await requireProductVisible(c.req.param('productId'), user.userId))
@@ -265,6 +335,36 @@ export function createShopHandler(container: AppContainer) {
     await productService.deleteProduct(product.id)
     return c.json({ ok: true })
   })
+
+  h.patch(
+    '/shops/:shopId/assets/:assetDefinitionId',
+    zValidator('json', updateAssetDefinitionSchema),
+    async (c) => {
+      const user = c.get('user')
+      const shopScopeService = container.resolve('shopScopeService')
+      const communityAssetService = container.resolve('communityAssetService')
+      const shop = await shopScopeService.requireShopManager(c.req.param('shopId'), user.userId)
+      const input = c.req.valid('json')
+      return c.json(
+        await communityAssetService.updateDefinition({
+          actor: c.get('actor'),
+          definitionId: c.req.param('assetDefinitionId'),
+          shopId: shop.id,
+          updatedBy: user.userId,
+          name: input.name,
+          description: input.description,
+          imageUrl: input.imageUrl,
+          giftable: input.giftable,
+          transferable: input.transferable,
+          consumable: input.consumable,
+          revocable: input.revocable,
+          expiresAfterDays: input.expiresAfterDays,
+          status: input.status,
+          metadata: input.metadata,
+        }),
+      )
+    },
+  )
 
   h.get('/commerce/product-picker', zValidator('query', productPickerSchema), async (c) => {
     const user = c.get('user')
@@ -398,6 +498,7 @@ export function createShopHandler(container: AppContainer) {
           skuId: input.skuId,
           idempotencyKey: input.idempotencyKey,
           destination,
+          actor: c.get('actor'),
         }),
         201,
       )
@@ -445,6 +546,7 @@ export function createShopHandler(container: AppContainer) {
           productId: c.req.param('productId'),
           skuId: input.skuId,
           idempotencyKey: input.idempotencyKey,
+          actor: c.get('actor'),
         }),
         201,
       )
@@ -479,6 +581,7 @@ export function createShopHandler(container: AppContainer) {
           skuId: input.skuId,
           idempotencyKey: input.idempotencyKey,
           destination: { kind: 'channel', id: message.channelId },
+          actor: c.get('actor'),
         }),
         201,
       )
@@ -516,6 +619,7 @@ export function createShopHandler(container: AppContainer) {
           skuId: input.skuId,
           idempotencyKey: input.idempotencyKey,
           destination: { kind: 'dm', id: message.dmChannelId },
+          actor: c.get('actor'),
         }),
         201,
       )
@@ -630,6 +734,7 @@ export function createShopHandler(container: AppContainer) {
           actorUserId: user.userId,
           entitlementId: c.req.param('entitlementId'),
           reason: c.req.valid('json').reason,
+          actor: c.get('actor'),
         }),
       )
     },
@@ -646,6 +751,7 @@ export function createShopHandler(container: AppContainer) {
           actorUserId: user.userId,
           entitlementId: c.req.param('entitlementId'),
           reason: c.req.valid('json').reason ?? 'cancel_renewal',
+          actor: c.get('actor'),
         }),
       )
     },
@@ -704,8 +810,19 @@ export function createShopHandler(container: AppContainer) {
       if (input.approved) {
         const entitlementService = container.resolve('entitlementService')
         const ledgerService = container.resolve('ledgerService')
+        const economyPolicyService = container.resolve('economyPolicyService')
+        const economyAuditService = container.resolve('economyAuditService')
+        const settlementService = container.resolve('settlementService')
         const entitlement = await entitlementService.getEntitlement(request.entitlementId)
         if (input.refundAmount && input.refundAmount > 0) {
+          await economyPolicyService.authorize({
+            actor: c.get('actor'),
+            action: 'wallet.refund',
+            resource: { kind: 'entitlement', id: entitlement.id },
+            scope: { kind: 'wallet', id: entitlement.userId },
+            dataClass: 'financial',
+            targetUserId: entitlement.userId,
+          })
           await ledgerService.credit({
             userId: entitlement.userId,
             amount: input.refundAmount,
@@ -714,6 +831,22 @@ export function createShopHandler(container: AppContainer) {
             referenceType: 'order',
             note: '不可抗力裁定退款',
           })
+          await economyAuditService.record({
+            actor: c.get('actor'),
+            action: 'wallet.refund',
+            resource: { kind: 'entitlement', id: entitlement.id },
+            scope: { kind: 'wallet', id: entitlement.userId },
+            request: { forceMajeureRequestId: request.id, approved: input.approved },
+            result: 'succeeded',
+            metadata: { refundAmount: input.refundAmount, orderId: entitlement.orderId },
+          })
+          if (entitlement.orderId) {
+            await settlementService.reverseLinesForSource({
+              sourceType: 'order',
+              sourceId: entitlement.orderId,
+              reason: 'force_majeure_refund',
+            })
+          }
         }
         await entitlementService.revokeEntitlement(
           request.entitlementId,
@@ -945,7 +1078,14 @@ export function createShopHandler(container: AppContainer) {
     const orderService = container.resolve('orderService')
     const input = c.req.valid('json')
     return c.json(
-      await orderService.createOrder(user.userId, shop.id, input.items, input.buyerNote),
+      await orderService.createOrder(
+        user.userId,
+        shop.id,
+        input.items,
+        input.buyerNote,
+        input.idempotencyKey,
+        c.get('actor'),
+      ),
       201,
     )
   })

--- a/apps/server/src/handlers/stripe-webhook.handler.ts
+++ b/apps/server/src/handlers/stripe-webhook.handler.ts
@@ -40,6 +40,7 @@ export function createStripeWebhookHandler(container: AppContainer) {
       const rechargeService = container.resolve('rechargeService')
       await rechargeService.handleWebhookEvent(
         event as unknown as {
+          id?: string
           type: string
           data: { object: Record<string, unknown> }
         },

--- a/apps/server/src/lib/stripe.ts
+++ b/apps/server/src/lib/stripe.ts
@@ -10,6 +10,14 @@ export const stripe = process.env.STRIPE_SECRET_KEY
 
 export const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET ?? ''
 
+if (
+  process.env.NODE_ENV === 'production' &&
+  process.env.STRIPE_SECRET_KEY &&
+  !STRIPE_WEBHOOK_SECRET
+) {
+  throw new Error('STRIPE_WEBHOOK_SECRET must be set in production when Stripe is enabled')
+}
+
 /**
  * Recharge tier definitions.
  * Exchange rate: 1 USD = 100 shrimp coins.

--- a/apps/server/src/services/auth.service.test.ts
+++ b/apps/server/src/services/auth.service.test.ts
@@ -39,6 +39,7 @@ describe('AuthService', () => {
     isAdmin: false,
     isBot: false,
     status: 'online' as const,
+    economyStatus: 'normal' as const,
     oauthAppId: null,
     parentUserId: null,
     createdAt: new Date(),

--- a/apps/server/src/services/commerce-card.service.ts
+++ b/apps/server/src/services/commerce-card.service.ts
@@ -40,7 +40,26 @@ function normalizeMetadata(metadata?: Record<string, unknown>) {
   if (json.length > 24_000) {
     throw apiError('MESSAGE_METADATA_TOO_LARGE', 400, { maxBytes: 24_000 })
   }
-  return metadata
+  const allowedKeys = new Set([
+    'agentChain',
+    'interactive',
+    'interactiveResponse',
+    'mentions',
+    'commerceOfferId',
+    'commerceCards',
+    'paidFileCards',
+    'custom',
+  ])
+  const normalized: Record<string, unknown> = {}
+  const custom: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(metadata)) {
+    if (allowedKeys.has(key)) normalized[key] = value
+    else custom[key] = value
+  }
+  if (Object.keys(custom).length > 0) {
+    normalized.custom = { ...((normalized.custom as Record<string, unknown>) ?? {}), ...custom }
+  }
+  return normalized
 }
 
 export class CommerceCardService {

--- a/apps/server/src/services/commerce-fulfillment.service.ts
+++ b/apps/server/src/services/commerce-fulfillment.service.ts
@@ -1,11 +1,25 @@
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, inArray, sql } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
 import type { Server as SocketIOServer } from 'socket.io'
 import type { WorkspaceNodeDao } from '../dao/workspace-node.dao'
 import type { Database } from '../db'
-import { commerceDeliverables, commerceFulfillmentJobs } from '../db/schema'
+import {
+  commerceDeliverables,
+  commerceFulfillmentJobs,
+  commerceFulfillmentRecords,
+} from '../db/schema'
+import type { CommunityAssetService } from './community-asset.service'
 import type { DmService } from './dm.service'
+import type { LedgerService } from './ledger.service'
 import type { MessageService } from './message.service'
+
+type FulfillmentJob = typeof commerceFulfillmentJobs.$inferSelect
+type CommerceDeliverable = typeof commerceDeliverables.$inferSelect
+type FulfillmentResult = {
+  resultType: string
+  resultId: string | null
+  resultMessageId: string | null
+}
 
 function errorCode(err: unknown) {
   if (
@@ -24,12 +38,19 @@ function textFromMetadata(metadata: Record<string, unknown> | null, key: string)
   return typeof value === 'string' && value.trim() ? value.trim() : undefined
 }
 
+function positiveIntegerFromMetadata(metadata: Record<string, unknown>, key: string) {
+  const value = metadata[key]
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
+}
+
 export class CommerceFulfillmentService {
   constructor(
     private deps: {
       db: Database
       messageService: MessageService
       dmService: DmService
+      communityAssetService: CommunityAssetService
+      ledgerService: LedgerService
       workspaceNodeDao: WorkspaceNodeDao
       io?: SocketIOServer
     },
@@ -47,22 +68,181 @@ export class CommerceFulfillmentService {
     }
   }
 
+  private requireDestination(job: FulfillmentJob) {
+    if (!job.destinationKind || !job.destinationId) {
+      throw Object.assign(new Error('Destination required'), {
+        code: 'COMMERCE_FULFILLMENT_DESTINATION_REQUIRED',
+      })
+    }
+    return { kind: job.destinationKind, id: job.destinationId }
+  }
+
+  private async sendFulfillmentMessage(
+    job: FulfillmentJob,
+    senderId: string,
+    content: string,
+    metadata?: Record<string, unknown>,
+  ) {
+    const destination = this.requireDestination(job)
+    if (destination.kind === 'channel') {
+      const message = await this.deps.messageService.send(destination.id, senderId, {
+        content,
+        metadata,
+      })
+      this.emit(`channel:${destination.id}`, 'message:new', message)
+      return message.id
+    }
+
+    const message = await this.deps.dmService.sendMessage(
+      destination.id,
+      senderId,
+      content,
+      undefined,
+      undefined,
+      metadata,
+    )
+    this.emit(`dm:${destination.id}`, 'dm:message', message)
+    return message.id ?? null
+  }
+
+  private async fulfillPaidFileMessage(
+    job: FulfillmentJob,
+    deliverable: CommerceDeliverable,
+    metadata: Record<string, unknown>,
+    senderId: string,
+    content: string,
+  ): Promise<FulfillmentResult> {
+    const file = await this.deps.workspaceNodeDao.findById(deliverable.resourceId)
+    if (!file || file.kind !== 'file') {
+      throw Object.assign(new Error('Paid file unavailable'), {
+        code: 'PAID_FILE_NOT_FOUND',
+      })
+    }
+
+    const card = {
+      id: nanoid(12),
+      kind: 'paid_file' as const,
+      fileId: file.id,
+      entitlementId: job.entitlementId,
+      deliverableId: deliverable.id,
+      snapshot: {
+        name: file.name,
+        mime: file.mime,
+        sizeBytes: file.sizeBytes,
+        previewUrl: file.previewUrl,
+        summary: textFromMetadata(metadata, 'summary') ?? null,
+      },
+      action: { mode: 'open_paid_file' as const },
+    }
+    const resultMessageId = await this.sendFulfillmentMessage(job, senderId, content, {
+      paidFileCards: [card],
+      commerceFulfillment: { jobId: job.id, deliverableId: deliverable.id },
+    })
+    return { resultType: 'message', resultId: resultMessageId, resultMessageId }
+  }
+
+  private async fulfillTextMessage(
+    job: FulfillmentJob,
+    deliverable: CommerceDeliverable,
+    senderId: string,
+    content: string,
+  ): Promise<FulfillmentResult> {
+    const resultMessageId = await this.sendFulfillmentMessage(job, senderId, content, {
+      commerceFulfillment: { jobId: job.id, deliverableId: deliverable.id },
+    })
+    return { resultType: 'message', resultId: resultMessageId, resultMessageId }
+  }
+
+  private async fulfillCommunityAsset(
+    job: FulfillmentJob,
+    deliverable: CommerceDeliverable,
+    idempotencyKey: string,
+  ): Promise<FulfillmentResult> {
+    const grant = await this.deps.communityAssetService.grantToUser({
+      actor: {
+        kind: 'system',
+        service: 'commerce-fulfillment',
+        capabilities: ['economy:assets:write'],
+      },
+      ownerUserId: job.buyerId,
+      definitionId: deliverable.resourceId,
+      sourceKind: 'commerce_fulfillment',
+      sourceId: job.id,
+      idempotencyKey,
+      metadata: { offerDeliverableId: deliverable.id, orderId: job.orderId },
+    })
+    return { resultType: 'community_asset_grant', resultId: grant.id, resultMessageId: null }
+  }
+
+  private async fulfillCurrencyReward(
+    job: FulfillmentJob,
+    metadata: Record<string, unknown>,
+  ): Promise<FulfillmentResult> {
+    const amount = positiveIntegerFromMetadata(metadata, 'amount')
+    if (amount <= 0) {
+      throw Object.assign(new Error('Currency deliverable amount invalid'), {
+        code: 'COMMERCE_CURRENCY_DELIVERABLE_INVALID',
+      })
+    }
+    await this.deps.ledgerService.credit({
+      userId: job.buyerId,
+      amount,
+      type: 'reward',
+      referenceId: job.id,
+      referenceType: 'commerce_fulfillment',
+      note: '商品交付奖励',
+    })
+    return { resultType: 'currency', resultId: job.id, resultMessageId: null }
+  }
+
+  private async fulfillDeliverable(
+    job: FulfillmentJob,
+    deliverable: CommerceDeliverable,
+    idempotencyKey: string,
+  ): Promise<FulfillmentResult> {
+    const metadata = (deliverable.metadata ?? {}) as Record<string, unknown>
+    const senderId = job.senderBuddyUserId ?? deliverable.senderBuddyUserId ?? job.buyerId
+    const content = textFromMetadata(metadata, 'message') ?? '\u200B'
+
+    switch (deliverable.kind) {
+      case 'paid_file':
+        return this.fulfillPaidFileMessage(job, deliverable, metadata, senderId, content)
+      case 'message':
+      case 'external':
+        return this.fulfillTextMessage(job, deliverable, senderId, content)
+      case 'community_asset':
+        return this.fulfillCommunityAsset(job, deliverable, idempotencyKey)
+      case 'currency':
+        return this.fulfillCurrencyReward(job, metadata)
+      default:
+        return { resultType: 'entitlement', resultId: job.entitlementId, resultMessageId: null }
+    }
+  }
+
   async processJob(jobId: string) {
     const [job] = await this.db
-      .select()
-      .from(commerceFulfillmentJobs)
-      .where(eq(commerceFulfillmentJobs.id, jobId))
-      .limit(1)
-    if (!job || (job.status !== 'pending' && job.status !== 'failed')) return job ?? null
-
-    await this.db
       .update(commerceFulfillmentJobs)
       .set({
         status: 'sending',
         attempts: sql`${commerceFulfillmentJobs.attempts} + 1`,
         updatedAt: new Date(),
       })
-      .where(eq(commerceFulfillmentJobs.id, job.id))
+      .where(
+        and(
+          eq(commerceFulfillmentJobs.id, jobId),
+          inArray(commerceFulfillmentJobs.status, ['pending', 'failed']),
+        ),
+      )
+      .returning()
+
+    if (!job) {
+      const [current] = await this.db
+        .select()
+        .from(commerceFulfillmentJobs)
+        .where(eq(commerceFulfillmentJobs.id, jobId))
+        .limit(1)
+      return current ?? null
+    }
 
     try {
       const [deliverable] = job.deliverableId
@@ -78,86 +258,52 @@ export class CommerceFulfillmentService {
         })
       }
 
-      const metadata = (deliverable.metadata ?? {}) as Record<string, unknown>
-      const senderId = job.senderBuddyUserId ?? deliverable.senderBuddyUserId ?? job.buyerId
-      const content = textFromMetadata(metadata, 'message') ?? '\u200B'
-      let resultMessageId: string | null = null
-
-      if (deliverable.kind === 'paid_file') {
-        const file = await this.deps.workspaceNodeDao.findById(deliverable.resourceId)
-        if (!file || file.kind !== 'file') {
-          throw Object.assign(new Error('Paid file unavailable'), {
-            code: 'PAID_FILE_NOT_FOUND',
+      const fulfillmentIdempotencyKey = `${job.id}:${deliverable.id}:${job.buyerId}`
+      const [existingRecord] = await this.db
+        .select()
+        .from(commerceFulfillmentRecords)
+        .where(eq(commerceFulfillmentRecords.idempotencyKey, fulfillmentIdempotencyKey))
+        .limit(1)
+      if (existingRecord?.status === 'succeeded') {
+        const [updated] = await this.db
+          .update(commerceFulfillmentJobs)
+          .set({
+            status: 'sent',
+            resultMessageId:
+              existingRecord.resultType === 'message' ? existingRecord.resultId : null,
+            lastErrorCode: null,
+            updatedAt: new Date(),
           })
-        }
-        const card = {
-          id: nanoid(12),
-          kind: 'paid_file' as const,
-          fileId: file.id,
-          entitlementId: job.entitlementId,
-          deliverableId: deliverable.id,
-          snapshot: {
-            name: file.name,
-            mime: file.mime,
-            sizeBytes: file.sizeBytes,
-            previewUrl: file.previewUrl,
-            summary: textFromMetadata(metadata, 'summary') ?? null,
-          },
-          action: { mode: 'open_paid_file' as const },
-        }
-        const messageMetadata = {
-          paidFileCards: [card],
-          commerceFulfillment: { jobId: job.id, deliverableId: deliverable.id },
-        }
-
-        if (job.destinationKind === 'channel') {
-          const message = await this.deps.messageService.send(job.destinationId, senderId, {
-            content,
-            metadata: messageMetadata,
-          })
-          resultMessageId = message.id
-          this.emit(`channel:${job.destinationId}`, 'message:new', message)
-        } else {
-          const message = await this.deps.dmService.sendMessage(
-            job.destinationId,
-            senderId,
-            content,
-            undefined,
-            undefined,
-            messageMetadata,
-          )
-          resultMessageId = message.id ?? null
-          this.emit(`dm:${job.destinationId}`, 'dm:message', message)
-        }
-      } else {
-        if (job.destinationKind === 'channel') {
-          const message = await this.deps.messageService.send(job.destinationId, senderId, {
-            content,
-            metadata: { commerceFulfillment: { jobId: job.id, deliverableId: deliverable.id } },
-          })
-          resultMessageId = message.id
-          this.emit(`channel:${job.destinationId}`, 'message:new', message)
-        } else {
-          const message = await this.deps.dmService.sendMessage(
-            job.destinationId,
-            senderId,
-            content,
-          )
-          resultMessageId = message.id ?? null
-          this.emit(`dm:${job.destinationId}`, 'dm:message', message)
-        }
+          .where(eq(commerceFulfillmentJobs.id, job.id))
+          .returning()
+        return updated ?? null
       }
+
+      const fulfillment = await this.fulfillDeliverable(job, deliverable, fulfillmentIdempotencyKey)
 
       const [updated] = await this.db
         .update(commerceFulfillmentJobs)
         .set({
           status: 'sent',
-          resultMessageId,
+          resultMessageId: fulfillment.resultMessageId,
           lastErrorCode: null,
           updatedAt: new Date(),
         })
         .where(eq(commerceFulfillmentJobs.id, job.id))
         .returning()
+      await this.db
+        .insert(commerceFulfillmentRecords)
+        .values({
+          jobId: job.id,
+          orderId: job.orderId,
+          deliverableId: deliverable.id,
+          recipientUserId: job.buyerId,
+          idempotencyKey: fulfillmentIdempotencyKey,
+          resultType: fulfillment.resultType,
+          resultId: fulfillment.resultId,
+          status: 'succeeded',
+        })
+        .onConflictDoNothing()
       return updated ?? null
     } catch (err) {
       const [updated] = await this.db

--- a/apps/server/src/services/commerce-offer.service.ts
+++ b/apps/server/src/services/commerce-offer.service.ts
@@ -205,7 +205,7 @@ export class CommerceOfferService {
   async createDeliverable(input: {
     offerId: string
     productId?: string
-    kind?: 'paid_file' | 'message' | 'external'
+    kind?: 'paid_file' | 'message' | 'external' | 'entitlement' | 'community_asset' | 'currency'
     resourceType?: string
     resourceId: string
     senderBuddyUserId?: string | null

--- a/apps/server/src/services/community-asset.service.ts
+++ b/apps/server/src/services/community-asset.service.ts
@@ -1,0 +1,655 @@
+import { and, eq, inArray, lte, sql } from 'drizzle-orm'
+import type { Database } from '../db'
+import {
+  communityAssetDefinitions,
+  communityAssetGrants,
+  communityAssetTransferLogs,
+} from '../db/schema'
+import { apiError } from '../lib/api-error'
+import { type Actor, actorFromUserId } from '../security/actor'
+import type { EconomyAuditService } from './economy-audit.service'
+import type { EconomyPolicyService } from './economy-policy.service'
+
+type DbLike = Database | Parameters<Parameters<Database['transaction']>[0]>[0]
+type AssetDefinitionStatus = 'draft' | 'active' | 'paused' | 'archived'
+type AssetType =
+  | 'badge'
+  | 'gift'
+  | 'coupon'
+  | 'service_ticket'
+  | 'collectible'
+  | 'content_pass'
+  | 'reward'
+
+function addDays(days?: number | null) {
+  return days && days > 0 ? new Date(Date.now() + days * 86_400_000) : null
+}
+
+export class CommunityAssetService {
+  constructor(
+    private deps: {
+      db: Database
+      economyPolicyService: EconomyPolicyService
+      economyAuditService: EconomyAuditService
+    },
+  ) {}
+
+  async createDefinition(input: {
+    actor: Actor
+    createdBy: string
+    issuerKind: 'platform' | 'server' | 'user' | 'shop'
+    issuerId?: string | null
+    shopId?: string | null
+    assetType: AssetType
+    name: string
+    description?: string | null
+    imageUrl?: string | null
+    giftable?: boolean
+    transferable?: boolean
+    consumable?: boolean
+    revocable?: boolean
+    expiresAfterDays?: number | null
+    status?: AssetDefinitionStatus
+    metadata?: Record<string, unknown>
+  }) {
+    await this.deps.economyPolicyService.authorize({
+      actor: input.actor,
+      action: 'asset.definition.create',
+      resource: { kind: 'community_asset_definition' },
+      scope: { kind: input.issuerKind, id: input.issuerId ?? input.shopId },
+      dataClass: 'commercial',
+      targetUserId: input.createdBy,
+    })
+    const [definition] = await this.deps.db
+      .insert(communityAssetDefinitions)
+      .values({
+        issuerKind: input.issuerKind,
+        issuerId: input.issuerId ?? null,
+        shopId: input.shopId ?? null,
+        assetType: input.assetType,
+        name: input.name,
+        description: input.description ?? null,
+        imageUrl: input.imageUrl ?? null,
+        giftable: input.giftable ?? false,
+        transferable: input.transferable ?? false,
+        consumable: input.consumable ?? false,
+        revocable: input.revocable ?? true,
+        expiresAfterDays: input.expiresAfterDays ?? null,
+        status: input.status ?? 'draft',
+        metadata: input.metadata ?? {},
+        createdBy: input.createdBy,
+      })
+      .returning()
+    if (!definition) throw apiError('COMMUNITY_ASSET_DEFINITION_CREATE_FAILED', 500)
+
+    await this.deps.economyAuditService.record({
+      actor: input.actor,
+      action: 'asset.definition.create',
+      resource: { kind: 'community_asset_definition', id: definition.id },
+      scope: { kind: input.issuerKind, id: input.issuerId ?? input.shopId },
+      result: 'succeeded',
+      metadata: { assetType: input.assetType, status: definition.status },
+    })
+    return definition
+  }
+
+  async listUserAssets(userId: string) {
+    return this.deps.db
+      .select({ grant: communityAssetGrants, definition: communityAssetDefinitions })
+      .from(communityAssetGrants)
+      .innerJoin(
+        communityAssetDefinitions,
+        eq(communityAssetDefinitions.id, communityAssetGrants.definitionId),
+      )
+      .where(eq(communityAssetGrants.ownerUserId, userId))
+  }
+
+  async listDefinitionsForShop(shopId: string) {
+    return this.deps.db
+      .select()
+      .from(communityAssetDefinitions)
+      .where(eq(communityAssetDefinitions.shopId, shopId))
+  }
+
+  async updateDefinition(input: {
+    actor: Actor
+    definitionId: string
+    shopId: string
+    updatedBy: string
+    name?: string
+    description?: string | null
+    imageUrl?: string | null
+    giftable?: boolean
+    transferable?: boolean
+    consumable?: boolean
+    revocable?: boolean
+    expiresAfterDays?: number | null
+    status?: AssetDefinitionStatus
+    metadata?: Record<string, unknown>
+  }) {
+    await this.deps.economyPolicyService.authorize({
+      actor: input.actor,
+      action: 'asset.definition.update',
+      resource: { kind: 'community_asset_definition', id: input.definitionId },
+      scope: { kind: 'shop', id: input.shopId },
+      dataClass: 'commercial',
+      targetUserId: input.updatedBy,
+    })
+
+    const [definition] = await this.deps.db
+      .update(communityAssetDefinitions)
+      .set({
+        ...(input.name !== undefined ? { name: input.name } : {}),
+        ...(input.description !== undefined ? { description: input.description } : {}),
+        ...(input.imageUrl !== undefined ? { imageUrl: input.imageUrl } : {}),
+        ...(input.giftable !== undefined ? { giftable: input.giftable } : {}),
+        ...(input.transferable !== undefined ? { transferable: input.transferable } : {}),
+        ...(input.consumable !== undefined ? { consumable: input.consumable } : {}),
+        ...(input.revocable !== undefined ? { revocable: input.revocable } : {}),
+        ...(input.expiresAfterDays !== undefined
+          ? { expiresAfterDays: input.expiresAfterDays }
+          : {}),
+        ...(input.status !== undefined ? { status: input.status } : {}),
+        ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(communityAssetDefinitions.id, input.definitionId),
+          eq(communityAssetDefinitions.shopId, input.shopId),
+        ),
+      )
+      .returning()
+    if (!definition) throw apiError('COMMUNITY_ASSET_DEFINITION_NOT_FOUND', 404)
+
+    await this.deps.economyAuditService.record({
+      actor: input.actor,
+      action: 'asset.definition.update',
+      resource: { kind: 'community_asset_definition', id: definition.id },
+      scope: { kind: 'shop', id: input.shopId },
+      result: 'succeeded',
+      metadata: { status: definition.status },
+    })
+    return definition
+  }
+
+  async getGrant(grantId: string, db: DbLike = this.deps.db) {
+    const [row] = await db
+      .select({ grant: communityAssetGrants, definition: communityAssetDefinitions })
+      .from(communityAssetGrants)
+      .innerJoin(
+        communityAssetDefinitions,
+        eq(communityAssetDefinitions.id, communityAssetGrants.definitionId),
+      )
+      .where(eq(communityAssetGrants.id, grantId))
+      .limit(1)
+    return row ?? null
+  }
+
+  private async getGrantByTransferLog(idempotencyKey: string, db: DbLike = this.deps.db) {
+    const [existingLog] = await db
+      .select()
+      .from(communityAssetTransferLogs)
+      .where(eq(communityAssetTransferLogs.idempotencyKey, idempotencyKey))
+      .limit(1)
+    if (!existingLog?.grantId) return null
+
+    const [grant] = await db
+      .select()
+      .from(communityAssetGrants)
+      .where(eq(communityAssetGrants.id, existingLog.grantId))
+      .limit(1)
+    return grant ?? null
+  }
+
+  async grantToUser(
+    input: {
+      actor: Actor
+      ownerUserId: string
+      definitionId: string
+      sourceKind: string
+      sourceId?: string | null
+      quantity?: number
+      idempotencyKey: string
+      metadata?: Record<string, unknown>
+    },
+    db: DbLike = this.deps.db,
+  ) {
+    const quantity = Math.max(Math.floor(input.quantity ?? 1), 1)
+    const existingGrant = await this.getGrantByTransferLog(input.idempotencyKey, db)
+    if (existingGrant) return existingGrant
+
+    const [definition] = await db
+      .select()
+      .from(communityAssetDefinitions)
+      .where(eq(communityAssetDefinitions.id, input.definitionId))
+      .limit(1)
+    if (!definition || definition.status !== 'active') {
+      throw apiError('COMMUNITY_ASSET_DEFINITION_NOT_ACTIVE', 400)
+    }
+
+    await this.deps.economyPolicyService.authorize({
+      actor: input.actor,
+      action: 'asset.grant',
+      resource: { kind: 'community_asset_definition', id: input.definitionId },
+      scope: { kind: 'community_asset', id: input.definitionId },
+      dataClass: 'commercial',
+      requiredScope: 'economy:assets:write',
+      targetUserId: input.ownerUserId,
+    })
+
+    const [grant] = await db
+      .insert(communityAssetGrants)
+      .values({
+        definitionId: input.definitionId,
+        ownerUserId: input.ownerUserId,
+        sourceKind: input.sourceKind,
+        sourceId: input.sourceId ?? null,
+        quantity,
+        remainingQuantity: quantity,
+        expiresAt: addDays(definition.expiresAfterDays),
+        metadata: input.metadata ?? {},
+      })
+      .returning()
+    if (!grant) throw apiError('COMMUNITY_ASSET_GRANT_FAILED', 500)
+
+    await db.insert(communityAssetTransferLogs).values({
+      definitionId: input.definitionId,
+      grantId: grant.id,
+      toUserId: input.ownerUserId,
+      quantity,
+      action: 'grant',
+      referenceType: input.sourceKind,
+      referenceId: input.sourceId ?? null,
+      idempotencyKey: input.idempotencyKey,
+    })
+
+    await this.deps.economyAuditService.record(
+      {
+        actor: input.actor,
+        action: 'asset.grant',
+        resource: { kind: 'community_asset_grant', id: grant.id },
+        scope: { kind: 'community_asset_definition', id: input.definitionId },
+        idempotencyKey: input.idempotencyKey,
+        result: 'succeeded',
+        metadata: { ownerUserId: input.ownerUserId, quantity },
+      },
+      db,
+    )
+
+    return grant
+  }
+
+  async transferGrant(
+    input: {
+      actorUserId: string
+      recipientUserId: string
+      grantId: string
+      quantity?: number
+      referenceType: string
+      referenceId: string
+      idempotencyKey: string
+      actor?: Actor
+    },
+    db: DbLike = this.deps.db,
+  ) {
+    const quantity = Math.max(Math.floor(input.quantity ?? 1), 1)
+    const existingGrant = await this.getGrantByTransferLog(input.idempotencyKey, db)
+    if (existingGrant) return existingGrant
+
+    const row = await this.getGrant(input.grantId, db)
+    if (!row) throw apiError('COMMUNITY_ASSET_GRANT_NOT_FOUND', 404)
+    if (row.grant.ownerUserId !== input.actorUserId) {
+      throw apiError('COMMUNITY_ASSET_OWNER_MISMATCH', 403)
+    }
+    if (!row.definition.giftable) throw apiError('COMMUNITY_ASSET_NOT_GIFTABLE', 400)
+    if (row.grant.status !== 'active' || row.grant.remainingQuantity < quantity) {
+      throw apiError('COMMUNITY_ASSET_GRANT_UNAVAILABLE', 400)
+    }
+    const actor = input.actor ?? actorFromUserId(input.actorUserId)
+    await this.deps.economyPolicyService.authorize({
+      actor,
+      action: 'asset.transfer',
+      resource: { kind: 'community_asset_grant', id: input.grantId },
+      scope: { kind: 'community_asset_definition', id: row.definition.id },
+      dataClass: 'commercial',
+      requiredScope: 'economy:assets:write',
+      targetUserId: input.actorUserId,
+    })
+
+    const updated = await db
+      .update(communityAssetGrants)
+      .set({
+        remainingQuantity: sql`${communityAssetGrants.remainingQuantity} - ${quantity}`,
+        status: row.grant.remainingQuantity === quantity ? 'consumed' : 'active',
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(communityAssetGrants.id, input.grantId),
+          eq(communityAssetGrants.ownerUserId, input.actorUserId),
+          eq(communityAssetGrants.status, 'active'),
+          sql`${communityAssetGrants.remainingQuantity} >= ${quantity}`,
+        ),
+      )
+      .returning({ id: communityAssetGrants.id })
+    if (updated.length === 0) throw apiError('COMMUNITY_ASSET_GRANT_CONFLICT', 409)
+
+    const [newGrant] = await db
+      .insert(communityAssetGrants)
+      .values({
+        definitionId: row.definition.id,
+        ownerUserId: input.recipientUserId,
+        sourceKind: 'gift',
+        sourceId: input.referenceId,
+        quantity,
+        remainingQuantity: quantity,
+        expiresAt: row.grant.expiresAt,
+        metadata: row.grant.metadata,
+      })
+      .returning()
+    if (!newGrant) throw apiError('COMMUNITY_ASSET_GIFT_GRANT_FAILED', 500)
+
+    await db.insert(communityAssetTransferLogs).values({
+      definitionId: row.definition.id,
+      grantId: newGrant.id,
+      fromUserId: input.actorUserId,
+      toUserId: input.recipientUserId,
+      quantity,
+      action: 'gift',
+      referenceType: input.referenceType,
+      referenceId: input.referenceId,
+      idempotencyKey: input.idempotencyKey,
+    })
+    await this.deps.economyAuditService.record(
+      {
+        actor,
+        action: 'asset.transfer',
+        resource: { kind: 'community_asset_grant', id: newGrant.id },
+        scope: { kind: 'community_asset_definition', id: row.definition.id },
+        idempotencyKey: input.idempotencyKey,
+        result: 'succeeded',
+        metadata: {
+          fromGrantId: input.grantId,
+          fromUserId: input.actorUserId,
+          toUserId: input.recipientUserId,
+          quantity,
+        },
+      },
+      db,
+    )
+
+    return newGrant
+  }
+
+  private async mutateGrantStatus(input: {
+    actor: Actor
+    actorUserId: string
+    grantId: string
+    fromStatuses: Array<'active' | 'locked'>
+    toStatus: 'active' | 'locked' | 'revoked' | 'expired'
+    action: 'asset.lock' | 'asset.unlock' | 'asset.revoke' | 'asset.expire'
+    transferAction: 'lock' | 'unlock' | 'revoke' | 'expire'
+    idempotencyKey: string
+    referenceType: string
+    referenceId: string
+    zeroRemaining?: boolean
+    db?: DbLike
+  }) {
+    const db = input.db ?? this.deps.db
+    const existingGrant = await this.getGrantByTransferLog(input.idempotencyKey, db)
+    if (existingGrant) return existingGrant
+
+    const row = await this.getGrant(input.grantId, db)
+    if (!row) throw apiError('COMMUNITY_ASSET_GRANT_NOT_FOUND', 404)
+    if (row.grant.ownerUserId !== input.actorUserId) {
+      throw apiError('COMMUNITY_ASSET_OWNER_MISMATCH', 403)
+    }
+    if (!input.fromStatuses.includes(row.grant.status as 'active' | 'locked')) {
+      throw apiError('COMMUNITY_ASSET_GRANT_UNAVAILABLE', 400)
+    }
+
+    await this.deps.economyPolicyService.authorize({
+      actor: input.actor,
+      action: input.action,
+      resource: { kind: 'community_asset_grant', id: input.grantId },
+      scope: { kind: 'community_asset_definition', id: row.definition.id },
+      dataClass: 'commercial',
+      requiredScope: 'economy:assets:write',
+      targetUserId: input.actorUserId,
+    })
+
+    const [updated] = await db
+      .update(communityAssetGrants)
+      .set({
+        status: input.toStatus,
+        ...(input.zeroRemaining ? { remainingQuantity: 0 } : {}),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(communityAssetGrants.id, input.grantId),
+          eq(communityAssetGrants.ownerUserId, input.actorUserId),
+          inArray(communityAssetGrants.status, input.fromStatuses),
+        ),
+      )
+      .returning()
+    if (!updated) throw apiError('COMMUNITY_ASSET_GRANT_CONFLICT', 409)
+
+    await db.insert(communityAssetTransferLogs).values({
+      definitionId: row.definition.id,
+      grantId: input.grantId,
+      fromUserId: input.actorUserId,
+      quantity: row.grant.remainingQuantity,
+      action: input.transferAction,
+      referenceType: input.referenceType,
+      referenceId: input.referenceId,
+      idempotencyKey: input.idempotencyKey,
+    })
+    await this.deps.economyAuditService.record(
+      {
+        actor: input.actor,
+        action: input.action,
+        resource: { kind: 'community_asset_grant', id: input.grantId },
+        scope: { kind: 'community_asset_definition', id: row.definition.id },
+        idempotencyKey: input.idempotencyKey,
+        result: 'succeeded',
+        metadata: {
+          fromStatus: row.grant.status,
+          toStatus: input.toStatus,
+          quantity: row.grant.remainingQuantity,
+        },
+      },
+      db,
+    )
+    return updated
+  }
+
+  async lockGrant(input: {
+    actorUserId: string
+    grantId: string
+    idempotencyKey: string
+    referenceType?: string
+    referenceId?: string
+    actor?: Actor
+  }) {
+    return this.mutateGrantStatus({
+      actor: input.actor ?? actorFromUserId(input.actorUserId),
+      actorUserId: input.actorUserId,
+      grantId: input.grantId,
+      fromStatuses: ['active'],
+      toStatus: 'locked',
+      action: 'asset.lock',
+      transferAction: 'lock',
+      idempotencyKey: input.idempotencyKey,
+      referenceType: input.referenceType ?? 'asset_grant',
+      referenceId: input.referenceId ?? input.grantId,
+    })
+  }
+
+  async unlockGrant(input: {
+    actorUserId: string
+    grantId: string
+    idempotencyKey: string
+    referenceType?: string
+    referenceId?: string
+    actor?: Actor
+  }) {
+    return this.mutateGrantStatus({
+      actor: input.actor ?? actorFromUserId(input.actorUserId),
+      actorUserId: input.actorUserId,
+      grantId: input.grantId,
+      fromStatuses: ['locked'],
+      toStatus: 'active',
+      action: 'asset.unlock',
+      transferAction: 'unlock',
+      idempotencyKey: input.idempotencyKey,
+      referenceType: input.referenceType ?? 'asset_grant',
+      referenceId: input.referenceId ?? input.grantId,
+    })
+  }
+
+  async revokeGrant(input: {
+    actorUserId: string
+    grantId: string
+    idempotencyKey: string
+    reason?: string
+    actor?: Actor
+  }) {
+    return this.mutateGrantStatus({
+      actor: input.actor ?? actorFromUserId(input.actorUserId),
+      actorUserId: input.actorUserId,
+      grantId: input.grantId,
+      fromStatuses: ['active', 'locked'],
+      toStatus: 'revoked',
+      action: 'asset.revoke',
+      transferAction: 'revoke',
+      idempotencyKey: input.idempotencyKey,
+      referenceType: 'asset_revoke',
+      referenceId: input.reason ?? input.grantId,
+      zeroRemaining: true,
+    })
+  }
+
+  async expireDueGrants(input: { actor: Actor; now?: Date; limit?: number }) {
+    await this.deps.economyPolicyService.authorize({
+      actor: input.actor,
+      action: 'asset.expire',
+      resource: { kind: 'community_asset_grant' },
+      scope: { kind: 'community_asset_grant' },
+      dataClass: 'commercial',
+      requiredScope: 'economy:assets:write',
+    })
+    const now = input.now ?? new Date()
+    const due = await this.deps.db
+      .select()
+      .from(communityAssetGrants)
+      .where(
+        and(
+          inArray(communityAssetGrants.status, ['active', 'locked']),
+          lte(communityAssetGrants.expiresAt, now),
+        ),
+      )
+      .limit(Math.min(Math.max(input.limit ?? 500, 1), 500))
+
+    const expired = []
+    for (const grant of due) {
+      const [updated] = await this.deps.db
+        .update(communityAssetGrants)
+        .set({ status: 'expired', remainingQuantity: 0, updatedAt: new Date() })
+        .where(
+          and(
+            eq(communityAssetGrants.id, grant.id),
+            inArray(communityAssetGrants.status, ['active', 'locked']),
+          ),
+        )
+        .returning()
+      if (!updated) continue
+      await this.deps.db.insert(communityAssetTransferLogs).values({
+        definitionId: grant.definitionId,
+        grantId: grant.id,
+        fromUserId: grant.ownerUserId,
+        quantity: grant.remainingQuantity,
+        action: 'expire',
+        referenceType: 'asset_expiry',
+        referenceId: grant.expiresAt?.toISOString() ?? grant.id,
+        idempotencyKey: `asset-expire:${grant.id}:${grant.expiresAt?.getTime() ?? now.getTime()}`,
+      })
+      await this.deps.economyAuditService.record({
+        actor: input.actor,
+        action: 'asset.expire',
+        resource: { kind: 'community_asset_grant', id: grant.id },
+        scope: { kind: 'community_asset_definition', id: grant.definitionId },
+        result: 'succeeded',
+        metadata: { ownerUserId: grant.ownerUserId, expiresAt: grant.expiresAt },
+      })
+      expired.push(updated)
+    }
+    return expired
+  }
+
+  async consume(input: {
+    actorUserId: string
+    grantId: string
+    idempotencyKey: string
+    actor?: Actor
+  }) {
+    const existingGrant = await this.getGrantByTransferLog(input.idempotencyKey)
+    if (existingGrant) return existingGrant
+
+    const row = await this.getGrant(input.grantId)
+    if (!row) throw apiError('COMMUNITY_ASSET_GRANT_NOT_FOUND', 404)
+    if (row.grant.ownerUserId !== input.actorUserId) {
+      throw apiError('COMMUNITY_ASSET_OWNER_MISMATCH', 403)
+    }
+    if (!row.definition.consumable) throw apiError('COMMUNITY_ASSET_NOT_CONSUMABLE', 400)
+    const actor = input.actor ?? actorFromUserId(input.actorUserId)
+    await this.deps.economyPolicyService.authorize({
+      actor,
+      action: 'asset.consume',
+      resource: { kind: 'community_asset_grant', id: input.grantId },
+      scope: { kind: 'community_asset_definition', id: row.definition.id },
+      dataClass: 'commercial',
+      requiredScope: 'economy:assets:write',
+      targetUserId: input.actorUserId,
+    })
+
+    return this.deps.db.transaction(async (tx) => {
+      const [updated] = await tx
+        .update(communityAssetGrants)
+        .set({ status: 'consumed', remainingQuantity: 0, updatedAt: new Date() })
+        .where(
+          and(
+            eq(communityAssetGrants.id, input.grantId),
+            eq(communityAssetGrants.ownerUserId, input.actorUserId),
+            eq(communityAssetGrants.status, 'active'),
+          ),
+        )
+        .returning()
+      if (!updated) throw apiError('COMMUNITY_ASSET_GRANT_UNAVAILABLE', 400)
+      await tx.insert(communityAssetTransferLogs).values({
+        definitionId: row.definition.id,
+        grantId: input.grantId,
+        fromUserId: input.actorUserId,
+        quantity: row.grant.remainingQuantity,
+        action: 'consume',
+        referenceType: 'asset_grant',
+        referenceId: input.grantId,
+        idempotencyKey: input.idempotencyKey,
+      })
+      await this.deps.economyAuditService.record(
+        {
+          actor,
+          action: 'asset.consume',
+          resource: { kind: 'community_asset_grant', id: input.grantId },
+          scope: { kind: 'community_asset_definition', id: row.definition.id },
+          idempotencyKey: input.idempotencyKey,
+          result: 'succeeded',
+          metadata: { quantity: row.grant.remainingQuantity },
+        },
+        tx,
+      )
+      return updated
+    })
+  }
+}

--- a/apps/server/src/services/economy-audit.service.ts
+++ b/apps/server/src/services/economy-audit.service.ts
@@ -1,0 +1,64 @@
+import { createHash } from 'node:crypto'
+import type { Database } from '../db'
+import { economyAuditEvents } from '../db/schema'
+import { type Actor, actorLabel } from '../security/actor'
+
+type DbLike = Database | Parameters<Parameters<Database['transaction']>[0]>[0]
+
+export type EconomyAuditInput = {
+  actor: Actor
+  action: string
+  resource: { kind: string; id?: string | null }
+  scope?: { kind?: string | null; id?: string | null }
+  idempotencyKey?: string | null
+  request?: unknown
+  result: 'started' | 'succeeded' | 'failed' | 'denied'
+  errorCode?: string | null
+  ip?: string | null
+  userAgent?: string | null
+  metadata?: Record<string, unknown>
+}
+
+function stableHash(value: unknown) {
+  if (value == null || value === '') return undefined
+  const raw = typeof value === 'string' ? value : JSON.stringify(value)
+  return createHash('sha256').update(raw).digest('hex')
+}
+
+function actorTokenKind(actor: Actor) {
+  if (actor.kind === 'system') return 'system'
+  return actor.kind === 'user' ? actor.authMethod : actor.kind
+}
+
+function actorId(actor: Actor) {
+  if (actor.kind === 'system') return actor.service
+  if ('tokenId' in actor && actor.tokenId) return `${actor.userId}:${actor.tokenId}`
+  return actor.userId
+}
+
+export class EconomyAuditService {
+  constructor(private deps: { db: Database }) {}
+
+  async record(input: EconomyAuditInput, db: DbLike = this.deps.db) {
+    await db.insert(economyAuditEvents).values({
+      actorKind: input.actor.kind,
+      actorId: actorId(input.actor),
+      actorTokenKind: actorTokenKind(input.actor),
+      action: input.action,
+      resourceKind: input.resource.kind,
+      resourceId: input.resource.id ?? undefined,
+      scopeKind: input.scope?.kind ?? undefined,
+      scopeId: input.scope?.id ?? undefined,
+      idempotencyKey: input.idempotencyKey ?? undefined,
+      requestHash: stableHash(input.request),
+      result: input.result,
+      errorCode: input.errorCode ?? undefined,
+      ipHash: stableHash(input.ip),
+      userAgentHash: stableHash(input.userAgent),
+      metadata: {
+        actor: actorLabel(input.actor),
+        ...(input.metadata ?? {}),
+      },
+    })
+  }
+}

--- a/apps/server/src/services/economy-idempotency.service.ts
+++ b/apps/server/src/services/economy-idempotency.service.ts
@@ -1,0 +1,156 @@
+import { and, eq } from 'drizzle-orm'
+import type { Database } from '../db'
+import { commerceIdempotencyKeys } from '../db/schema'
+import { apiError } from '../lib/api-error'
+
+type DbLike = Database | Parameters<Parameters<Database['transaction']>[0]>[0]
+
+export class EconomyIdempotencyService {
+  constructor(private deps: { db: Database }) {}
+
+  async getCompleted<T = Record<string, unknown>>(input: {
+    actorUserId: string
+    key: string
+    action: string
+  }) {
+    const rows = await this.deps.db
+      .select()
+      .from(commerceIdempotencyKeys)
+      .where(
+        and(
+          eq(commerceIdempotencyKeys.actorUserId, input.actorUserId),
+          eq(commerceIdempotencyKeys.key, input.key),
+          eq(commerceIdempotencyKeys.action, input.action),
+        ),
+      )
+      .limit(1)
+
+    const existing = rows[0]
+    if (!existing) return null
+    if (existing.status === 'completed') return existing.response as T
+    if (existing.status === 'started') {
+      throw apiError('ECONOMY_OPERATION_IN_PROGRESS', 409)
+    }
+    return null
+  }
+
+  async begin(
+    input: {
+      actorUserId: string
+      key: string
+      action: string
+      ttlMs?: number
+    },
+    db: DbLike = this.deps.db,
+  ) {
+    if (!input.key || input.key.length < 8 || input.key.length > 200) {
+      throw apiError('IDEMPOTENCY_KEY_REQUIRED', 400, { maxLength: 200 })
+    }
+
+    const inserted = await db
+      .insert(commerceIdempotencyKeys)
+      .values({
+        actorUserId: input.actorUserId,
+        key: input.key,
+        action: input.action,
+        status: 'started',
+        expiresAt: new Date(Date.now() + (input.ttlMs ?? 24 * 60 * 60 * 1000)),
+      })
+      .onConflictDoNothing()
+      .returning({ id: commerceIdempotencyKeys.id })
+    if (inserted.length > 0) return inserted[0]!
+
+    const [existing] = await db
+      .select()
+      .from(commerceIdempotencyKeys)
+      .where(
+        and(
+          eq(commerceIdempotencyKeys.actorUserId, input.actorUserId),
+          eq(commerceIdempotencyKeys.key, input.key),
+          eq(commerceIdempotencyKeys.action, input.action),
+        ),
+      )
+      .limit(1)
+
+    if (existing?.status === 'failed') {
+      const restarted = await db
+        .update(commerceIdempotencyKeys)
+        .set({
+          status: 'started',
+          error: null,
+          response: null,
+          referenceId: null,
+          expiresAt: new Date(Date.now() + (input.ttlMs ?? 24 * 60 * 60 * 1000)),
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(commerceIdempotencyKeys.actorUserId, input.actorUserId),
+            eq(commerceIdempotencyKeys.key, input.key),
+            eq(commerceIdempotencyKeys.action, input.action),
+            eq(commerceIdempotencyKeys.status, 'failed'),
+          ),
+        )
+        .returning({ id: commerceIdempotencyKeys.id })
+      if (restarted.length > 0) return restarted[0]!
+    }
+
+    if (existing?.status === 'completed') {
+      throw apiError('ECONOMY_OPERATION_COMPLETED', 409)
+    }
+
+    throw apiError('ECONOMY_OPERATION_IN_PROGRESS', 409)
+  }
+
+  async complete(
+    input: {
+      actorUserId: string
+      key: string
+      action: string
+      referenceId?: string | null
+      response: Record<string, unknown>
+    },
+    db: DbLike = this.deps.db,
+  ) {
+    await db
+      .update(commerceIdempotencyKeys)
+      .set({
+        status: 'completed',
+        referenceId: input.referenceId ?? undefined,
+        response: input.response,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(commerceIdempotencyKeys.actorUserId, input.actorUserId),
+          eq(commerceIdempotencyKeys.key, input.key),
+          eq(commerceIdempotencyKeys.action, input.action),
+        ),
+      )
+  }
+
+  async fail(
+    input: {
+      actorUserId: string
+      key: string
+      action: string
+      error: string
+    },
+    db: DbLike = this.deps.db,
+  ) {
+    await db
+      .update(commerceIdempotencyKeys)
+      .set({
+        status: 'failed',
+        error: input.error,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(commerceIdempotencyKeys.actorUserId, input.actorUserId),
+          eq(commerceIdempotencyKeys.key, input.key),
+          eq(commerceIdempotencyKeys.action, input.action),
+        ),
+      )
+  }
+}

--- a/apps/server/src/services/economy-policy.service.ts
+++ b/apps/server/src/services/economy-policy.service.ts
@@ -1,0 +1,127 @@
+import { eq } from 'drizzle-orm'
+import type { Database } from '../db'
+import { users } from '../db/schema'
+import { type Actor, actorHasScope, actorUserId } from '../security/actor'
+
+export type EconomyAction =
+  | 'wallet.read'
+  | 'recharge.create'
+  | 'recharge.webhook'
+  | 'order.purchase'
+  | 'offer.purchase'
+  | 'wallet.refund'
+  | 'wallet.adjust'
+  | 'fulfillment.process'
+  | 'settlement.process'
+  | string
+
+export type EconomyDataClass = 'public' | 'commercial' | 'financial' | 'restricted' | 'secret'
+
+export type EconomyPolicyInput = {
+  actor: Actor
+  action: EconomyAction
+  resource: { kind: string; id?: string | null }
+  scope?: { kind: string; id?: string | null }
+  dataClass: EconomyDataClass
+  requiredScope?: string
+  targetUserId?: string | null
+}
+
+function isWriteAction(action: string) {
+  return !action.endsWith('.read') && action !== 'wallet.read'
+}
+
+function economyScopeForAction(action: string) {
+  if (action === 'wallet.read') return 'economy:wallet:read'
+  if (action === 'order.purchase' || action === 'offer.purchase') return 'economy:orders:write'
+  if (action === 'recharge.create') return 'economy:recharge:write'
+  if (action === 'wallet.refund') return 'economy:refunds:write'
+  if (action === 'wallet.adjust') return 'economy:admin:adjust'
+  if (action === 'fulfillment.process') return 'economy:fulfillment:write'
+  if (action === 'settlement.process') return 'economy:settlements:write'
+  if (
+    action === 'asset.grant' ||
+    action === 'asset.lock' ||
+    action === 'asset.unlock' ||
+    action === 'asset.transfer' ||
+    action === 'asset.consume' ||
+    action === 'asset.revoke' ||
+    action === 'asset.expire' ||
+    action === 'asset.definition.create' ||
+    action === 'asset.definition.update'
+  ) {
+    return 'economy:assets:write'
+  }
+  if (action === 'tip.send') return 'economy:tips:write'
+  if (action === 'gift.send') return 'economy:gifts:write'
+  return `economy:${action.replaceAll('.', ':')}`
+}
+
+export class EconomyPolicyService {
+  constructor(private deps: { db: Database }) {}
+
+  private async getUserEconomyStatus(userId: string) {
+    const rows = await this.deps.db
+      .select({ economyStatus: users.economyStatus, isAdmin: users.isAdmin })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+    return rows[0] ?? null
+  }
+
+  async authorize(input: EconomyPolicyInput) {
+    const requiredScope = input.requiredScope ?? economyScopeForAction(input.action)
+
+    if (input.actor.kind === 'system') {
+      if (!actorHasScope(input.actor, requiredScope)) {
+        throw Object.assign(new Error(`Requires capability: ${requiredScope}`), {
+          status: 403,
+          code: 'ECONOMY_SCOPE_REQUIRED',
+          scope: requiredScope,
+        })
+      }
+      return { ok: true as const, requiredScope }
+    }
+
+    if (['agent', 'oauth', 'pat'].includes(input.actor.kind) && isWriteAction(input.action)) {
+      if (!actorHasScope(input.actor, requiredScope)) {
+        throw Object.assign(new Error(`Requires economy scope: ${requiredScope}`), {
+          status: 403,
+          code: 'ECONOMY_SCOPE_REQUIRED',
+          scope: requiredScope,
+        })
+      }
+    }
+
+    const userId = actorUserId(input.actor)
+    const user = await this.getUserEconomyStatus(userId)
+    if (!user) {
+      throw Object.assign(new Error('Economy actor not found'), {
+        status: 403,
+        code: 'ECONOMY_ACTOR_NOT_FOUND',
+      })
+    }
+
+    if (isWriteAction(input.action) && user.economyStatus !== 'normal') {
+      throw Object.assign(new Error('Economy actions are restricted for this user'), {
+        status: 403,
+        code: 'ECONOMY_USER_RESTRICTED',
+        economyStatus: user.economyStatus,
+      })
+    }
+
+    if (
+      input.action === 'wallet.adjust' &&
+      !user.isAdmin &&
+      !actorHasScope(input.actor, requiredScope)
+    ) {
+      throw Object.assign(new Error('Platform admin capability is required'), {
+        status: 403,
+        code: 'ECONOMY_ADMIN_REQUIRED',
+        scope: requiredScope,
+      })
+    }
+
+    return { ok: true as const, requiredScope }
+  }
+}

--- a/apps/server/src/services/entitlement-cancellation.service.ts
+++ b/apps/server/src/services/entitlement-cancellation.service.ts
@@ -1,9 +1,13 @@
 import type { OrderDao } from '../dao/order.dao'
 import { apiError } from '../lib/api-error'
+import { type Actor, actorFromUserId } from '../security/actor'
+import type { EconomyAuditService } from './economy-audit.service'
+import type { EconomyPolicyService } from './economy-policy.service'
 import type { EntitlementService } from './entitlement.service'
 import type { LedgerService } from './ledger.service'
 import type { NotificationTriggerService } from './notification-trigger.service'
 import type { ProductService } from './product.service'
+import type { SettlementService } from './settlement.service'
 
 function startOfUtcDay(date: Date) {
   return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
@@ -30,11 +34,20 @@ export class EntitlementCancellationService {
       orderDao: OrderDao
       productService: ProductService
       ledgerService: LedgerService
+      economyPolicyService: EconomyPolicyService
+      economyAuditService: EconomyAuditService
       notificationTriggerService: NotificationTriggerService
+      settlementService: SettlementService
     },
   ) {}
 
-  async cancel(input: { actorUserId: string; entitlementId: string; reason?: string }) {
+  async cancel(input: {
+    actorUserId: string
+    entitlementId: string
+    reason?: string
+    actor?: Actor
+  }) {
+    const actor = input.actor ?? actorFromUserId(input.actorUserId)
     const entitlement = await this.deps.entitlementService.getEntitlement(input.entitlementId)
     if (entitlement.userId !== input.actorUserId) {
       throw apiError('ENTITLEMENT_OWNER_MISMATCH', 403)
@@ -70,6 +83,14 @@ export class EntitlementCancellationService {
     )
 
     if (refundAmount > 0) {
+      await this.deps.economyPolicyService.authorize({
+        actor,
+        action: 'wallet.refund',
+        resource: { kind: 'entitlement', id: entitlement.id },
+        scope: { kind: 'wallet', id: entitlement.userId },
+        dataClass: 'financial',
+        targetUserId: entitlement.userId,
+      })
       await this.deps.ledgerService.credit({
         userId: entitlement.userId,
         amount: refundAmount,
@@ -78,6 +99,22 @@ export class EntitlementCancellationService {
         referenceType: 'order',
         note: `虚拟服务取消退款 - ${product?.name ?? entitlement.id}`,
       })
+      await this.deps.economyAuditService.record({
+        actor,
+        action: 'wallet.refund',
+        resource: { kind: 'entitlement', id: entitlement.id },
+        scope: { kind: 'wallet', id: entitlement.userId },
+        request: { reason: input.reason },
+        result: 'succeeded',
+        metadata: { refundAmount, orderId: entitlement.orderId },
+      })
+      if (entitlement.orderId) {
+        await this.deps.settlementService.reverseLinesForSource({
+          sourceType: 'order',
+          sourceId: entitlement.orderId,
+          reason: 'entitlement_refund',
+        })
+      }
     }
 
     await this.deps.notificationTriggerService.triggerCommerceSubscriptionCancelled({

--- a/apps/server/src/services/entitlement-purchase.service.ts
+++ b/apps/server/src/services/entitlement-purchase.service.ts
@@ -12,13 +12,17 @@ import {
   skus,
 } from '../db/schema'
 import { apiError } from '../lib/api-error'
+import { type Actor, actorFromUserId } from '../security/actor'
 import type { CommerceFulfillmentService } from './commerce-fulfillment.service'
 import type { CommerceOfferService } from './commerce-offer.service'
+import type { EconomyAuditService } from './economy-audit.service'
+import type { EconomyPolicyService } from './economy-policy.service'
 import type { EntitlementProvisionerService } from './entitlement-provisioner.service'
 import { resolveProductEntitlementResource } from './entitlement-resource'
 import type { LedgerService } from './ledger.service'
 import type { NotificationTriggerService } from './notification-trigger.service'
 import type { ProductService } from './product.service'
+import type { SettlementService } from './settlement.service'
 
 function addSeconds(seconds?: number | null) {
   return seconds ? new Date(Date.now() + seconds * 1000) : null
@@ -34,6 +38,9 @@ export class EntitlementPurchaseService {
       entitlementProvisionerService: EntitlementProvisionerService
       commerceOfferService: CommerceOfferService
       commerceFulfillmentService: CommerceFulfillmentService
+      economyPolicyService: EconomyPolicyService
+      economyAuditService: EconomyAuditService
+      settlementService: SettlementService
     },
   ) {}
 
@@ -43,6 +50,7 @@ export class EntitlementPurchaseService {
     productId: string
     skuId?: string
     idempotencyKey: string
+    actor?: Actor
   }) {
     const product = await this.deps.productService.getProductById(input.productId)
     if (product.shopId !== input.shopId) {
@@ -56,6 +64,7 @@ export class EntitlementPurchaseService {
       offerId: offer.id,
       skuId: input.skuId,
       idempotencyKey: input.idempotencyKey,
+      actor: input.actor,
     })
   }
 
@@ -65,10 +74,23 @@ export class EntitlementPurchaseService {
     skuId?: string
     idempotencyKey: string
     destination?: { kind: 'channel' | 'dm'; id: string }
+    actor?: Actor
   }) {
     if (!input.idempotencyKey || input.idempotencyKey.length > 200) {
       throw apiError('IDEMPOTENCY_KEY_REQUIRED', 400, { maxLength: 200 })
     }
+
+    const actor = input.actor ?? actorFromUserId(input.buyerId)
+    await this.deps.economyPolicyService.authorize({
+      actor,
+      action: 'offer.purchase',
+      resource: { kind: 'offer', id: input.offerId },
+      scope: input.destination
+        ? { kind: input.destination.kind, id: input.destination.id }
+        : { kind: 'offer', id: input.offerId },
+      dataClass: 'financial',
+      targetUserId: input.buyerId,
+    })
 
     const existing = await this.deps.db
       .select()
@@ -179,18 +201,35 @@ export class EntitlementPurchaseService {
         tx,
       )
       if (settlementUserId) {
-        await this.deps.ledgerService.credit(
+        await this.deps.settlementService.createLine(
           {
-            userId: settlementUserId,
-            amount: price,
-            type: 'settlement',
-            referenceId: order.id,
-            referenceType: 'order',
-            note: `虚拟服务收入 - 订单 ${orderNo}`,
+            sellerUserId: settlementUserId,
+            shopId: shop.id,
+            sourceType: 'order',
+            sourceId: order.id,
+            grossAmount: price,
           },
           tx,
         )
       }
+
+      await this.deps.economyAuditService.record(
+        {
+          actor,
+          action: 'commerce.offer.purchase',
+          resource: { kind: 'order', id: order.id },
+          scope: { kind: 'offer', id: offer.id },
+          idempotencyKey: input.idempotencyKey,
+          request: {
+            offerId: input.offerId,
+            skuId: input.skuId,
+            destination: input.destination,
+          },
+          result: 'succeeded',
+          metadata: { price, productId: product.id, shopId: shop.id },
+        },
+        tx,
+      )
 
       await tx.insert(orderItems).values({
         orderId: order.id,
@@ -229,22 +268,23 @@ export class EntitlementPurchaseService {
       if (!entitlement) throw apiError('ENTITLEMENT_CREATE_FAILED', 500)
 
       const fulfillmentJobs = []
-      if (input.destination) {
-        for (const deliverable of deliverables) {
-          const [job] = await tx
-            .insert(commerceFulfillmentJobs)
-            .values({
-              orderId: order.id,
-              entitlementId: entitlement.id,
-              deliverableId: deliverable.id,
-              buyerId: input.buyerId,
-              destinationKind: input.destination.kind,
-              destinationId: input.destination.id,
-              senderBuddyUserId: deliverable.senderBuddyUserId ?? offer.sellerBuddyUserId,
-            })
-            .returning()
-          if (job) fulfillmentJobs.push(job)
-        }
+      for (const deliverable of deliverables) {
+        const requiresDestination = ['paid_file', 'message', 'external'].includes(deliverable.kind)
+        if (requiresDestination && !input.destination) continue
+
+        const [job] = await tx
+          .insert(commerceFulfillmentJobs)
+          .values({
+            orderId: order.id,
+            entitlementId: entitlement.id,
+            deliverableId: deliverable.id,
+            buyerId: input.buyerId,
+            destinationKind: input.destination?.kind,
+            destinationId: input.destination?.id,
+            senderBuddyUserId: deliverable.senderBuddyUserId ?? offer.sellerBuddyUserId,
+          })
+          .returning()
+        if (job) fulfillmentJobs.push(job)
       }
 
       await tx

--- a/apps/server/src/services/entitlement-renewal.service.ts
+++ b/apps/server/src/services/entitlement-renewal.service.ts
@@ -72,7 +72,7 @@ export class EntitlementRenewalService {
     const orderNo = `SH${Date.now().toString(36).toUpperCase()}${nanoid(6).toUpperCase()}`
     const price = product.basePrice
 
-    const order = await this.deps.db.transaction(async (tx) => {
+    return this.deps.db.transaction(async (tx) => {
       const [created] = await tx
         .insert(orders)
         .values({
@@ -97,11 +97,14 @@ export class EntitlementRenewalService {
         },
         tx,
       )
+      await this.deps.entitlementService.extendEntitlement(
+        entitlement.id,
+        nextExpiresAt,
+        created.id,
+        tx,
+      )
+      await tx.update(orders).set({ updatedAt: new Date() }).where(eq(orders.id, created.id))
       return created
     })
-
-    await this.deps.entitlementService.extendEntitlement(entitlement.id, nextExpiresAt, order.id)
-    await this.deps.db.update(orders).set({ updatedAt: new Date() }).where(eq(orders.id, order.id))
-    return order
   }
 }

--- a/apps/server/src/services/entitlement.service.ts
+++ b/apps/server/src/services/entitlement.service.ts
@@ -1,5 +1,8 @@
 import type { EntitlementDao } from '../dao/entitlement.dao'
+import type { Database } from '../db'
 import { apiError } from '../lib/api-error'
+
+type DbLike = Database | Parameters<Parameters<Database['transaction']>[0]>[0]
 
 /**
  * EntitlementService — manages purchased resource capabilities.
@@ -80,14 +83,18 @@ export class EntitlementService {
     })
   }
 
-  async extendEntitlement(id: string, expiresAt: Date, renewalOrderId?: string) {
-    return this.deps.entitlementDao.update(id, {
-      status: 'active',
-      isActive: true,
-      expiresAt,
-      nextRenewalAt: expiresAt,
-      renewalOrderId: renewalOrderId ?? null,
-    })
+  async extendEntitlement(id: string, expiresAt: Date, renewalOrderId?: string, db?: DbLike) {
+    return this.deps.entitlementDao.update(
+      id,
+      {
+        status: 'active',
+        isActive: true,
+        expiresAt,
+        nextRenewalAt: expiresAt,
+        renewalOrderId: renewalOrderId ?? null,
+      },
+      db,
+    )
   }
 
   async getDueRenewals(now = new Date(), limit = 100) {

--- a/apps/server/src/services/gift.service.ts
+++ b/apps/server/src/services/gift.service.ts
@@ -1,0 +1,233 @@
+import { and, eq, gte, sql } from 'drizzle-orm'
+import type { Database } from '../db'
+import { economyGiftItems, economyGifts, users } from '../db/schema'
+import { apiError } from '../lib/api-error'
+import { type Actor, actorFromUserId } from '../security/actor'
+import type { CommunityAssetService } from './community-asset.service'
+import type { EconomyAuditService } from './economy-audit.service'
+import type { EconomyIdempotencyService } from './economy-idempotency.service'
+import type { EconomyPolicyService } from './economy-policy.service'
+import type { LedgerService } from './ledger.service'
+import type { SettlementService } from './settlement.service'
+
+function normalizeQuantity(value?: number) {
+  return Math.max(Math.floor(value ?? 1), 1)
+}
+
+function positiveIntEnv(name: string, fallback: number) {
+  const value = Number.parseInt(process.env[name] ?? '', 10)
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function startOfUtcDay(date = new Date()) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+}
+
+export class GiftService {
+  constructor(
+    private deps: {
+      db: Database
+      ledgerService: LedgerService
+      communityAssetService: CommunityAssetService
+      economyPolicyService: EconomyPolicyService
+      economyAuditService: EconomyAuditService
+      economyIdempotencyService: EconomyIdempotencyService
+      settlementService: SettlementService
+    },
+  ) {}
+
+  private async assertRecipientCanReceive(recipientUserId: string) {
+    const [recipient] = await this.deps.db
+      .select({ economyStatus: users.economyStatus })
+      .from(users)
+      .where(eq(users.id, recipientUserId))
+      .limit(1)
+    if (!recipient) throw apiError('GIFT_RECIPIENT_NOT_FOUND', 404)
+    if (recipient.economyStatus === 'banned' || recipient.economyStatus === 'frozen') {
+      throw apiError('GIFT_RECIPIENT_BLOCKED', 403)
+    }
+    if (recipient.economyStatus === 'economy_restricted') {
+      throw apiError('GIFT_RECIPIENT_ECONOMY_RESTRICTED', 403)
+    }
+  }
+
+  private async enforceGiftLimits(input: { senderUserId: string; currencyAmount: number }) {
+    const maxCurrencyAmount = positiveIntEnv('SHADOW_GIFT_MAX_CURRENCY_AMOUNT', 1_000_000)
+    if (input.currencyAmount > maxCurrencyAmount) {
+      throw apiError('GIFT_CURRENCY_AMOUNT_LIMIT_EXCEEDED', 429, { maxCurrencyAmount })
+    }
+
+    const [daily] = await this.deps.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(economyGifts)
+      .where(
+        and(
+          eq(economyGifts.senderUserId, input.senderUserId),
+          gte(economyGifts.createdAt, startOfUtcDay()),
+        ),
+      )
+    const dailyCount = Number(daily?.count ?? 0)
+    const dailyCountLimit = positiveIntEnv('SHADOW_GIFT_DAILY_COUNT_LIMIT', 100)
+    if (dailyCount >= dailyCountLimit) {
+      throw apiError('GIFT_DAILY_COUNT_LIMIT_EXCEEDED', 429, { dailyCountLimit })
+    }
+  }
+
+  async sendGift(input: {
+    senderUserId: string
+    recipientUserId: string
+    assets?: Array<{ assetGrantId: string; quantity?: number }>
+    currencies?: Array<{ currencyCode: 'shrimp_coin'; amount: number }>
+    message?: string
+    idempotencyKey: string
+    actor?: Actor
+  }) {
+    if (input.senderUserId === input.recipientUserId) {
+      throw apiError('GIFT_SELF_NOT_ALLOWED', 400)
+    }
+    const assets = input.assets ?? []
+    const currencies = input.currencies ?? []
+    if (assets.length === 0 && currencies.length === 0) {
+      throw apiError('GIFT_EMPTY', 400)
+    }
+    if (
+      currencies.some(
+        (item) =>
+          item.currencyCode !== 'shrimp_coin' || !Number.isFinite(item.amount) || item.amount <= 0,
+      )
+    ) {
+      throw apiError('GIFT_CURRENCY_AMOUNT_INVALID', 400)
+    }
+    if (assets.some((item) => !Number.isFinite(item.quantity ?? 1) || (item.quantity ?? 1) <= 0)) {
+      throw apiError('GIFT_ASSET_QUANTITY_INVALID', 400)
+    }
+    const currencyAmount = currencies.reduce((sum, item) => sum + item.amount, 0)
+    const actor = input.actor ?? actorFromUserId(input.senderUserId)
+    await this.deps.economyPolicyService.authorize({
+      actor,
+      action: 'gift.send',
+      resource: { kind: 'user', id: input.recipientUserId },
+      scope: { kind: 'gift', id: input.recipientUserId },
+      dataClass: 'financial',
+      targetUserId: input.senderUserId,
+    })
+
+    const cached = await this.deps.economyIdempotencyService.getCompleted({
+      actorUserId: input.senderUserId,
+      key: input.idempotencyKey,
+      action: 'economy.gift.send',
+    })
+    if (cached) return cached
+    await this.assertRecipientCanReceive(input.recipientUserId)
+    await this.enforceGiftLimits({ senderUserId: input.senderUserId, currencyAmount })
+
+    return this.deps.db.transaction(async (tx) => {
+      await this.deps.economyIdempotencyService.begin(
+        {
+          actorUserId: input.senderUserId,
+          key: input.idempotencyKey,
+          action: 'economy.gift.send',
+        },
+        tx,
+      )
+
+      const [gift] = await tx
+        .insert(economyGifts)
+        .values({
+          senderUserId: input.senderUserId,
+          recipientUserId: input.recipientUserId,
+          message: input.message,
+          idempotencyKey: input.idempotencyKey,
+          metadata: { assetCount: assets.length, currencyCount: currencies.length },
+        })
+        .returning()
+      if (!gift) throw apiError('GIFT_CREATE_FAILED', 500)
+
+      if (currencyAmount > 0) {
+        await this.deps.ledgerService.debit(
+          {
+            userId: input.senderUserId,
+            amount: currencyAmount,
+            type: 'purchase',
+            referenceId: gift.id,
+            referenceType: 'gift',
+            note: '社区赠送',
+          },
+          tx,
+        )
+        await this.deps.settlementService.createLine(
+          {
+            sellerUserId: input.recipientUserId,
+            sourceType: 'gift',
+            sourceId: gift.id,
+            grossAmount: currencyAmount,
+          },
+          tx,
+        )
+        await tx.insert(economyGiftItems).values(
+          currencies.map((item) => ({
+            giftId: gift.id,
+            itemKind: 'currency' as const,
+            currencyCode: item.currencyCode,
+            amount: item.amount,
+          })),
+        )
+      }
+
+      for (const [index, asset] of assets.entries()) {
+        const quantity = normalizeQuantity(asset.quantity)
+        const grant = await this.deps.communityAssetService.transferGrant(
+          {
+            actorUserId: input.senderUserId,
+            recipientUserId: input.recipientUserId,
+            grantId: asset.assetGrantId,
+            quantity,
+            referenceType: 'gift',
+            referenceId: gift.id,
+            idempotencyKey: `${input.idempotencyKey}:asset:${index}`,
+            actor,
+          },
+          tx,
+        )
+        await tx.insert(economyGiftItems).values({
+          giftId: gift.id,
+          itemKind: 'asset',
+          assetGrantId: grant.id,
+          assetDefinitionId: grant.definitionId,
+          quantity,
+        })
+      }
+
+      await this.deps.economyAuditService.record(
+        {
+          actor,
+          action: 'gift.send',
+          resource: { kind: 'gift', id: gift.id },
+          scope: { kind: 'user', id: input.recipientUserId },
+          idempotencyKey: input.idempotencyKey,
+          request: input,
+          result: 'succeeded',
+          metadata: { currencyAmount, assetCount: assets.length },
+        },
+        tx,
+      )
+
+      const response = { gift }
+      await this.deps.economyIdempotencyService.complete(
+        {
+          actorUserId: input.senderUserId,
+          key: input.idempotencyKey,
+          action: 'economy.gift.send',
+          referenceId: gift.id,
+          response,
+        },
+        tx,
+      )
+      return response
+    })
+  }
+
+  async listForUser(userId: string) {
+    return this.deps.db.select().from(economyGifts).where(eq(economyGifts.recipientUserId, userId))
+  }
+}

--- a/apps/server/src/services/order.service.ts
+++ b/apps/server/src/services/order.service.ts
@@ -3,18 +3,15 @@ import { nanoid } from 'nanoid'
 import type { OrderDao } from '../dao/order.dao'
 import type { ServerDao } from '../dao/server.dao'
 import type { Database } from '../db'
-import {
-  cartItems,
-  orderItems,
-  orders,
-  products,
-  skus,
-  wallets,
-  walletTransactions,
-} from '../db/schema'
+import { cartItems, orderItems, orders, products, skus } from '../db/schema'
+import { type Actor, actorFromUserId } from '../security/actor'
 import type { CartService } from './cart.service'
+import type { EconomyAuditService } from './economy-audit.service'
+import type { EconomyIdempotencyService } from './economy-idempotency.service'
+import type { EconomyPolicyService } from './economy-policy.service'
 import type { EntitlementService } from './entitlement.service'
 import { resolveProductEntitlementResource } from './entitlement-resource'
+import type { LedgerService } from './ledger.service'
 import type { ProductService } from './product.service'
 import type { ShopService } from './shop.service'
 import type { WalletService } from './wallet.service'
@@ -48,6 +45,10 @@ export class OrderService {
       serverDao: ServerDao
       productService: ProductService
       walletService: WalletService
+      ledgerService: LedgerService
+      economyPolicyService: EconomyPolicyService
+      economyAuditService: EconomyAuditService
+      economyIdempotencyService: EconomyIdempotencyService
       entitlementService: EntitlementService
       cartService: CartService
       shopService: ShopService
@@ -61,8 +62,35 @@ export class OrderService {
     shopId: string,
     items: Array<{ productId: string; skuId?: string; quantity: number }>,
     buyerNote?: string,
+    idempotencyKey?: string,
+    actor: Actor = actorFromUserId(buyerId),
   ) {
     if (items.length === 0) throw Object.assign(new Error('Cart is empty'), { status: 400 })
+    if (!idempotencyKey) {
+      throw Object.assign(new Error('idempotencyKey is required'), {
+        status: 400,
+        code: 'IDEMPOTENCY_KEY_REQUIRED',
+      })
+    }
+
+    await this.deps.economyPolicyService.authorize({
+      actor,
+      action: 'order.purchase',
+      resource: { kind: 'shop', id: shopId },
+      scope: { kind: 'shop', id: shopId },
+      dataClass: 'financial',
+      targetUserId: buyerId,
+    })
+
+    const cached = await this.deps.economyIdempotencyService.getCompleted<{
+      id: string
+      items: Array<Record<string, unknown>>
+    }>({
+      actorUserId: buyerId,
+      key: idempotencyKey,
+      action: 'shop.order.create',
+    })
+    if (cached) return cached
 
     // 1. Validate items and calculate total
     let totalAmount = 0
@@ -134,9 +162,16 @@ export class OrderService {
     // 2. Generate order number
     const orderNo = `SH${Date.now().toString(36).toUpperCase()}${nanoid(6).toUpperCase()}`
 
-    const wallet = await this.deps.walletService.getOrCreateWallet(buyerId)
-
     const order = await this.deps.db.transaction(async (tx) => {
+      await this.deps.economyIdempotencyService.begin(
+        {
+          actorUserId: buyerId,
+          key: idempotencyKey,
+          action: 'shop.order.create',
+        },
+        tx,
+      )
+
       for (const item of items) {
         if (!item.skuId) continue
         const stockRows = await tx
@@ -147,22 +182,6 @@ export class OrderService {
         if (stockRows.length === 0) {
           throw Object.assign(new Error('Insufficient stock'), { status: 400 })
         }
-      }
-
-      const debitRows = await tx
-        .update(wallets)
-        .set({ balance: sql`${wallets.balance} - ${totalAmount}`, updatedAt: new Date() })
-        .where(and(eq(wallets.id, wallet.id), sql`${wallets.balance} >= ${totalAmount}`))
-        .returning({ balance: wallets.balance })
-      if (debitRows.length === 0) {
-        throw Object.assign(new Error('Insufficient balance'), {
-          status: 402,
-          code: 'WALLET_INSUFFICIENT_BALANCE',
-          requiredAmount: totalAmount,
-          balance: wallet.balance,
-          shortfall: Math.max(totalAmount - wallet.balance, 0),
-          nextAction: 'earn_or_recharge',
-        })
       }
 
       const [createdOrder] = await tx
@@ -183,17 +202,49 @@ export class OrderService {
         ...item,
         orderId: createdOrder.id,
       }))
-      await tx.insert(orderItems).values(itemsWithOrderId)
+      const createdItems = await tx.insert(orderItems).values(itemsWithOrderId).returning()
 
-      await tx.insert(walletTransactions).values({
-        walletId: wallet.id,
-        type: 'purchase',
-        amount: -totalAmount,
-        balanceAfter: debitRows[0]!.balance,
-        referenceId: createdOrder.id,
-        referenceType: 'order',
-        note: `购买商品 - 订单 ${orderNo}`,
-      })
+      await this.deps.ledgerService.debit(
+        {
+          userId: buyerId,
+          amount: totalAmount,
+          type: 'purchase',
+          referenceId: createdOrder.id,
+          referenceType: 'order',
+          note: `购买商品 - 订单 ${orderNo}`,
+        },
+        tx,
+      )
+
+      await this.deps.economyAuditService.record(
+        {
+          actor,
+          action: 'shop.order.create',
+          resource: { kind: 'order', id: createdOrder.id },
+          scope: { kind: 'shop', id: shopId },
+          idempotencyKey,
+          request: { shopId, items, buyerNote },
+          result: 'succeeded',
+          metadata: { totalAmount },
+        },
+        tx,
+      )
+
+      const response = {
+        ...createdOrder,
+        items: createdItems,
+      }
+
+      await this.deps.economyIdempotencyService.complete(
+        {
+          actorUserId: buyerId,
+          key: idempotencyKey,
+          action: 'shop.order.create',
+          referenceId: createdOrder.id,
+          response,
+        },
+        tx,
+      )
 
       for (const item of items) {
         await tx
@@ -206,7 +257,7 @@ export class OrderService {
         .delete(cartItems)
         .where(and(eq(cartItems.userId, buyerId), eq(cartItems.shopId, shopId)))
 
-      return createdOrder
+      return response
     })
 
     // 9. Provision entitlements for entitlement-type products
@@ -241,7 +292,7 @@ export class OrderService {
       }
     }
 
-    return this.getOrderDetail(order.id)
+    return order
   }
 
   /* ───────── Query ───────── */
@@ -310,11 +361,7 @@ export class OrderService {
 
     // Settle: credit the shop owner (server owner) on order completion
     if (status === 'completed') {
-      try {
-        await this.settleOrder(currentOrder)
-      } catch {
-        // Settlement failure should not block order completion
-      }
+      await this.settleOrder(currentOrder)
     }
 
     return result

--- a/apps/server/src/services/paid-file.service.ts
+++ b/apps/server/src/services/paid-file.service.ts
@@ -95,7 +95,8 @@ export class PaidFileService {
         status: grant.status,
         expiresAt: grant.expiresAt,
       },
-      viewerUrl: `/api/paid-files/${fileId}/view/${grant.id}?token=${encodeURIComponent(token)}`,
+      grantToken: token,
+      viewerUrl: `/api/paid-files/${fileId}/view/${grant.id}`,
     }
   }
 

--- a/apps/server/src/services/product.service.ts
+++ b/apps/server/src/services/product.service.ts
@@ -149,17 +149,37 @@ export class ProductService {
     }
 
     if (skus !== undefined) {
-      await this.deps.skuDao.deleteByProductId(id)
+      const retainedSkuIds: string[] = []
       for (const s of skus) {
-        await this.deps.skuDao.create({
+        if (s.id) {
+          const existing = await this.deps.skuDao.findById(s.id)
+          if (!existing || existing.productId !== id) {
+            throw apiError('SKU_PRODUCT_MISMATCH', 400)
+          }
+          await this.deps.skuDao.update(s.id, {
+            specValues: s.specValues,
+            price: s.price,
+            stock: s.stock,
+            imageUrl: s.imageUrl,
+            skuCode: s.skuCode,
+            isActive: s.isActive ?? true,
+          })
+          retainedSkuIds.push(s.id)
+          continue
+        }
+
+        const created = await this.deps.skuDao.create({
           productId: id,
           specValues: s.specValues,
           price: s.price,
           stock: s.stock,
           imageUrl: s.imageUrl,
           skuCode: s.skuCode,
+          isActive: s.isActive ?? true,
         })
+        if (created) retainedSkuIds.push(created.id)
       }
+      await this.deps.skuDao.deactivateMissing(id, retainedSkuIds)
     }
 
     return this.getProductDetail(id)

--- a/apps/server/src/services/recharge.service.ts
+++ b/apps/server/src/services/recharge.service.ts
@@ -1,7 +1,8 @@
+import { createHash } from 'node:crypto'
 import { and, eq, ne } from 'drizzle-orm'
 import type { RechargeDao } from '../dao/recharge.dao'
 import type { Database } from '../db'
-import { paymentOrders } from '../db/schema'
+import { paymentOrders, paymentProviderEvents, riskCases } from '../db/schema'
 import {
   CUSTOM_AMOUNT_MAX,
   CUSTOM_AMOUNT_MIN,
@@ -11,8 +12,25 @@ import {
   shrimpCoinsToUsdCents,
   stripe,
 } from '../lib/stripe'
+import { type Actor, actorFromUserId } from '../security/actor'
+import type { EconomyAuditService } from './economy-audit.service'
+import type { EconomyIdempotencyService } from './economy-idempotency.service'
+import type { EconomyPolicyService } from './economy-policy.service'
 import type { LedgerService } from './ledger.service'
 import type { NotificationTriggerService } from './notification-trigger.service'
+
+function supportedStripeCurrencies() {
+  return new Set(
+    (process.env.SUPPORTED_STRIPE_CURRENCIES ?? 'usd')
+      .split(',')
+      .map((item) => item.trim().toLowerCase())
+      .filter(Boolean),
+  )
+}
+
+function hashPayload(value: unknown) {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex')
+}
 
 export class RechargeService {
   constructor(
@@ -20,6 +38,9 @@ export class RechargeService {
       rechargeDao: RechargeDao
       db: Database
       ledgerService: LedgerService
+      economyPolicyService: EconomyPolicyService
+      economyAuditService: EconomyAuditService
+      economyIdempotencyService: EconomyIdempotencyService
       notificationTriggerService: NotificationTriggerService
     },
   ) {}
@@ -49,9 +70,47 @@ export class RechargeService {
     tier: RechargeTierKey | 'custom',
     customAmount?: number,
     currency = 'usd',
+    actor: Actor = actorFromUserId(userId),
+    idempotencyKey?: string,
   ) {
     if (!stripe) {
       throw Object.assign(new Error('Payment service unavailable'), { status: 503 })
+    }
+
+    await this.deps.economyPolicyService.authorize({
+      actor,
+      action: 'recharge.create',
+      resource: { kind: 'payment_order' },
+      scope: { kind: 'wallet', id: userId },
+      dataClass: 'financial',
+      targetUserId: userId,
+    })
+
+    if (!idempotencyKey) {
+      throw Object.assign(new Error('idempotencyKey is required'), {
+        status: 400,
+        code: 'IDEMPOTENCY_KEY_REQUIRED',
+      })
+    }
+
+    const cached = await this.deps.economyIdempotencyService.getCompleted<{
+      clientSecret: string
+      paymentIntentId: string
+      orderNo: string
+      amount: { shrimpCoins: number; usdCents: number }
+    }>({
+      actorUserId: userId,
+      key: idempotencyKey,
+      action: 'recharge.create-intent',
+    })
+    if (cached) return cached
+
+    const normalizedCurrency = currency.toLowerCase()
+    if (!supportedStripeCurrencies().has(normalizedCurrency)) {
+      throw Object.assign(new Error('Unsupported payment currency'), {
+        status: 400,
+        code: 'UNSUPPORTED_PAYMENT_CURRENCY',
+      })
     }
 
     // Determine amounts
@@ -84,38 +143,86 @@ export class RechargeService {
 
     const orderNo = generateOrderNo()
 
-    // Create Stripe PaymentIntent
-    const paymentIntent = await stripe.paymentIntents.create(
-      {
-        amount: usdCents,
-        currency,
-        automatic_payment_methods: { enabled: true },
-        metadata: {
-          userId,
-          orderNo,
-          shrimpCoins: String(shrimpCoins),
-        },
-      },
-      { idempotencyKey: `recharge-${orderNo}` },
-    )
-
-    // Create local payment order record
-    const order = await this.deps.rechargeDao.createPaymentOrder({
-      userId,
-      orderNo,
-      shrimpCoinAmount: shrimpCoins,
-      usdAmount: usdCents,
-      stripePaymentIntentId: paymentIntent.id,
+    await this.deps.economyIdempotencyService.begin({
+      actorUserId: userId,
+      key: idempotencyKey,
+      action: 'recharge.create-intent',
     })
 
-    return {
-      clientSecret: paymentIntent.client_secret!,
-      paymentIntentId: paymentIntent.id,
-      orderNo: order.orderNo,
-      amount: {
-        shrimpCoins,
-        usdCents,
-      },
+    try {
+      // Create Stripe PaymentIntent
+      const paymentIntent = await stripe.paymentIntents.create(
+        {
+          amount: usdCents,
+          currency: normalizedCurrency,
+          automatic_payment_methods: { enabled: true },
+          metadata: {
+            userId,
+            orderNo,
+            shrimpCoins: String(shrimpCoins),
+          },
+        },
+        { idempotencyKey: `recharge-${userId}-${idempotencyKey}` },
+      )
+
+      // Create local payment order record
+      const order = await this.deps.rechargeDao.createPaymentOrder({
+        userId,
+        orderNo,
+        shrimpCoinAmount: shrimpCoins,
+        usdAmount: usdCents,
+        stripePaymentIntentId: paymentIntent.id,
+      })
+
+      await this.deps.economyAuditService.record({
+        actor,
+        action: 'recharge.create-intent',
+        resource: { kind: 'payment_order', id: order.id },
+        scope: { kind: 'wallet', id: userId },
+        idempotencyKey,
+        request: { tier, customAmount, currency: normalizedCurrency },
+        result: 'succeeded',
+        metadata: { stripePaymentIntentId: paymentIntent.id, shrimpCoins, usdCents },
+      })
+
+      const response = {
+        clientSecret: paymentIntent.client_secret!,
+        paymentIntentId: paymentIntent.id,
+        orderNo: order.orderNo,
+        amount: {
+          shrimpCoins,
+          usdCents,
+        },
+      }
+
+      await this.deps.economyIdempotencyService.complete({
+        actorUserId: userId,
+        key: idempotencyKey,
+        action: 'recharge.create-intent',
+        referenceId: order.id,
+        response,
+      })
+
+      return response
+    } catch (err) {
+      const errorCode = (err as { code?: string }).code ?? 'RECHARGE_CREATE_INTENT_FAILED'
+      await this.deps.economyIdempotencyService.fail({
+        actorUserId: userId,
+        key: idempotencyKey,
+        action: 'recharge.create-intent',
+        error: errorCode,
+      })
+      await this.deps.economyAuditService.record({
+        actor,
+        action: 'recharge.create-intent',
+        resource: { kind: 'payment_order' },
+        scope: { kind: 'wallet', id: userId },
+        idempotencyKey,
+        request: { tier, customAmount, currency: normalizedCurrency },
+        result: 'failed',
+        errorCode,
+      })
+      throw err
     }
   }
 
@@ -123,23 +230,77 @@ export class RechargeService {
    * Handle Stripe webhook events.
    * This is the primary way payments are confirmed — NOT client-side confirmation.
    */
-  async handleWebhookEvent(event: { type: string; data: { object: Record<string, unknown> } }) {
+  async handleWebhookEvent(event: {
+    id?: string
+    type: string
+    data: { object: Record<string, unknown> }
+  }) {
+    const providerEventId =
+      event.id ??
+      `${event.type}:${typeof event.data.object.id === 'string' ? event.data.object.id : hashPayload(event)}`
+    const payloadHash = hashPayload(event)
+    const inserted = await this.deps.db
+      .insert(paymentProviderEvents)
+      .values({
+        provider: 'stripe',
+        providerEventId,
+        eventType: event.type,
+        payloadHash,
+        status: 'processing',
+      })
+      .onConflictDoNothing()
+      .returning({ id: paymentProviderEvents.id })
+
+    if (inserted.length === 0) return
+
     const obj = event.data.object
 
-    switch (event.type) {
-      case 'payment_intent.succeeded':
-        await this.handlePaymentSucceeded(obj)
-        break
-      case 'payment_intent.payment_failed':
-        await this.handlePaymentFailed(obj)
-        break
-      case 'payment_intent.canceled':
-        await this.handlePaymentCanceled(obj)
-        break
-      case 'charge.dispute.created':
-        await this.handleDisputeCreated(obj)
-        break
+    try {
+      switch (event.type) {
+        case 'payment_intent.succeeded':
+          await this.handlePaymentSucceeded(obj)
+          break
+        case 'payment_intent.payment_failed':
+          await this.handlePaymentFailed(obj)
+          break
+        case 'payment_intent.canceled':
+          await this.handlePaymentCanceled(obj)
+          break
+        case 'charge.dispute.created':
+          await this.handleDisputeCreated(obj)
+          break
+        default:
+          await this.markProviderEvent(providerEventId, 'ignored')
+          return
+      }
+      await this.markProviderEvent(providerEventId, 'processed')
+    } catch (err) {
+      await this.markProviderEvent(providerEventId, 'failed', {
+        errorCode: (err as { code?: string }).code ?? 'STRIPE_WEBHOOK_PROCESSING_FAILED',
+      })
+      throw err
     }
+  }
+
+  private async markProviderEvent(
+    providerEventId: string,
+    status: 'processed' | 'failed' | 'ignored',
+    opts?: { errorCode?: string },
+  ) {
+    await this.deps.db
+      .update(paymentProviderEvents)
+      .set({
+        status,
+        errorCode: opts?.errorCode,
+        processedAt: status === 'processed' || status === 'ignored' ? new Date() : undefined,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(paymentProviderEvents.provider, 'stripe'),
+          eq(paymentProviderEvents.providerEventId, providerEventId),
+        ),
+      )
   }
 
   private async handlePaymentSucceeded(paymentIntent: Record<string, unknown>) {
@@ -210,8 +371,28 @@ export class RechargeService {
     if (!order) return
 
     await this.deps.rechargeDao.updateStatus(order.id, 'disputed')
-    // Log the dispute for manual review
-    console.error(`[DISPUTE] Order ${order.orderNo} disputed. PaymentIntent: ${piId}`)
+    await this.deps.db.insert(riskCases).values({
+      userId: order.userId,
+      resourceType: 'payment_order',
+      resourceId: order.id,
+      kind: 'payment_dispute',
+      status: 'open',
+      severity: 'high',
+      metadata: { stripePaymentIntentId: piId, disputeId: dispute.id },
+    })
+
+    await this.deps.economyAuditService.record({
+      actor: {
+        kind: 'system',
+        service: 'stripe-webhook',
+        capabilities: ['economy:recharge:write'],
+      },
+      action: 'recharge.dispute.created',
+      resource: { kind: 'payment_order', id: order.id },
+      scope: { kind: 'wallet', id: order.userId },
+      result: 'succeeded',
+      metadata: { stripePaymentIntentId: piId, orderNo: order.orderNo },
+    })
   }
 
   /** Get a user's recharge history. */

--- a/apps/server/src/services/settlement.service.ts
+++ b/apps/server/src/services/settlement.service.ts
@@ -1,0 +1,315 @@
+import { and, eq, inArray, lte, sql } from 'drizzle-orm'
+import type { Database } from '../db'
+import { settlementAccounts, settlementLines } from '../db/schema'
+import { apiError } from '../lib/api-error'
+import type { LedgerService } from './ledger.service'
+
+type DbLike = Database | Parameters<Parameters<Database['transaction']>[0]>[0]
+type SettlementLine = typeof settlementLines.$inferSelect
+
+function settlementDelayDays() {
+  const value = Number.parseInt(process.env.SHADOW_COMMERCE_SETTLEMENT_DELAY_DAYS ?? '', 10)
+  return Number.isFinite(value) && value > 0 ? value : 0
+}
+
+function platformFeeBps() {
+  const value = Number.parseInt(process.env.SHADOW_COMMERCE_PLATFORM_FEE_BPS ?? '', 10)
+  return Number.isFinite(value) && value > 0 ? Math.min(value, 10_000) : 0
+}
+
+function addDays(days: number) {
+  return days > 0 ? new Date(Date.now() + days * 86_400_000) : new Date()
+}
+
+export class SettlementService {
+  constructor(private deps: { db: Database; ledgerService: LedgerService }) {}
+
+  private async adjustAccount(
+    db: DbLike,
+    userId: string,
+    delta: { pending?: number; available?: number; held?: number },
+  ) {
+    await db
+      .update(settlementAccounts)
+      .set({
+        pendingBalance:
+          delta.pending != null
+            ? sql`${settlementAccounts.pendingBalance} + ${delta.pending}`
+            : sql`${settlementAccounts.pendingBalance}`,
+        availableBalance:
+          delta.available != null
+            ? sql`${settlementAccounts.availableBalance} + ${delta.available}`
+            : sql`${settlementAccounts.availableBalance}`,
+        heldBalance:
+          delta.held != null
+            ? sql`${settlementAccounts.heldBalance} + ${delta.held}`
+            : sql`${settlementAccounts.heldBalance}`,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(settlementAccounts.ownerKind, 'user'),
+          eq(settlementAccounts.ownerId, userId),
+          eq(settlementAccounts.currencyCode, 'shrimp_coin'),
+        ),
+      )
+  }
+
+  async createLine(
+    input: {
+      sellerUserId: string
+      shopId?: string | null
+      sourceType: 'order' | 'tip' | 'gift' | 'adjustment'
+      sourceId: string
+      grossAmount: number
+      platformFee?: number
+      status?: 'pending' | 'available' | 'held'
+    },
+    db: DbLike = this.deps.db,
+  ) {
+    if (!Number.isFinite(input.grossAmount) || input.grossAmount <= 0) {
+      throw apiError('SETTLEMENT_AMOUNT_INVALID', 400)
+    }
+    const fee = input.platformFee ?? Math.floor((input.grossAmount * platformFeeBps()) / 10_000)
+    const net = Math.max(input.grossAmount - fee, 0)
+    const delayDays = settlementDelayDays()
+    const status = input.status ?? (delayDays > 0 ? 'pending' : 'available')
+    const availableAt = status === 'pending' ? addDays(delayDays) : new Date()
+
+    await db
+      .insert(settlementAccounts)
+      .values({
+        ownerKind: 'user',
+        ownerId: input.sellerUserId,
+        currencyCode: 'shrimp_coin',
+      })
+      .onConflictDoNothing()
+
+    const [line] = await db
+      .insert(settlementLines)
+      .values({
+        sellerUserId: input.sellerUserId,
+        shopId: input.shopId ?? undefined,
+        sourceType: input.sourceType,
+        sourceId: input.sourceId,
+        grossAmount: input.grossAmount,
+        platformFee: fee,
+        netAmount: net,
+        status,
+        availableAt,
+      })
+      .returning()
+    if (!line) throw apiError('SETTLEMENT_LINE_CREATE_FAILED', 500)
+
+    await db
+      .update(settlementAccounts)
+      .set({
+        pendingBalance:
+          status === 'pending'
+            ? sql`${settlementAccounts.pendingBalance} + ${net}`
+            : sql`${settlementAccounts.pendingBalance}`,
+        availableBalance:
+          status === 'available'
+            ? sql`${settlementAccounts.availableBalance} + ${net}`
+            : sql`${settlementAccounts.availableBalance}`,
+        heldBalance:
+          status === 'held'
+            ? sql`${settlementAccounts.heldBalance} + ${net}`
+            : sql`${settlementAccounts.heldBalance}`,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(settlementAccounts.ownerKind, 'user'),
+          eq(settlementAccounts.ownerId, input.sellerUserId),
+          eq(settlementAccounts.currencyCode, 'shrimp_coin'),
+        ),
+      )
+
+    return line
+  }
+
+  async listForUser(userId: string, limit = 50, offset = 0) {
+    return this.deps.db
+      .select()
+      .from(settlementLines)
+      .where(eq(settlementLines.sellerUserId, userId))
+      .limit(Math.min(Math.max(limit, 1), 100))
+      .offset(Math.max(offset, 0))
+  }
+
+  async makePendingAvailableForUser(
+    userId: string,
+    limit = 500,
+    db: DbLike = this.deps.db,
+    now = new Date(),
+  ) {
+    const lines = await db
+      .select()
+      .from(settlementLines)
+      .where(
+        and(
+          eq(settlementLines.sellerUserId, userId),
+          eq(settlementLines.status, 'pending'),
+          lte(settlementLines.availableAt, now),
+        ),
+      )
+      .limit(Math.min(Math.max(limit, 1), 500))
+
+    const released: SettlementLine[] = []
+    for (const line of lines) {
+      const [updated] = await db
+        .update(settlementLines)
+        .set({ status: 'available', updatedAt: new Date() })
+        .where(and(eq(settlementLines.id, line.id), eq(settlementLines.status, 'pending')))
+        .returning()
+      if (!updated || !line.sellerUserId) continue
+      await this.adjustAccount(db, line.sellerUserId, {
+        pending: -line.netAmount,
+        available: line.netAmount,
+      })
+      released.push(updated)
+    }
+    return released
+  }
+
+  async holdLinesForSource(
+    input: { sourceType: string; sourceId: string; reason?: string },
+    db: DbLike = this.deps.db,
+  ) {
+    const lines = await db
+      .select()
+      .from(settlementLines)
+      .where(
+        and(
+          eq(settlementLines.sourceType, input.sourceType),
+          eq(settlementLines.sourceId, input.sourceId),
+          inArray(settlementLines.status, ['pending', 'available']),
+        ),
+      )
+
+    const held: SettlementLine[] = []
+    for (const line of lines) {
+      const [updated] = await db
+        .update(settlementLines)
+        .set({
+          status: 'held',
+          heldAmount: line.netAmount,
+          errorCode: input.reason ?? 'settlement_held',
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(settlementLines.id, line.id),
+            inArray(settlementLines.status, ['pending', 'available']),
+          ),
+        )
+        .returning()
+      if (!updated || !line.sellerUserId) continue
+      await this.adjustAccount(db, line.sellerUserId, {
+        pending: line.status === 'pending' ? -line.netAmount : 0,
+        available: line.status === 'available' ? -line.netAmount : 0,
+        held: line.netAmount,
+      })
+      held.push(updated)
+    }
+    return held
+  }
+
+  async reverseLinesForSource(
+    input: { sourceType: string; sourceId: string; reason?: string },
+    db: DbLike = this.deps.db,
+  ) {
+    const lines = await db
+      .select()
+      .from(settlementLines)
+      .where(
+        and(
+          eq(settlementLines.sourceType, input.sourceType),
+          eq(settlementLines.sourceId, input.sourceId),
+          inArray(settlementLines.status, ['pending', 'available', 'held']),
+        ),
+      )
+
+    const reversed: SettlementLine[] = []
+    for (const line of lines) {
+      const [updated] = await db
+        .update(settlementLines)
+        .set({
+          status: 'reversed',
+          refundAmount: line.netAmount,
+          errorCode: input.reason ?? 'settlement_reversed',
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(settlementLines.id, line.id),
+            inArray(settlementLines.status, ['pending', 'available', 'held']),
+          ),
+        )
+        .returning()
+      if (!updated || !line.sellerUserId) continue
+      await this.adjustAccount(db, line.sellerUserId, {
+        pending: line.status === 'pending' ? -line.netAmount : 0,
+        available: line.status === 'available' ? -line.netAmount : 0,
+        held: line.status === 'held' ? -line.netAmount : 0,
+      })
+      reversed.push(updated)
+    }
+    return reversed
+  }
+
+  async settleAvailableForUser(userId: string, limit = 50) {
+    return this.deps.db.transaction(async (tx) => {
+      await this.makePendingAvailableForUser(userId, limit, tx)
+      const lines = await tx
+        .select()
+        .from(settlementLines)
+        .where(
+          and(
+            eq(settlementLines.sellerUserId, userId),
+            eq(settlementLines.status, 'available'),
+            lte(settlementLines.availableAt, new Date()),
+          ),
+        )
+        .limit(Math.min(Math.max(limit, 1), 100))
+
+      for (const line of lines) {
+        await this.deps.ledgerService.credit(
+          {
+            userId,
+            amount: line.netAmount,
+            type: 'settlement',
+            referenceId: line.id,
+            referenceType: 'settlement_line',
+            note: `社区经济结算 - ${line.sourceType}`,
+          },
+          tx,
+        )
+        await tx
+          .update(settlementLines)
+          .set({ status: 'settled', settledAt: new Date(), updatedAt: new Date() })
+          .where(eq(settlementLines.id, line.id))
+      }
+
+      if (lines.length > 0) {
+        const total = lines.reduce((sum, line) => sum + line.netAmount, 0)
+        await tx
+          .update(settlementAccounts)
+          .set({
+            availableBalance: sql`${settlementAccounts.availableBalance} - ${total}`,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(settlementAccounts.ownerKind, 'user'),
+              eq(settlementAccounts.ownerId, userId),
+              eq(settlementAccounts.currencyCode, 'shrimp_coin'),
+            ),
+          )
+      }
+
+      return lines
+    })
+  }
+}

--- a/apps/server/src/services/tip.service.ts
+++ b/apps/server/src/services/tip.service.ts
@@ -1,0 +1,199 @@
+import { and, eq, gte, sql } from 'drizzle-orm'
+import type { Database } from '../db'
+import { economyTips } from '../db/schema'
+import { apiError } from '../lib/api-error'
+import { type Actor, actorFromUserId } from '../security/actor'
+import type { EconomyAuditService } from './economy-audit.service'
+import type { EconomyIdempotencyService } from './economy-idempotency.service'
+import type { EconomyPolicyService } from './economy-policy.service'
+import type { LedgerService } from './ledger.service'
+import type { SettlementService } from './settlement.service'
+
+function maxTipAmount() {
+  const value = Number.parseInt(process.env.SHADOW_MAX_TIP_AMOUNT ?? '', 10)
+  return Number.isFinite(value) && value > 0 ? value : 100_000
+}
+
+function positiveIntEnv(name: string, fallback: number) {
+  const value = Number.parseInt(process.env[name] ?? '', 10)
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function startOfUtcDay(date = new Date()) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+}
+
+export class TipService {
+  constructor(
+    private deps: {
+      db: Database
+      ledgerService: LedgerService
+      settlementService: SettlementService
+      economyPolicyService: EconomyPolicyService
+      economyAuditService: EconomyAuditService
+      economyIdempotencyService: EconomyIdempotencyService
+    },
+  ) {}
+
+  private async enforceTipLimits(input: {
+    senderUserId: string
+    amount: number
+    context?: { kind: string; id: string }
+  }) {
+    const since = startOfUtcDay()
+    const [daily] = await this.deps.db
+      .select({
+        count: sql<number>`count(*)::int`,
+        amount: sql<number>`coalesce(sum(${economyTips.amount}), 0)::int`,
+      })
+      .from(economyTips)
+      .where(
+        and(eq(economyTips.senderUserId, input.senderUserId), gte(economyTips.createdAt, since)),
+      )
+    const dailyCount = Number(daily?.count ?? 0)
+    const dailyAmount = Number(daily?.amount ?? 0)
+    const dailyCountLimit = positiveIntEnv('SHADOW_TIP_DAILY_COUNT_LIMIT', 100)
+    const dailyAmountLimit = positiveIntEnv('SHADOW_TIP_DAILY_AMOUNT_LIMIT', 1_000_000)
+    if (dailyCount >= dailyCountLimit) {
+      throw apiError('TIP_DAILY_COUNT_LIMIT_EXCEEDED', 429, { dailyCountLimit })
+    }
+    if (dailyAmount + input.amount > dailyAmountLimit) {
+      throw apiError('TIP_DAILY_AMOUNT_LIMIT_EXCEEDED', 429, { dailyAmountLimit })
+    }
+
+    if (!input.context) return
+    const [contextDaily] = await this.deps.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(economyTips)
+      .where(
+        and(
+          eq(economyTips.senderUserId, input.senderUserId),
+          eq(economyTips.contextKind, input.context.kind),
+          eq(economyTips.contextId, input.context.id),
+          gte(economyTips.createdAt, since),
+        ),
+      )
+    const contextCount = Number(contextDaily?.count ?? 0)
+    const contextLimit = positiveIntEnv('SHADOW_TIP_CONTEXT_DAILY_COUNT_LIMIT', 20)
+    if (contextCount >= contextLimit) {
+      throw apiError('TIP_CONTEXT_DAILY_LIMIT_EXCEEDED', 429, { contextLimit })
+    }
+  }
+
+  async sendTip(input: {
+    senderUserId: string
+    recipientUserId: string
+    amount: number
+    message?: string
+    context?: { kind: string; id: string }
+    idempotencyKey: string
+    actor?: Actor
+  }) {
+    if (input.senderUserId === input.recipientUserId) {
+      throw apiError('TIP_SELF_NOT_ALLOWED', 400)
+    }
+    if (!Number.isFinite(input.amount) || input.amount <= 0 || input.amount > maxTipAmount()) {
+      throw apiError('TIP_AMOUNT_INVALID', 400, { maxAmount: maxTipAmount() })
+    }
+    const actor = input.actor ?? actorFromUserId(input.senderUserId)
+    await this.deps.economyPolicyService.authorize({
+      actor,
+      action: 'tip.send',
+      resource: { kind: 'user', id: input.recipientUserId },
+      scope: input.context
+        ? { kind: input.context.kind, id: input.context.id }
+        : { kind: 'user', id: input.recipientUserId },
+      dataClass: 'financial',
+      targetUserId: input.senderUserId,
+    })
+
+    const cached = await this.deps.economyIdempotencyService.getCompleted({
+      actorUserId: input.senderUserId,
+      key: input.idempotencyKey,
+      action: 'economy.tip.send',
+    })
+    if (cached) return cached
+    await this.enforceTipLimits(input)
+
+    return this.deps.db.transaction(async (tx) => {
+      await this.deps.economyIdempotencyService.begin(
+        {
+          actorUserId: input.senderUserId,
+          key: input.idempotencyKey,
+          action: 'economy.tip.send',
+        },
+        tx,
+      )
+
+      const [tip] = await tx
+        .insert(economyTips)
+        .values({
+          senderUserId: input.senderUserId,
+          recipientUserId: input.recipientUserId,
+          amount: input.amount,
+          contextKind: input.context?.kind,
+          contextId: input.context?.id,
+          message: input.message,
+          sellerNet: input.amount,
+          idempotencyKey: input.idempotencyKey,
+        })
+        .returning()
+      if (!tip) throw apiError('TIP_CREATE_FAILED', 500)
+
+      await this.deps.ledgerService.debit(
+        {
+          userId: input.senderUserId,
+          amount: input.amount,
+          type: 'purchase',
+          referenceId: tip.id,
+          referenceType: 'tip',
+          note: '社区打赏',
+        },
+        tx,
+      )
+
+      await this.deps.settlementService.createLine(
+        {
+          sellerUserId: input.recipientUserId,
+          sourceType: 'tip',
+          sourceId: tip.id,
+          grossAmount: input.amount,
+        },
+        tx,
+      )
+
+      await this.deps.economyAuditService.record(
+        {
+          actor,
+          action: 'tip.send',
+          resource: { kind: 'tip', id: tip.id },
+          scope: input.context
+            ? { kind: input.context.kind, id: input.context.id }
+            : { kind: 'user', id: input.recipientUserId },
+          idempotencyKey: input.idempotencyKey,
+          request: input,
+          result: 'succeeded',
+          metadata: { amount: input.amount, recipientUserId: input.recipientUserId },
+        },
+        tx,
+      )
+
+      const response = { tip }
+      await this.deps.economyIdempotencyService.complete(
+        {
+          actorUserId: input.senderUserId,
+          key: input.idempotencyKey,
+          action: 'economy.tip.send',
+          referenceId: tip.id,
+          response,
+        },
+        tx,
+      )
+      return response
+    })
+  }
+
+  async listForUser(userId: string) {
+    return this.deps.db.select().from(economyTips).where(eq(economyTips.recipientUserId, userId))
+  }
+}

--- a/apps/server/src/validators/message.schema.ts
+++ b/apps/server/src/validators/message.schema.ts
@@ -137,19 +137,36 @@ const paidFileCardSchema = z.object({
   action: z.record(z.unknown()).optional(),
 })
 
-const metadataSchema = z
-  .object({
-    agentChain: agentChainSchema.optional(),
-    interactive: interactiveBlockSchema.optional(),
-    interactiveResponse: interactiveResponseSchema.optional(),
-    mentions: messageMentionsSchema.optional(),
-    commerceCards: z
-      .array(z.union([commerceOfferCardSchema, commerceProductCardSchema]))
-      .max(3)
-      .optional(),
-    paidFileCards: z.array(paidFileCardSchema).max(3).optional(),
-  })
-  .passthrough() // Allow additional custom metadata
+const commerceFulfillmentSchema = z.object({
+  jobId: z.string().uuid(),
+  deliverableId: z.string().uuid(),
+})
+
+const playLaunchSchema = z.union([
+  z.boolean(),
+  z.object({
+    kind: z.enum(['public_channel', 'private_room', 'cloud_deploy']).optional(),
+    playId: z.string().max(120).nullable().optional(),
+    deploymentId: z.string().uuid().optional(),
+    templateSlug: z.string().max(160).optional(),
+  }),
+])
+
+export const metadataSchema = z.object({
+  agentChain: agentChainSchema.optional(),
+  interactive: interactiveBlockSchema.optional(),
+  interactiveResponse: interactiveResponseSchema.optional(),
+  mentions: messageMentionsSchema.optional(),
+  commerceOfferId: z.string().uuid().optional(),
+  commerceCards: z
+    .array(z.union([commerceOfferCardSchema, commerceProductCardSchema]))
+    .max(3)
+    .optional(),
+  paidFileCards: z.array(paidFileCardSchema).max(3).optional(),
+  commerceFulfillment: commerceFulfillmentSchema.optional(),
+  playLaunch: playLaunchSchema.optional(),
+  custom: z.record(z.unknown()).optional(),
+})
 
 export const sendMessageSchema = z.object({
   content: z

--- a/apps/server/src/validators/shop.schema.ts
+++ b/apps/server/src/validators/shop.schema.ts
@@ -96,6 +96,7 @@ export const updateCartItemSchema = z.object({
 /* ═══════════════ Order ═══════════════ */
 
 export const createOrderSchema = z.object({
+  idempotencyKey: z.string().min(8).max(200),
   items: z
     .array(
       z.object({

--- a/apps/web/__tests__/community-economy-wallet-ui.test.tsx
+++ b/apps/web/__tests__/community-economy-wallet-ui.test.tsx
@@ -1,0 +1,234 @@
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WalletSettings } from '../src/pages/settings/wallet'
+
+const fetchApiMock = vi.fn()
+
+vi.mock('../src/lib/api', () => ({
+  fetchApi: (path: string, options?: RequestInit) => fetchApiMock(path, options),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('../src/stores/recharge.store', () => ({
+  useRechargeStore: () => ({ openModal: vi.fn() }),
+}))
+
+vi.mock('../src/pages/commerce', () => ({
+  EntitlementsPage: () => <div>commerce.entitlements</div>,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown> | string) => {
+      if (key === 'communityEconomy.assetCount' && typeof options === 'object') {
+        return `${options.count} communityEconomy.assetCount`
+      }
+      return key
+    },
+  }),
+}))
+
+function renderWithQuery(ui: React.ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+function mockCommunityEconomyApi() {
+  fetchApiMock.mockImplementation((path: string, options?: RequestInit) => {
+    if (path === '/api/wallet') {
+      return Promise.resolve({ id: 'wallet-1', balance: 500, frozenAmount: 0 })
+    }
+    if (path.startsWith('/api/wallet/transactions/count')) {
+      return Promise.resolve({ count: 0 })
+    }
+    if (path.startsWith('/api/wallet/transactions')) {
+      return Promise.resolve([])
+    }
+    if (path === '/api/friends') {
+      return Promise.resolve([
+        {
+          friendshipId: 'friendship-1',
+          source: 'friend',
+          createdAt: '2026-05-01T00:00:00.000Z',
+          user: {
+            id: 'recipient-1',
+            username: 'recipient_one',
+            displayName: 'Recipient One',
+            avatarUrl: null,
+            status: 'online',
+            isBot: false,
+          },
+        },
+        {
+          friendshipId: 'friendship-2',
+          source: 'friend',
+          createdAt: '2026-05-01T00:00:00.000Z',
+          user: {
+            id: 'recipient-2',
+            username: 'recipient_two',
+            displayName: 'Recipient Two',
+            avatarUrl: null,
+            status: 'online',
+            isBot: false,
+          },
+        },
+      ])
+    }
+    if (path === '/api/dm/channels') {
+      return Promise.resolve([])
+    }
+    if (path === '/api/economy/assets') {
+      return Promise.resolve({
+        assets: [
+          {
+            grant: {
+              id: 'grant-1',
+              definitionId: 'asset-1',
+              ownerUserId: 'user-1',
+              quantity: 2,
+              remainingQuantity: 2,
+              status: 'active',
+              expiresAt: null,
+            },
+            definition: {
+              id: 'asset-1',
+              assetType: 'badge',
+              name: 'Founding Badge',
+              description: 'Early supporter badge',
+              imageUrl: null,
+              giftable: true,
+              consumable: true,
+              status: 'published',
+            },
+          },
+        ],
+      })
+    }
+    if (path.startsWith('/api/economy/assets/grant-1/')) {
+      return Promise.resolve({ grant: { id: 'grant-1', status: 'active' } })
+    }
+    if (path.startsWith('/api/economy/settlements')) {
+      if (path === '/api/economy/settlements/settle') {
+        return Promise.resolve({ settlements: [] })
+      }
+      return Promise.resolve({
+        settlements: [
+          {
+            id: 'settlement-1',
+            sellerUserId: 'seller-1',
+            sourceType: 'gift',
+            sourceId: 'gift-1',
+            grossAmount: 100,
+            platformFee: 10,
+            netAmount: 90,
+            status: 'available',
+            availableAt: '2026-05-01T00:00:00.000Z',
+            settledAt: null,
+          },
+        ],
+      })
+    }
+    if (path === '/api/economy/tips' || path === '/api/economy/gifts') {
+      return Promise.resolve({ ok: true, body: options?.body })
+    }
+    return Promise.resolve({})
+  })
+}
+
+beforeEach(() => {
+  fetchApiMock.mockReset()
+  mockCommunityEconomyApi()
+  vi.spyOn(window, 'confirm').mockReturnValue(true)
+})
+
+describe('Community economy wallet UI', () => {
+  it('renders assets and sends lifecycle actions through the economy API', async () => {
+    renderWithQuery(<WalletSettings initialSection="assets" />)
+
+    expect(await screen.findByText('Founding Badge')).toBeTruthy()
+
+    await userEvent.click(screen.getByRole('button', { name: 'communityEconomy.consume' }))
+
+    await waitFor(() => {
+      expect(fetchApiMock).toHaveBeenCalledWith(
+        '/api/economy/assets/grant-1/consume',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+
+  it('renders settlement lines and settles available balance', async () => {
+    renderWithQuery(<WalletSettings initialSection="settlements" />)
+
+    expect(await screen.findByText('communityEconomy.source.gift')).toBeTruthy()
+
+    await userEvent.click(screen.getByRole('button', { name: 'communityEconomy.settleAvailable' }))
+
+    await waitFor(() => {
+      expect(fetchApiMock).toHaveBeenCalledWith(
+        '/api/economy/settlements/settle',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+
+  it('submits tips through the recipient picker with idempotency keys', async () => {
+    renderWithQuery(<WalletSettings initialSection="actions" />)
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'communityEconomy.sendTip' })[0]!)
+    await userEvent.click(await screen.findByText('Recipient One'))
+    await userEvent.click(screen.getByRole('button', { name: '10' }))
+    const tipButtons = screen.getAllByRole('button', { name: 'communityEconomy.sendTip' })
+    await userEvent.click(tipButtons[tipButtons.length - 1]!)
+
+    await waitFor(() => {
+      const tipCall = fetchApiMock.mock.calls.find(([path]) => path === '/api/economy/tips')
+      expect(tipCall).toBeTruthy()
+      expect(JSON.parse(String(tipCall?.[1]?.body))).toEqual(
+        expect.objectContaining({
+          recipientUserId: 'recipient-1',
+          amount: 10,
+          idempotencyKey: expect.any(String),
+        }),
+      )
+    })
+  })
+
+  it('submits gifts through the recipient picker with selected assets', async () => {
+    renderWithQuery(<WalletSettings initialSection="actions" />)
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'communityEconomy.sendGift' })[0]!)
+    await userEvent.click(await screen.findByText('Recipient Two'))
+    await userEvent.click(screen.getByRole('button', { name: '50' }))
+    await userEvent.click(screen.getByText('Founding Badge'))
+    const giftButtons = screen.getAllByRole('button', { name: 'communityEconomy.sendGift' })
+    await userEvent.click(giftButtons[giftButtons.length - 1]!)
+
+    await waitFor(() => {
+      const giftCall = fetchApiMock.mock.calls.find(([path]) => path === '/api/economy/gifts')
+      expect(giftCall).toBeTruthy()
+      expect(JSON.parse(String(giftCall?.[1]?.body))).toEqual(
+        expect.objectContaining({
+          recipientUserId: 'recipient-2',
+          currencies: [{ currencyCode: 'shrimp_coin', amount: 50 }],
+          assets: [{ assetGrantId: 'grant-1', quantity: 1 }],
+          idempotencyKey: expect.any(String),
+        }),
+      )
+    })
+  })
+})

--- a/apps/web/src/components/chat/message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble.tsx
@@ -13,6 +13,8 @@ import {
   Copy,
   ExternalLink,
   FileText,
+  Gift,
+  HandCoins,
   Hash,
   Lock,
   MoreHorizontal,
@@ -40,6 +42,7 @@ import { UserAvatar } from '../common/avatar'
 import { useConfirmStore } from '../common/confirm-dialog'
 import { EmojiPicker } from '../common/emoji-picker'
 import { UserProfileCard } from '../common/user-profile-card'
+import { CommunityEconomySendModal } from '../community-economy/community-economy-send-modal'
 import { formatFileSize } from '../workspace/workspace-utils'
 import { FileCard } from './file-card'
 import { ImageContextMenu } from './image-context-menu'
@@ -341,7 +344,7 @@ function formatPriceValue(
   t: (key: string, options?: Record<string, unknown>) => string,
 ) {
   if (currency === 'shrimp_coin') {
-    return `${price.toLocaleString()} ${t('common.shrimpCoin', { defaultValue: '虾币' })}`
+    return `${price.toLocaleString()} ${t('common.shrimpCoin')}`
   }
   return new Intl.NumberFormat(undefined, {
     style: 'currency',
@@ -1185,6 +1188,7 @@ function MessageBubbleInner({
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [showFullPicker, setShowFullPicker] = useState(false)
   const [showMoreMenu, setShowMoreMenu] = useState(false)
+  const [economyMode, setEconomyMode] = useState<'tip' | 'gift' | null>(null)
   const [isEditing, setIsEditing] = useState(false)
   const [editContent, setEditContent] = useState('')
   const [copied, setCopied] = useState(false)
@@ -1260,6 +1264,7 @@ function MessageBubbleInner({
   )
   const queryClient = useQueryClient()
   const author = message.author
+  const canSendEconomyAction = Boolean(author && !isOwn && !author.isBot)
 
   const handleEdit = useCallback(() => {
     setEditContent(message.content)
@@ -1874,7 +1879,7 @@ function MessageBubbleInner({
         {message.sendStatus === 'failed' && (
           <div className="flex items-center gap-1.5 mt-1 text-xs text-danger">
             <AlertCircle size={12} />
-            <span>{t('chat.sendFailed', '发送失败')}</span>
+            <span>{t('chat.sendFailed')}</span>
             <button
               type="button"
               onClick={() => {
@@ -1928,7 +1933,7 @@ function MessageBubbleInner({
               }}
               className="ml-1 px-2 py-0.5 bg-danger/10 hover:bg-danger/20 rounded text-danger text-xs font-medium transition"
             >
-              {t('chat.retry', '重试')}
+              {t('chat.retry')}
             </button>
           </div>
         )}
@@ -1938,7 +1943,7 @@ function MessageBubbleInner({
       {showActions &&
         messageRef.current &&
         (() => {
-          const floatingStyle = getFloatingControlsStyle(16, 116)
+          const floatingStyle = getFloatingControlsStyle(16, canSendEconomyAction ? 184 : 116)
           if (!floatingStyle) return null
           return createPortal(
             <div
@@ -1966,6 +1971,35 @@ function MessageBubbleInner({
               >
                 <Reply size={18} strokeWidth={2} />
               </Button>
+              {canSendEconomyAction && (
+                <>
+                  <div className="mx-0.5 h-5 w-px bg-black/5 dark:bg-white/10" />
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => {
+                      setShowMoreMenu(false)
+                      setEconomyMode('tip')
+                    }}
+                    className="!w-8 !h-8 !p-0 !rounded-[10px] !font-normal !normal-case !tracking-normal text-text-secondary hover:text-primary hover:bg-primary/10 transition-colors"
+                    title={t('communityEconomy.sendTip')}
+                  >
+                    <HandCoins size={18} strokeWidth={2} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => {
+                      setShowMoreMenu(false)
+                      setEconomyMode('gift')
+                    }}
+                    className="!w-8 !h-8 !p-0 !rounded-[10px] !font-normal !normal-case !tracking-normal text-text-secondary hover:text-primary hover:bg-primary/10 transition-colors"
+                    title={t('communityEconomy.sendGift')}
+                  >
+                    <Gift size={18} strokeWidth={2} />
+                  </Button>
+                </>
+              )}
               <div className="relative">
                 <Button
                   variant="ghost"
@@ -2010,6 +2044,35 @@ function MessageBubbleInner({
                       <ExternalLink size={16} strokeWidth={2} className="mr-1.5 opacity-70" />
                       {t('chat.shareLink')}
                     </Button>
+                    {canSendEconomyAction && (
+                      <>
+                        <div className="h-px bg-black/5 dark:bg-white/10 mx-2 my-1" />
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setShowMoreMenu(false)
+                            setEconomyMode('tip')
+                          }}
+                          className="!w-full !justify-start !rounded-[10px] !font-medium !normal-case !tracking-normal !px-3 !py-2.5 !text-[14px] !h-auto text-text-primary hover:bg-primary/10 hover:text-primary transition-colors"
+                        >
+                          <HandCoins size={16} strokeWidth={2} className="mr-1.5 opacity-70" />
+                          {t('communityEconomy.sendTip')}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setShowMoreMenu(false)
+                            setEconomyMode('gift')
+                          }}
+                          className="!w-full !justify-start !rounded-[10px] !font-medium !normal-case !tracking-normal !px-3 !py-2.5 !text-[14px] !h-auto text-text-primary hover:bg-primary/10 hover:text-primary transition-colors"
+                        >
+                          <Gift size={16} strokeWidth={2} className="mr-1.5 opacity-70" />
+                          {t('communityEconomy.sendGift')}
+                        </Button>
+                      </>
+                    )}
                     {onEnterSelectionMode && (
                       <Button
                         variant="ghost"
@@ -2021,7 +2084,7 @@ function MessageBubbleInner({
                         className="!w-full !justify-start !rounded-[10px] !font-medium !normal-case !tracking-normal !px-3 !py-2.5 !text-[14px] !h-auto text-text-primary hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
                       >
                         <CheckSquare size={16} strokeWidth={2} className="mr-1.5 opacity-70" />
-                        {t('chat.selectMessages', '多选消息')}
+                        {t('chat.selectMessages')}
                       </Button>
                     )}
                     {canDelete && (
@@ -2251,6 +2314,19 @@ function MessageBubbleInner({
           </>,
           document.body,
         )}
+      {author && canSendEconomyAction && (
+        <CommunityEconomySendModal
+          open={economyMode !== null}
+          mode={economyMode ?? 'tip'}
+          recipient={{
+            id: author.id,
+            username: author.username,
+            displayName: author.displayName,
+            avatarUrl: author.avatarUrl,
+          }}
+          onClose={() => setEconomyMode(null)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/community-economy/community-economy-send-modal.tsx
+++ b/apps/web/src/components/community-economy/community-economy-send-modal.tsx
@@ -1,0 +1,675 @@
+import { Button, cn } from '@shadowob/ui'
+import { useQuery } from '@tanstack/react-query'
+import { AlertCircle, CheckCircle2, Gift, Package, Search, Send, Wallet, X } from 'lucide-react'
+import type { FormEvent, ReactNode } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  type CommunityAsset,
+  useCommunityAssets,
+  useSendGift,
+  useSendTip,
+} from '../../hooks/use-community-economy'
+import { fetchApi } from '../../lib/api'
+import { UserAvatar } from '../common/avatar'
+import { ShrimpCoinIcon } from '../shop/ui/currency'
+
+type SendMode = 'tip' | 'gift'
+
+export interface CommunityEconomyRecipient {
+  id: string
+  username?: string | null
+  displayName?: string | null
+  avatarUrl?: string | null
+}
+
+interface FriendEntry {
+  user: CommunityEconomyRecipient & { status?: string; isBot?: boolean }
+}
+
+interface DmChannelEntry {
+  otherUser: (CommunityEconomyRecipient & { status?: string; isBot?: boolean }) | null
+  lastMessageAt?: string | null
+}
+
+function createIdempotencyKey(prefix: string) {
+  return `${prefix}_${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}_${Math.random().toString(36).slice(2)}`}`
+}
+
+function formatApiError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function displayName(recipient: CommunityEconomyRecipient) {
+  return recipient.displayName || recipient.username || recipient.id
+}
+
+export function CommunityEconomySendModal({
+  open,
+  mode = 'tip',
+  recipient,
+  recipientUserId,
+  initialAssetGrantId,
+  onClose,
+}: {
+  open: boolean
+  mode?: SendMode
+  recipient?: CommunityEconomyRecipient
+  recipientUserId?: string
+  initialAssetGrantId?: string
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const { data } = useCommunityAssets()
+  const sendTip = useSendTip()
+  const sendGift = useSendGift()
+  const [activeMode, setActiveMode] = useState<SendMode>(mode)
+  const [selectedRecipient, setSelectedRecipient] = useState<CommunityEconomyRecipient | null>(
+    recipient ?? null,
+  )
+  const [recipientQuery, setRecipientQuery] = useState('')
+  const [amount, setAmount] = useState('')
+  const [assetGrantId, setAssetGrantId] = useState(initialAssetGrantId ?? '')
+  const [assetQuantity, setAssetQuantity] = useState('1')
+  const [message, setMessage] = useState('')
+
+  const { data: wallet } = useQuery({
+    queryKey: ['wallet'],
+    queryFn: () => fetchApi<{ id: string; balance: number; frozenAmount: number }>('/api/wallet'),
+    enabled: open,
+  })
+
+  const { data: resolvedRecipient } = useQuery({
+    queryKey: ['community-economy-recipient', recipientUserId],
+    queryFn: () => fetchApi<CommunityEconomyRecipient>(`/api/auth/users/${recipientUserId}`),
+    enabled: open && !recipient && !!recipientUserId,
+  })
+
+  const { data: friends = [] } = useQuery({
+    queryKey: ['friends'],
+    queryFn: () => fetchApi<FriendEntry[]>('/api/friends'),
+    enabled: open && !recipient && !recipientUserId,
+  })
+
+  const { data: dmChannels = [] } = useQuery({
+    queryKey: ['dm-channels'],
+    queryFn: () => fetchApi<DmChannelEntry[]>('/api/dm/channels'),
+    enabled: open && !recipient && !recipientUserId,
+  })
+
+  useEffect(() => {
+    if (!open) return
+    setActiveMode(mode)
+    setSelectedRecipient(recipient ?? resolvedRecipient ?? null)
+    setAssetGrantId(initialAssetGrantId ?? '')
+    setAssetQuantity('1')
+    setAmount('')
+    setMessage('')
+    setRecipientQuery('')
+    sendTip.reset()
+    sendGift.reset()
+  }, [open, mode, recipient, resolvedRecipient, initialAssetGrantId])
+
+  const contacts = useMemo(() => {
+    const map = new Map<string, CommunityEconomyRecipient>()
+    for (const channel of dmChannels) {
+      if (channel.otherUser) map.set(channel.otherUser.id, channel.otherUser)
+    }
+    for (const friend of friends) {
+      map.set(friend.user.id, friend.user)
+    }
+    const query = recipientQuery.trim().toLowerCase()
+    return Array.from(map.values()).filter((item) => {
+      if (!query) return true
+      return `${item.displayName ?? ''} ${item.username ?? ''}`.toLowerCase().includes(query)
+    })
+  }, [dmChannels, friends, recipientQuery])
+
+  if (!open) return null
+
+  const giftableAssets =
+    data?.assets.filter(
+      (asset) =>
+        asset.definition.giftable &&
+        asset.grant.status === 'active' &&
+        asset.grant.remainingQuantity > 0,
+    ) ?? []
+  const selectedAsset = giftableAssets.find((asset) => asset.grant.id === assetGrantId) ?? null
+  const pending = sendTip.isPending || sendGift.isPending
+  const error = sendTip.error ?? sendGift.error
+  const completed = sendTip.isSuccess || sendGift.isSuccess
+  const amountValue = Number(amount)
+  const hasCurrency = Number.isFinite(amountValue) && amountValue > 0
+  const quantityValue = Number(assetQuantity)
+  const quantityValid =
+    !selectedAsset ||
+    (Number.isFinite(quantityValue) &&
+      quantityValue > 0 &&
+      quantityValue <= selectedAsset.grant.remainingQuantity)
+  const amountWithinBalance = !wallet || !hasCurrency || amountValue <= wallet.balance
+  const canSubmit =
+    !!selectedRecipient &&
+    !pending &&
+    !completed &&
+    amountWithinBalance &&
+    quantityValid &&
+    (activeMode === 'tip' ? hasCurrency : hasCurrency || Boolean(assetGrantId))
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    if (!selectedRecipient) return
+    if (activeMode === 'tip') {
+      sendTip.mutate({
+        recipientUserId: selectedRecipient.id,
+        amount: amountValue,
+        message: message.trim() || undefined,
+        idempotencyKey: createIdempotencyKey('tip'),
+      })
+      return
+    }
+
+    sendGift.mutate({
+      recipientUserId: selectedRecipient.id,
+      currencies: hasCurrency ? [{ currencyCode: 'shrimp_coin', amount: amountValue }] : undefined,
+      assets: assetGrantId
+        ? [{ assetGrantId, quantity: quantityValue > 0 ? quantityValue : 1 }]
+        : undefined,
+      message: message.trim() || undefined,
+      idempotencyKey: createIdempotencyKey('gift'),
+    })
+  }
+
+  const resetCurrentMutation = () => {
+    sendTip.reset()
+    sendGift.reset()
+    setAmount('')
+    setAssetQuantity('1')
+    setMessage('')
+  }
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center p-4">
+      <button
+        type="button"
+        className="absolute inset-0 h-full w-full cursor-default border-none bg-bg-deep/70 p-0 backdrop-blur-md"
+        onClick={onClose}
+        aria-label={t('common.close')}
+      />
+      <div className="relative z-10 flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-border-subtle bg-bg-primary shadow-2xl">
+        <div className="flex items-center justify-between gap-3 border-b border-border-subtle p-5">
+          <div>
+            <p className="text-[11px] font-black uppercase tracking-[0.2em] text-text-muted/60">
+              {t('communityEconomy.actions')}
+            </p>
+            <h2 className="text-lg font-black text-text-primary">
+              {activeMode === 'tip'
+                ? t('communityEconomy.sendTip')
+                : t('communityEconomy.sendGift')}
+            </h2>
+          </div>
+          <Button variant="ghost" size="icon" type="button" icon={X} onClick={onClose} />
+        </div>
+
+        <form className="min-h-0 overflow-y-auto p-5" onSubmit={submit}>
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_220px]">
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-2 rounded-2xl bg-bg-tertiary/40 p-1">
+                {(['tip', 'gift'] as SendMode[]).map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    onClick={() => setActiveMode(option)}
+                    className={cn(
+                      'rounded-xl px-3 py-2 text-xs font-black transition',
+                      activeMode === option
+                        ? 'bg-primary/15 text-primary shadow-sm'
+                        : 'text-text-muted hover:text-text-primary',
+                    )}
+                  >
+                    {option === 'tip'
+                      ? t('communityEconomy.sendTip')
+                      : t('communityEconomy.sendGift')}
+                  </button>
+                ))}
+              </div>
+
+              <RecipientPicker
+                fixed={Boolean(recipient || recipientUserId)}
+                selected={selectedRecipient}
+                contacts={contacts}
+                query={recipientQuery}
+                onQueryChange={setRecipientQuery}
+                onSelect={setSelectedRecipient}
+              />
+
+              <AmountPicker
+                label={
+                  activeMode === 'tip'
+                    ? t('communityEconomy.amount')
+                    : t('communityEconomy.currencyGiftAmount')
+                }
+                amount={amount}
+                onChange={setAmount}
+                required={activeMode === 'tip'}
+              />
+
+              {activeMode === 'gift' && (
+                <AssetPicker
+                  assets={giftableAssets}
+                  selectedAsset={selectedAsset}
+                  selectedGrantId={assetGrantId}
+                  quantity={assetQuantity}
+                  onSelect={setAssetGrantId}
+                  onQuantityChange={setAssetQuantity}
+                />
+              )}
+
+              <CommunityEconomyInput
+                label={t('communityEconomy.message')}
+                value={message}
+                onChange={setMessage}
+                multiline
+              />
+            </div>
+
+            <div className="space-y-3 rounded-2xl border border-border-subtle bg-bg-secondary/50 p-4">
+              {completed ? (
+                <div className="space-y-3">
+                  <div className="rounded-2xl border border-success/20 bg-success/10 p-4 text-success">
+                    <CheckCircle2 size={28} />
+                    <p className="mt-3 text-sm font-black">
+                      {activeMode === 'tip'
+                        ? t('communityEconomy.tipSent')
+                        : t('communityEconomy.giftSent')}
+                    </p>
+                    {selectedRecipient && (
+                      <p className="mt-1 text-xs font-bold text-text-muted">
+                        {t('communityEconomy.sentTo', { name: displayName(selectedRecipient) })}
+                      </p>
+                    )}
+                  </div>
+                  <Button
+                    variant="primary"
+                    size="md"
+                    type="button"
+                    className="w-full"
+                    onClick={onClose}
+                  >
+                    {t('common.done')}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="md"
+                    type="button"
+                    className="w-full"
+                    onClick={resetCurrentMutation}
+                  >
+                    {t('communityEconomy.sendAnother')}
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  <p className="text-[11px] font-black uppercase tracking-[0.16em] text-text-muted/60">
+                    {t('communityEconomy.confirmation')}
+                  </p>
+                  {selectedRecipient ? (
+                    <RecipientCard recipient={selectedRecipient} compact />
+                  ) : (
+                    <p className="text-sm text-text-muted">
+                      {t('communityEconomy.chooseRecipient')}
+                    </p>
+                  )}
+                  <div className="rounded-xl bg-bg-tertiary/50 p-3">
+                    <p className="text-[10px] font-black uppercase tracking-[0.14em] text-text-muted/60">
+                      {activeMode === 'tip'
+                        ? t('communityEconomy.sendTip')
+                        : t('communityEconomy.sendGift')}
+                    </p>
+                    <div className="mt-2 flex items-center gap-2 text-lg font-black text-text-primary">
+                      {hasCurrency ? amountValue.toLocaleString() : 0}
+                      <ShrimpCoinIcon size={16} />
+                    </div>
+                  </div>
+                  <div className="rounded-xl bg-bg-tertiary/50 p-3">
+                    <p className="flex items-center gap-1 text-[10px] font-black uppercase tracking-[0.14em] text-text-muted/60">
+                      <Wallet size={12} />
+                      {t('wallet.balance')}
+                    </p>
+                    <div className="mt-2 flex items-center gap-2 text-sm font-black text-text-primary">
+                      {(wallet?.balance ?? 0).toLocaleString()}
+                      <ShrimpCoinIcon size={14} />
+                    </div>
+                    {hasCurrency && wallet && (
+                      <p className="mt-1 text-xs text-text-muted">
+                        {t('communityEconomy.estimatedBalanceAfter')}:{' '}
+                        {Math.max(0, wallet.balance - amountValue).toLocaleString()}
+                      </p>
+                    )}
+                  </div>
+                  {selectedAsset && (
+                    <div className="rounded-xl bg-bg-tertiary/50 p-3">
+                      <p className="text-[10px] font-black uppercase tracking-[0.14em] text-text-muted/60">
+                        {t('communityEconomy.assetGift')}
+                      </p>
+                      <p className="mt-2 truncate text-sm font-black text-text-primary">
+                        {selectedAsset.definition.name} × {assetQuantity || 1}
+                      </p>
+                    </div>
+                  )}
+                  {!amountWithinBalance && (
+                    <InlineWarning message={t('communityEconomy.insufficientBalance')} />
+                  )}
+                  {!quantityValid && (
+                    <InlineWarning message={t('communityEconomy.assetQuantityExceeded')} />
+                  )}
+                  <Button
+                    variant="primary"
+                    size="md"
+                    type="submit"
+                    icon={activeMode === 'tip' ? Send : Gift}
+                    disabled={!canSubmit}
+                    className="w-full"
+                  >
+                    {activeMode === 'tip'
+                      ? t('communityEconomy.sendTip')
+                      : t('communityEconomy.sendGift')}
+                  </Button>
+                </>
+              )}
+              {error && (
+                <p className="rounded-2xl border border-danger/20 bg-danger/10 px-3 py-2 text-xs font-bold text-danger">
+                  {t('communityEconomy.operationFailed')}: {formatApiError(error)}
+                </p>
+              )}
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function InlineWarning({ message }: { message: string }) {
+  return (
+    <p className="flex items-start gap-2 rounded-2xl border border-warning/25 bg-warning/10 px-3 py-2 text-xs font-bold text-warning">
+      <AlertCircle size={14} className="mt-0.5 shrink-0" />
+      {message}
+    </p>
+  )
+}
+
+function RecipientPicker({
+  fixed,
+  selected,
+  contacts,
+  query,
+  onQueryChange,
+  onSelect,
+}: {
+  fixed: boolean
+  selected: CommunityEconomyRecipient | null
+  contacts: CommunityEconomyRecipient[]
+  query: string
+  onQueryChange: (value: string) => void
+  onSelect: (recipient: CommunityEconomyRecipient) => void
+}) {
+  const { t } = useTranslation()
+  if (fixed && selected) {
+    return (
+      <div className="space-y-2">
+        <FieldLabel>{t('communityEconomy.sendTo')}</FieldLabel>
+        <RecipientCard recipient={selected} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <FieldLabel>{t('communityEconomy.chooseRecipient')}</FieldLabel>
+      <label className="flex items-center gap-2 rounded-2xl border border-border-subtle bg-bg-secondary px-3 py-2">
+        <Search size={16} className="text-text-muted" />
+        <input
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+          placeholder={t('communityEconomy.searchRecipient')}
+          className="min-w-0 flex-1 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-muted"
+        />
+      </label>
+      <div className="grid max-h-44 gap-2 overflow-y-auto pr-1">
+        {contacts.length === 0 ? (
+          <p className="rounded-2xl border border-border-subtle bg-bg-secondary/50 p-4 text-sm text-text-muted">
+            {t('communityEconomy.noRecipients')}
+          </p>
+        ) : (
+          contacts.map((contact) => (
+            <button
+              key={contact.id}
+              type="button"
+              onClick={() => onSelect(contact)}
+              className={cn(
+                'rounded-2xl border p-3 text-left transition',
+                selected?.id === contact.id
+                  ? 'border-primary/50 bg-primary/10'
+                  : 'border-border-subtle bg-bg-secondary/40 hover:border-primary/30',
+              )}
+            >
+              <RecipientCard recipient={contact} compact />
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+function RecipientCard({
+  recipient,
+  compact = false,
+}: {
+  recipient: CommunityEconomyRecipient
+  compact?: boolean
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <UserAvatar
+        userId={recipient.id}
+        avatarUrl={recipient.avatarUrl ?? null}
+        displayName={displayName(recipient)}
+        size={compact ? 'sm' : 'md'}
+      />
+      <div className="min-w-0">
+        <p className="truncate text-sm font-black text-text-primary">{displayName(recipient)}</p>
+        {recipient.username && (
+          <p className="truncate text-xs font-bold text-text-muted">@{recipient.username}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function AmountPicker({
+  label,
+  amount,
+  onChange,
+  required,
+}: {
+  label: string
+  amount: string
+  onChange: (value: string) => void
+  required: boolean
+}) {
+  const { t } = useTranslation()
+  const presets = [10, 50, 100, 520]
+  return (
+    <div className="space-y-2">
+      <FieldLabel>{label}</FieldLabel>
+      <div className="grid grid-cols-4 gap-2">
+        {presets.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => onChange(String(preset))}
+            className={cn(
+              'rounded-2xl border px-3 py-2 text-sm font-black transition',
+              amount === String(preset)
+                ? 'border-primary/50 bg-primary/10 text-primary'
+                : 'border-border-subtle bg-bg-secondary/40 text-text-primary hover:border-primary/30',
+            )}
+          >
+            {preset}
+          </button>
+        ))}
+      </div>
+      <label className="flex items-center gap-2 rounded-2xl border border-border-subtle bg-bg-secondary px-3 py-2">
+        <ShrimpCoinIcon size={16} />
+        <input
+          value={amount}
+          onChange={(event) => onChange(event.target.value)}
+          type="number"
+          min={required ? 1 : 0}
+          required={required}
+          placeholder={t('communityEconomy.customAmount')}
+          className="min-w-0 flex-1 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-muted"
+        />
+      </label>
+    </div>
+  )
+}
+
+function AssetPicker({
+  assets,
+  selectedAsset,
+  selectedGrantId,
+  quantity,
+  onSelect,
+  onQuantityChange,
+}: {
+  assets: CommunityAsset[]
+  selectedAsset: CommunityAsset | null
+  selectedGrantId: string
+  quantity: string
+  onSelect: (grantId: string) => void
+  onQuantityChange: (value: string) => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="space-y-2">
+      <FieldLabel>{t('communityEconomy.chooseAsset')}</FieldLabel>
+      {assets.length === 0 ? (
+        <p className="rounded-2xl border border-border-subtle bg-bg-secondary/50 p-4 text-sm text-text-muted">
+          {t('communityEconomy.noGiftableAssets')}
+        </p>
+      ) : (
+        <div className="grid max-h-52 gap-2 overflow-y-auto pr-1">
+          <button
+            type="button"
+            onClick={() => onSelect('')}
+            className={cn(
+              'rounded-2xl border p-3 text-left text-sm font-bold transition',
+              !selectedGrantId
+                ? 'border-primary/50 bg-primary/10 text-primary'
+                : 'border-border-subtle bg-bg-secondary/40 text-text-muted hover:border-primary/30',
+            )}
+          >
+            {t('communityEconomy.noAssetGift')}
+          </button>
+          {assets.map((asset) => (
+            <button
+              key={asset.grant.id}
+              type="button"
+              onClick={() => onSelect(asset.grant.id)}
+              className={cn(
+                'rounded-2xl border p-3 text-left transition',
+                selectedGrantId === asset.grant.id
+                  ? 'border-primary/50 bg-primary/10'
+                  : 'border-border-subtle bg-bg-secondary/40 hover:border-primary/30',
+              )}
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                {asset.definition.imageUrl ? (
+                  <img
+                    src={asset.definition.imageUrl}
+                    alt=""
+                    className="h-10 w-10 rounded-xl object-cover"
+                  />
+                ) : (
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                    <Package size={18} />
+                  </span>
+                )}
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-black text-text-primary">
+                    {asset.definition.name}
+                  </span>
+                  <span className="block text-xs font-bold text-text-muted">
+                    {t('communityEconomy.remaining')}: {asset.grant.remainingQuantity}
+                  </span>
+                </span>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+      {selectedAsset && (
+        <CommunityEconomyInput
+          label={t('communityEconomy.assetQuantity')}
+          value={quantity}
+          onChange={onQuantityChange}
+          type="number"
+          min={1}
+          max={selectedAsset.grant.remainingQuantity}
+        />
+      )}
+    </div>
+  )
+}
+
+function CommunityEconomyInput({
+  label,
+  value,
+  onChange,
+  type = 'text',
+  required = false,
+  min,
+  max,
+  multiline = false,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  type?: 'text' | 'number'
+  required?: boolean
+  min?: number
+  max?: number
+  multiline?: boolean
+}) {
+  const className =
+    'w-full rounded-2xl border border-border-subtle bg-bg-secondary px-3 py-2 text-sm text-text-primary outline-none focus:border-primary'
+
+  return (
+    <label className="block space-y-1.5">
+      <FieldLabel>{label}</FieldLabel>
+      {multiline ? (
+        <textarea
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className={cn(className, 'min-h-20 resize-none')}
+        />
+      ) : (
+        <input
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          type={type}
+          min={min}
+          max={max}
+          required={required}
+          className={className}
+        />
+      )}
+    </label>
+  )
+}
+
+function FieldLabel({ children }: { children: ReactNode }) {
+  return <span className="text-xs font-black text-text-muted">{children}</span>
+}

--- a/apps/web/src/components/profile/ProfileCommentSection.tsx
+++ b/apps/web/src/components/profile/ProfileCommentSection.tsx
@@ -311,7 +311,7 @@ function CommentItem({
               </span>
               {comment.author.isBot && (
                 <Badge variant="info" size="xs">
-                  {t('buddy')}
+                  {t('common.buddy')}
                 </Badge>
               )}
               <span className="text-xs text-text-muted">
@@ -539,7 +539,7 @@ function ReplyItem({ reply, currentUserId, onToggleReaction, onDelete }: ReplyIt
             </span>
             {reply.author.isBot && (
               <Badge variant="info" size="xs">
-                {t('buddy')}
+                {t('common.buddy')}
               </Badge>
             )}
             <span className="text-xs text-text-muted">

--- a/apps/web/src/components/recharge/recharge-modal.tsx
+++ b/apps/web/src/components/recharge/recharge-modal.tsx
@@ -81,7 +81,13 @@ export function RechargeModal() {
     if (loading) return
     setLoading(true)
     try {
-      const params: { tier: string; customAmount?: number } = { tier: selectedTier }
+      const idempotencyKey =
+        globalThis.crypto?.randomUUID?.() ??
+        `recharge-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const params: { tier: string; customAmount?: number; idempotencyKey: string } = {
+        tier: selectedTier,
+        idempotencyKey,
+      }
       if (selectedTier === 'custom') {
         params.customAmount = customAmount
       }

--- a/apps/web/src/components/shop/order-confirm.tsx
+++ b/apps/web/src/components/shop/order-confirm.tsx
@@ -10,6 +10,10 @@ import { useShopStore } from '../../stores/shop.store'
 import type { Product, ProductMediaItem, SkuItem } from './shop-page'
 import { PriceDisplay } from './ui/currency'
 
+function createIdempotencyKey(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
 interface OrderConfirmProps {
   serverId: string
   productId: string
@@ -42,7 +46,7 @@ export function OrderConfirm({ serverId, productId, skuId, quantity, onBack }: O
     mutationFn: (data: { items: Array<{ productId: string; skuId?: string; quantity: number }> }) =>
       fetchApi<{ id: string }>(`/api/servers/${serverId}/shop/orders`, {
         method: 'POST',
-        body: JSON.stringify(data),
+        body: JSON.stringify({ ...data, idempotencyKey: createIdempotencyKey('shop-order') }),
       }),
     onSuccess: (res) => {
       queryClient.invalidateQueries({ queryKey: ['shop-orders', serverId] })

--- a/apps/web/src/components/shop/product-detail.tsx
+++ b/apps/web/src/components/shop/product-detail.tsx
@@ -23,6 +23,10 @@ import { OrderConfirm } from './order-confirm'
 import type { Product, ProductMediaItem, SkuItem } from './shop-page'
 import { PriceDisplay } from './ui/currency'
 
+function createIdempotencyKey(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
 interface ProductDetailProps {
   serverId: string
   productId: string
@@ -190,6 +194,7 @@ export function ProductDetail({
         await fetchApi<{ id: string }>(`/api/servers/${serverId}/shop/orders`, {
           method: 'POST',
           body: JSON.stringify({
+            idempotencyKey: createIdempotencyKey('shop-order'),
             items: [{ productId: product.id, skuId: selectedSkuId ?? undefined, quantity }],
           }),
         })

--- a/apps/web/src/components/shop/shop-cart.tsx
+++ b/apps/web/src/components/shop/shop-cart.tsx
@@ -7,6 +7,10 @@ import { fetchApi } from '../../lib/api'
 import { showToast } from '../../lib/toast'
 import { PriceDisplay } from './ui/currency'
 
+function createIdempotencyKey(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
 interface CartItem {
   id: string
   userId: string
@@ -67,7 +71,7 @@ export function ShopCart({ serverId, onCheckout }: ShopCartProps) {
     mutationFn: (items: Array<{ productId: string; skuId?: string; quantity: number }>) =>
       fetchApi<{ id: string }>(`/api/servers/${serverId}/shop/orders`, {
         method: 'POST',
-        body: JSON.stringify({ items }),
+        body: JSON.stringify({ items, idempotencyKey: createIdempotencyKey('shop-order') }),
       }),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['shop-cart', serverId] })

--- a/apps/web/src/hooks/use-community-economy.ts
+++ b/apps/web/src/hooks/use-community-economy.ts
@@ -1,0 +1,175 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchApi } from '../lib/api'
+
+export interface CommunityAssetDefinition {
+  id: string
+  assetType: string
+  name: string
+  description?: string | null
+  imageUrl?: string | null
+  giftable: boolean
+  consumable: boolean
+  status: string
+}
+
+export interface CommunityAssetGrant {
+  id: string
+  definitionId: string
+  ownerUserId: string
+  quantity: number
+  remainingQuantity: number
+  status: string
+  expiresAt?: string | null
+}
+
+export interface CommunityAsset {
+  grant: CommunityAssetGrant
+  definition: CommunityAssetDefinition
+}
+
+export interface SettlementLine {
+  id: string
+  sellerUserId: string
+  sourceType: string
+  sourceId: string
+  grossAmount: number
+  platformFee: number
+  netAmount: number
+  status: string
+  availableAt?: string | null
+  settledAt?: string | null
+}
+
+export function useCommunityAssets() {
+  return useQuery({
+    queryKey: ['community-assets'],
+    queryFn: () => fetchApi<{ assets: CommunityAsset[] }>('/api/economy/assets'),
+  })
+}
+
+export function useConsumeCommunityAsset() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { grantId: string; idempotencyKey: string }) =>
+      fetchApi<{ grant: CommunityAssetGrant }>(`/api/economy/assets/${input.grantId}/consume`, {
+        method: 'POST',
+        body: JSON.stringify({ idempotencyKey: input.idempotencyKey }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+    },
+  })
+}
+
+export function useLockCommunityAsset() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { grantId: string; idempotencyKey: string }) =>
+      fetchApi<{ grant: CommunityAssetGrant }>(`/api/economy/assets/${input.grantId}/lock`, {
+        method: 'POST',
+        body: JSON.stringify({ idempotencyKey: input.idempotencyKey }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+    },
+  })
+}
+
+export function useUnlockCommunityAsset() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { grantId: string; idempotencyKey: string }) =>
+      fetchApi<{ grant: CommunityAssetGrant }>(`/api/economy/assets/${input.grantId}/unlock`, {
+        method: 'POST',
+        body: JSON.stringify({ idempotencyKey: input.idempotencyKey }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+    },
+  })
+}
+
+export function useRevokeCommunityAsset() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { grantId: string; idempotencyKey: string; reason?: string }) =>
+      fetchApi<{ grant: CommunityAssetGrant }>(`/api/economy/assets/${input.grantId}/revoke`, {
+        method: 'POST',
+        body: JSON.stringify({ idempotencyKey: input.idempotencyKey, reason: input.reason }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+    },
+  })
+}
+
+export function useSendTip() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: {
+      recipientUserId: string
+      amount: number
+      message?: string
+      context?: { kind: string; id: string }
+      idempotencyKey: string
+    }) =>
+      fetchApi('/api/economy/tips', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['wallet'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet-transactions'] })
+    },
+  })
+}
+
+export function useSendGift() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: {
+      recipientUserId: string
+      assets?: Array<{ assetGrantId: string; quantity?: number }>
+      currencies?: Array<{ currencyCode: 'shrimp_coin'; amount: number }>
+      message?: string
+      idempotencyKey: string
+    }) =>
+      fetchApi('/api/economy/gifts', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-assets'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet-transactions'] })
+    },
+  })
+}
+
+export function useSettlementLines(params?: { limit?: number; offset?: number }) {
+  return useQuery({
+    queryKey: ['community-settlements', params?.limit ?? 50, params?.offset ?? 0],
+    queryFn: () => {
+      const qs = new URLSearchParams()
+      if (params?.limit != null) qs.set('limit', String(params.limit))
+      if (params?.offset != null) qs.set('offset', String(params.offset))
+      const suffix = qs.toString() ? `?${qs}` : ''
+      return fetchApi<{ settlements: SettlementLine[] }>(`/api/economy/settlements${suffix}`)
+    },
+  })
+}
+
+export function useSettleAvailableLines() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      fetchApi<{ settlements: SettlementLine[] }>('/api/economy/settlements/settle', {
+        method: 'POST',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['community-settlements'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet'] })
+      queryClient.invalidateQueries({ queryKey: ['wallet-transactions'] })
+    },
+  })
+}

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -28,7 +28,9 @@
     "close": "Close",
     "back": "Back",
     "bot": "Buddy",
-    "shrimpCoin": "Shrimp Coins"
+    "shrimpCoin": "Shrimp Coins",
+    "done": "Done",
+    "unknown": "Unknown"
   },
   "nav": {
     "features": "Features",
@@ -775,6 +777,9 @@
     "deleteConfirm": "Are you sure you want to delete this message?",
     "copyMessage": "Copy Message",
     "shareLink": "Share Message Link",
+    "sendFailed": "Failed to send",
+    "retry": "Retry",
+    "selectMessages": "Select messages",
     "loading": "Loading...",
     "loadingOlder": "Loading older messages...",
     "downloadFile": "Download File",
@@ -844,7 +849,8 @@
       "manual_pending": "Manual handling",
       "failed": "Delivery issue"
     },
-    "copyFailed": "Copy failed"
+    "copyFailed": "Copy failed",
+    "typing": "is typing..."
   },
   "member": {
     "online": "Online",
@@ -1035,7 +1041,8 @@
     "tagDeploy": "Deployment",
     "tagCustom": "Custom",
     "tagMcp": "MCP",
-    "tagApi": "API"
+    "tagApi": "API",
+    "owner": "Owner"
   },
   "pricing": {
     "pageTitle": "Simple, Transparent Pricing",
@@ -1738,7 +1745,8 @@
     "tipSearch": "Search",
     "tipSearchDesc": "Type a username to quickly find contacts",
     "tipAdd": "Add",
-    "tipAddDesc": "Tap the + icon to add friends by username"
+    "tipAddDesc": "Tap the + icon to add friends by username",
+    "inputPlaceholderToUser": "Message @{{name}}"
   },
   "openclaw": {
     "nav": {
@@ -2089,7 +2097,8 @@
     "expense": "Expense",
     "transactionNote": "Note",
     "balanceAfter": "Balance",
-    "rechargeBtn": "Recharge"
+    "rechargeBtn": "Recharge",
+    "frozen": "Frozen"
   },
   "commerce": {
     "myShop": "My shop",
@@ -2200,6 +2209,8 @@
     "cancelFailed": "Cancellation failed",
     "noOrders": "No delivery records",
     "buyer": "Buyer",
+    "buyerPreview": "Buyer preview",
+    "serviceDeliveryHint": "The buyer receives the service access or manual fulfillment described by the creator.",
     "entitlementGroups": {
       "active": "Active entitlements",
       "expiring": "Expiring soon",
@@ -2214,6 +2225,7 @@
       "service": "Virtual service",
       "workspace_file": "Paid file",
       "digital_asset": "Digital asset",
+      "community_asset": "Community asset",
       "subscription": "Subscription entitlement",
       "external_resource": "External resource"
     },
@@ -2328,5 +2340,114 @@
       "pricingTitle": "You keep the compute.",
       "pricingDesc": "Shop revenue funds the compute cost — creators absorb the infra and own the resources."
     }
-  }
+  },
+  "communityEconomy": {
+    "assets": "Assets",
+    "settlements": "Settlements",
+    "actions": "Send",
+    "assetCount": "{{count}} assets",
+    "noAssets": "No assets yet",
+    "noAssetsHint": "Purchased, granted, or gifted assets will appear here.",
+    "quantity": "Quantity",
+    "remaining": "Remaining",
+    "type": "Type",
+    "expiresAt": "Expires",
+    "never": "Never",
+    "consume": "Consume",
+    "lock": "Lock",
+    "unlock": "Unlock",
+    "revoke": "Revoke",
+    "settleAvailable": "Settle available",
+    "totalLines": "Total",
+    "availableLines": "Available",
+    "pendingNet": "Pending net",
+    "noSettlements": "No settlement lines yet",
+    "noSettlementsHint": "Tips, gifts, and creator revenue will collect here before settlement.",
+    "availableAt": "Available at",
+    "notAvailable": "Not available",
+    "settledAt": "Settled at",
+    "gross": "Gross",
+    "fee": "Fee",
+    "net": "Net",
+    "sendTip": "Send tip",
+    "sendGift": "Send gift",
+    "recipientUserId": "Recipient user ID",
+    "amount": "Amount",
+    "message": "Message",
+    "tipSent": "Tip sent",
+    "giftSent": "Gift sent",
+    "operationFailed": "Operation failed",
+    "currencyGiftAmount": "Currency gift amount",
+    "assetGift": "Asset gift",
+    "noAssetGift": "Do not include an asset",
+    "assetQuantity": "Asset quantity",
+    "source": {
+      "tip": "Tip",
+      "gift": "Gift",
+      "purchase": "Purchase",
+      "settlement": "Settlement",
+      "asset": "Asset"
+    },
+    "status": {
+      "active": "Active",
+      "locked": "Locked",
+      "consumed": "Consumed",
+      "revoked": "Revoked",
+      "expired": "Expired",
+      "pending": "Pending",
+      "available": "Available",
+      "settled": "Settled",
+      "held": "Held",
+      "frozen": "Frozen",
+      "reversed": "Reversed",
+      "failed": "Failed",
+      "canceled": "Canceled",
+      "provisioned": "Provisioned",
+      "processing": "Processing"
+    },
+    "allAssetTypes": "All types",
+    "viewAssets": "View assets",
+    "purchaseDeliveryStatus": "Purchase delivery status",
+    "deliveryTarget": "Delivery target",
+    "chooseRecipient": "Choose recipient",
+    "searchRecipient": "Search friends or recent chats",
+    "noRecipients": "No contacts found. Open a profile or chat to send directly.",
+    "sendTo": "Send to",
+    "customAmount": "Custom amount",
+    "chooseAsset": "Choose asset",
+    "noGiftableAssets": "No giftable assets available",
+    "confirmation": "Confirm",
+    "deliveryType": "What buyers receive",
+    "assetDelivery": "Asset delivery",
+    "assetDeliveryHint": "The asset is delivered to the buyer's asset library after purchase.",
+    "assetDefinitionsCount": "{{count}} asset templates",
+    "assetNamePlaceholder": "Asset name shown to buyers",
+    "assetDescriptionPlaceholder": "Short description for this asset",
+    "deliveryPreset": {
+      "service": "Service access",
+      "badge": "Badge",
+      "gift": "Digital gift",
+      "service_ticket": "Service ticket"
+    },
+    "deliveryPresetHint": {
+      "service": "Access, membership, files, or manual service fulfillment.",
+      "badge": "A permanent identity badge for supporters or members.",
+      "gift": "A collectible digital gift that can be transferred.",
+      "service_ticket": "A redeemable ticket for one service or event."
+    },
+    "tipEntryTitle": "Send appreciation in seconds",
+    "tipEntryHint": "Choose a friend or recent chat, pick an amount, and send with a short note.",
+    "giftEntryTitle": "Share coins and owned assets",
+    "giftEntryHint": "Send Shrimp Coins, a badge, gift, or service ticket from your asset library.",
+    "estimatedBalanceAfter": "After sending",
+    "insufficientBalance": "Your balance is not enough for this send.",
+    "assetQuantityExceeded": "Asset quantity exceeds what you currently own.",
+    "sentTo": "Sent to {{name}}",
+    "sendAnother": "Send another",
+    "confirm": {
+      "consume": "Use this asset now? This may reduce the remaining quantity.",
+      "revoke": "Revoke this asset? This action cannot be undone."
+    }
+  },
+  "buddy": "Buddy"
 }

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -30,7 +30,8 @@
     "bot": "Buddy",
     "shrimpCoin": "Shrimp Coins",
     "done": "Done",
-    "unknown": "Unknown"
+    "unknown": "Unknown",
+    "buddy": "Buddy"
   },
   "nav": {
     "features": "Features",
@@ -2448,6 +2449,5 @@
       "consume": "Use this asset now? This may reduce the remaining quantity.",
       "revoke": "Revoke this asset? This action cannot be undone."
     }
-  },
-  "buddy": "Buddy"
+  }
 }

--- a/apps/web/src/lib/locales/ja.json
+++ b/apps/web/src/lib/locales/ja.json
@@ -30,7 +30,8 @@
     "bot": "Buddy",
     "shrimpCoin": "シュリンプコイン",
     "done": "完了",
-    "unknown": "不明"
+    "unknown": "不明",
+    "buddy": "Buddy"
   },
   "nav": {
     "features": "機能紹介",
@@ -2448,6 +2449,5 @@
       "consume": "この資産を今使いますか？残数が減る場合があります。",
       "revoke": "この資産を取り消しますか？この操作は元に戻せません。"
     }
-  },
-  "buddy": "Buddy"
+  }
 }

--- a/apps/web/src/lib/locales/ja.json
+++ b/apps/web/src/lib/locales/ja.json
@@ -28,7 +28,9 @@
     "close": "閉じる",
     "back": "戻る",
     "bot": "Buddy",
-    "shrimpCoin": "シュリンプコイン"
+    "shrimpCoin": "シュリンプコイン",
+    "done": "完了",
+    "unknown": "不明"
   },
   "nav": {
     "features": "機能紹介",
@@ -587,6 +589,9 @@
     "deleteConfirm": "このメッセージを削除しますか？",
     "copyMessage": "メッセージをコピー",
     "shareLink": "メッセージリンクを共有",
+    "sendFailed": "送信に失敗しました",
+    "retry": "再試行",
+    "selectMessages": "メッセージを選択",
     "loading": "読み込み中...",
     "loadingOlder": "過去のメッセージを読み込み中...",
     "downloadFile": "ファイルをダウンロード",
@@ -656,7 +661,8 @@
       "manual_pending": "手動対応待ち",
       "failed": "配布エラー"
     },
-    "copyFailed": "コピー失敗"
+    "copyFailed": "コピー失敗",
+    "typing": "入力中..."
   },
   "member": {
     "online": "オンライン",
@@ -847,7 +853,8 @@
     "tagDeploy": "デプロイ",
     "tagCustom": "カスタム",
     "tagMcp": "MCP",
-    "tagApi": "API"
+    "tagApi": "API",
+    "owner": "オーナー"
   },
   "pricing": {
     "pageTitle": "シンプルで透明な料金体系",
@@ -1550,7 +1557,8 @@
     "tipSearch": "検索",
     "tipSearchDesc": "ユーザー名で連絡先をすばやく検索",
     "tipAdd": "追加",
-    "tipAddDesc": "+ アイコンをタップしてユーザー名でフレンドを追加"
+    "tipAddDesc": "+ アイコンをタップしてユーザー名でフレンドを追加",
+    "inputPlaceholderToUser": "@{{name}} にメッセージを送信"
   },
   "openclaw": {
     "nav": {
@@ -1891,7 +1899,8 @@
     "expense": "支出",
     "transactionNote": "メモ",
     "balanceAfter": "残高",
-    "rechargeBtn": "チャージする"
+    "rechargeBtn": "チャージする",
+    "frozen": "凍結中"
   },
   "commerce": {
     "myShop": "自分のショップ",
@@ -2002,6 +2011,8 @@
     "cancelFailed": "キャンセルに失敗しました",
     "noOrders": "配布記録はありません",
     "buyer": "購入者",
+    "buyerPreview": "購入者向けプレビュー",
+    "serviceDeliveryHint": "購入者は、クリエイターが説明したサービス権限または手動対応を受け取ります。",
     "entitlementGroups": {
       "active": "利用可能な権限",
       "expiring": "まもなく期限切れ",
@@ -2016,6 +2027,7 @@
       "service": "仮想サービス",
       "workspace_file": "有料ファイル",
       "digital_asset": "デジタル資産",
+      "community_asset": "コミュニティ資産",
       "subscription": "サブスクリプション権限",
       "external_resource": "外部リソース"
     },
@@ -2328,5 +2340,114 @@
       "deployInfrastructureFailed": "デプロイサービスで環境上の問題が発生しました。虾幣は自動的に返金されます。後で再試行するか、Cloud のデプロイ履歴をご確認ください。",
       "deployTimeout": "デプロイはまだ進行中です。後ほど Cloud を確認してください。"
     }
-  }
+  },
+  "communityEconomy": {
+    "assets": "コミュニティ資産",
+    "settlements": "精算",
+    "actions": "チップとギフト",
+    "assetCount": "{{count}} 件の資産",
+    "noAssets": "資産はまだありません",
+    "noAssetsHint": "購入、付与、受け取ったコミュニティ資産がここに表示されます。",
+    "quantity": "数量",
+    "remaining": "残数",
+    "type": "タイプ",
+    "expiresAt": "有効期限",
+    "never": "無期限",
+    "consume": "消費",
+    "lock": "ロック",
+    "unlock": "解除",
+    "revoke": "取り消し",
+    "settleAvailable": "利用可能分を精算",
+    "totalLines": "合計",
+    "availableLines": "精算可能",
+    "pendingNet": "保留中の純額",
+    "noSettlements": "精算行はまだありません",
+    "noSettlementsHint": "チップ、ギフト、クリエイター収益は精算前にここへ集約されます。",
+    "availableAt": "利用可能日時",
+    "notAvailable": "未利用可能",
+    "settledAt": "精算日時",
+    "gross": "総額",
+    "fee": "手数料",
+    "net": "純額",
+    "sendTip": "チップを送る",
+    "sendGift": "ギフトを送る",
+    "recipientUserId": "受取人ユーザー ID",
+    "amount": "金額",
+    "message": "メッセージ",
+    "tipSent": "チップを送信しました",
+    "giftSent": "ギフトを送信しました",
+    "operationFailed": "操作に失敗しました",
+    "currencyGiftAmount": "通貨ギフト金額",
+    "assetGift": "資産ギフト",
+    "noAssetGift": "資産を含めない",
+    "assetQuantity": "資産数量",
+    "source": {
+      "tip": "チップ",
+      "gift": "ギフト",
+      "purchase": "購入",
+      "settlement": "精算",
+      "asset": "資産"
+    },
+    "status": {
+      "active": "有効",
+      "locked": "ロック中",
+      "consumed": "消費済み",
+      "revoked": "取り消し済み",
+      "expired": "期限切れ",
+      "pending": "保留中",
+      "available": "精算可能",
+      "settled": "精算済み",
+      "held": "保留",
+      "frozen": "凍結",
+      "reversed": "取り消し済み",
+      "failed": "失敗",
+      "canceled": "キャンセル済み",
+      "provisioned": "配信済み",
+      "processing": "処理中"
+    },
+    "allAssetTypes": "すべてのタイプ",
+    "viewAssets": "資産を見る",
+    "purchaseDeliveryStatus": "購入後の配信状態",
+    "deliveryTarget": "配信先",
+    "chooseRecipient": "受取人を選択",
+    "searchRecipient": "友だちや最近のチャットを検索",
+    "noRecipients": "選択できる連絡先がありません。プロフィールまたはチャットから直接送信できます。",
+    "sendTo": "送信先",
+    "customAmount": "任意の金額",
+    "chooseAsset": "資産を選択",
+    "noGiftableAssets": "贈れる資産がありません",
+    "confirmation": "確認",
+    "deliveryType": "購入者が受け取るもの",
+    "assetDelivery": "資産配信",
+    "assetDeliveryHint": "購入後、資産は購入者の資産ライブラリに届きます。",
+    "assetDefinitionsCount": "{{count}} 件の資産テンプレート",
+    "assetNamePlaceholder": "購入者に表示する資産名",
+    "assetDescriptionPlaceholder": "この資産の短い説明",
+    "deliveryPreset": {
+      "service": "サービス権限",
+      "badge": "バッジ",
+      "gift": "デジタルギフト",
+      "service_ticket": "サービスチケット"
+    },
+    "deliveryPresetHint": {
+      "service": "アクセス権、会員権、ファイル、手動サービスに適しています。",
+      "badge": "支援者やメンバー向けの永続バッジです。",
+      "gift": "譲渡やコレクションに向くデジタルギフトです。",
+      "service_ticket": "1 回分のサービスやイベントに使えるチケットです。"
+    },
+    "tipEntryTitle": "すばやく応援を送る",
+    "tipEntryHint": "友だちや最近のチャットを選び、金額と短いメッセージを添えて送れます。",
+    "giftEntryTitle": "コインと保有資産を贈る",
+    "giftEntryHint": "Shrimp Coin、バッジ、ギフト、サービスチケットを資産ライブラリから送れます。",
+    "estimatedBalanceAfter": "送信後の残高",
+    "insufficientBalance": "残高が不足しているため送信できません。",
+    "assetQuantityExceeded": "贈る数量が現在保有している数量を超えています。",
+    "sentTo": "{{name}} に送信しました",
+    "sendAnother": "もう一度送る",
+    "confirm": {
+      "consume": "この資産を今使いますか？残数が減る場合があります。",
+      "revoke": "この資産を取り消しますか？この操作は元に戻せません。"
+    }
+  },
+  "buddy": "Buddy"
 }

--- a/apps/web/src/lib/locales/ko.json
+++ b/apps/web/src/lib/locales/ko.json
@@ -28,7 +28,9 @@
     "close": "닫기",
     "back": "뒤로",
     "bot": "Buddy",
-    "shrimpCoin": "쉬림프 코인"
+    "shrimpCoin": "쉬림프 코인",
+    "done": "완료",
+    "unknown": "알 수 없음"
   },
   "nav": {
     "features": "기능 소개",
@@ -587,6 +589,9 @@
     "deleteConfirm": "이 메시지를 삭제하시겠습니까?",
     "copyMessage": "메시지 복사",
     "shareLink": "메시지 링크 공유",
+    "sendFailed": "전송 실패",
+    "retry": "다시 시도",
+    "selectMessages": "메시지 선택",
     "loading": "로딩 중...",
     "loadingOlder": "이전 메시지 로딩 중...",
     "downloadFile": "파일 다운로드",
@@ -656,7 +661,8 @@
       "manual_pending": "수동 처리 대기",
       "failed": "배송 오류"
     },
-    "copyFailed": "복사 실패"
+    "copyFailed": "복사 실패",
+    "typing": "입력 중..."
   },
   "member": {
     "online": "온라인",
@@ -847,7 +853,8 @@
     "tagDeploy": "배포",
     "tagCustom": "커스텀",
     "tagMcp": "MCP",
-    "tagApi": "API"
+    "tagApi": "API",
+    "owner": "소유자"
   },
   "pricing": {
     "pageTitle": "간단하고 투명한 요금제",
@@ -1550,7 +1557,8 @@
     "tipSearch": "검색",
     "tipSearchDesc": "사용자 이름으로 빠르게 연락처 찾기",
     "tipAdd": "추가",
-    "tipAddDesc": "+ 아이콘을 눌러 사용자 이름으로 친구 추가"
+    "tipAddDesc": "+ 아이콘을 눌러 사용자 이름으로 친구 추가",
+    "inputPlaceholderToUser": "@{{name}}에게 메시지 보내기"
   },
   "openclaw": {
     "nav": {
@@ -1891,7 +1899,8 @@
     "expense": "지출",
     "transactionNote": "메모",
     "balanceAfter": "잔액",
-    "rechargeBtn": "충전하기"
+    "rechargeBtn": "충전하기",
+    "frozen": "동결"
   },
   "commerce": {
     "myShop": "내 상점",
@@ -2002,6 +2011,8 @@
     "cancelFailed": "취소 실패",
     "noOrders": "배송 기록이 없습니다",
     "buyer": "구매자",
+    "buyerPreview": "구매자 미리보기",
+    "serviceDeliveryHint": "구매자는 크리에이터가 설명한 서비스 권한 또는 수동 제공을 받습니다.",
     "entitlementGroups": {
       "active": "사용 가능한 권한",
       "expiring": "곧 만료됨",
@@ -2016,6 +2027,7 @@
       "service": "가상 서비스",
       "workspace_file": "유료 파일",
       "digital_asset": "디지털 자산",
+      "community_asset": "커뮤니티 자산",
       "subscription": "구독 권한",
       "external_resource": "외부 리소스"
     },
@@ -2328,5 +2340,114 @@
       "deployInfrastructureFailed": "배포 서비스에 일시적인 환경 문제가 발생했습니다. 새우 코인은 자동으로 환불됩니다. 잠시 후 다시 시도하거나 Cloud에서 배포 기록을 확인해 주세요.",
       "deployTimeout": "배포가 아직 진행 중입니다. 잠시 후 Cloud에서 확인해 주세요."
     }
-  }
+  },
+  "communityEconomy": {
+    "assets": "커뮤니티 자산",
+    "settlements": "정산",
+    "actions": "팁과 선물",
+    "assetCount": "자산 {{count}}개",
+    "noAssets": "아직 자산이 없습니다",
+    "noAssetsHint": "구매, 지급, 선물받은 커뮤니티 자산이 여기에 표시됩니다.",
+    "quantity": "수량",
+    "remaining": "남은 수량",
+    "type": "유형",
+    "expiresAt": "만료일",
+    "never": "영구",
+    "consume": "사용",
+    "lock": "잠금",
+    "unlock": "잠금 해제",
+    "revoke": "회수",
+    "settleAvailable": "사용 가능분 정산",
+    "totalLines": "전체",
+    "availableLines": "정산 가능",
+    "pendingNet": "대기 순액",
+    "noSettlements": "정산 내역이 없습니다",
+    "noSettlementsHint": "팁, 선물, 크리에이터 수익은 정산 전 여기에 모입니다.",
+    "availableAt": "사용 가능 시각",
+    "notAvailable": "아직 사용 불가",
+    "settledAt": "정산 시각",
+    "gross": "총액",
+    "fee": "수수료",
+    "net": "순액",
+    "sendTip": "팁 보내기",
+    "sendGift": "선물 보내기",
+    "recipientUserId": "받는 사용자 ID",
+    "amount": "금액",
+    "message": "메시지",
+    "tipSent": "팁을 보냈습니다",
+    "giftSent": "선물을 보냈습니다",
+    "operationFailed": "작업 실패",
+    "currencyGiftAmount": "통화 선물 금액",
+    "assetGift": "자산 선물",
+    "noAssetGift": "자산 포함 안 함",
+    "assetQuantity": "자산 수량",
+    "source": {
+      "tip": "팁",
+      "gift": "선물",
+      "purchase": "구매",
+      "settlement": "정산",
+      "asset": "자산"
+    },
+    "status": {
+      "active": "활성",
+      "locked": "잠김",
+      "consumed": "사용됨",
+      "revoked": "회수됨",
+      "expired": "만료됨",
+      "pending": "대기",
+      "available": "정산 가능",
+      "settled": "정산됨",
+      "held": "보류",
+      "frozen": "동결",
+      "reversed": "취소됨",
+      "failed": "실패",
+      "canceled": "취소됨",
+      "provisioned": "지급됨",
+      "processing": "처리 중"
+    },
+    "allAssetTypes": "전체 유형",
+    "viewAssets": "자산 보기",
+    "purchaseDeliveryStatus": "구매 지급 상태",
+    "deliveryTarget": "지급 대상",
+    "chooseRecipient": "받는 사람 선택",
+    "searchRecipient": "친구 또는 최근 채팅 검색",
+    "noRecipients": "선택할 연락처가 없습니다. 프로필이나 채팅에서 바로 보낼 수 있습니다.",
+    "sendTo": "받는 사람",
+    "customAmount": "직접 입력",
+    "chooseAsset": "자산 선택",
+    "noGiftableAssets": "선물 가능한 자산이 없습니다",
+    "confirmation": "확인",
+    "deliveryType": "구매자가 받을 항목",
+    "assetDelivery": "자산 지급",
+    "assetDeliveryHint": "구매가 완료되면 자산이 구매자의 자산 라이브러리에 지급됩니다.",
+    "assetDefinitionsCount": "자산 템플릿 {{count}}개",
+    "assetNamePlaceholder": "구매자에게 보일 자산 이름",
+    "assetDescriptionPlaceholder": "이 자산에 대한 짧은 설명",
+    "deliveryPreset": {
+      "service": "서비스 권한",
+      "badge": "배지",
+      "gift": "디지털 선물",
+      "service_ticket": "서비스 티켓"
+    },
+    "deliveryPresetHint": {
+      "service": "접근 권한, 멤버십, 파일, 수동 서비스 제공에 적합합니다.",
+      "badge": "후원자나 멤버를 위한 영구 배지입니다.",
+      "gift": "양도하거나 수집할 수 있는 디지털 선물입니다.",
+      "service_ticket": "1회 서비스나 이벤트에 사용할 수 있는 티켓입니다."
+    },
+    "tipEntryTitle": "빠르게 응원 보내기",
+    "tipEntryHint": "친구나 최근 채팅을 선택하고 금액과 짧은 메시지를 더해 보낼 수 있습니다.",
+    "giftEntryTitle": "코인과 보유 자산 선물하기",
+    "giftEntryHint": "새우 코인, 배지, 디지털 선물, 서비스 티켓을 자산함에서 보낼 수 있습니다.",
+    "estimatedBalanceAfter": "보낸 후 잔액",
+    "insufficientBalance": "현재 잔액이 부족해 보낼 수 없습니다.",
+    "assetQuantityExceeded": "선물 수량이 현재 보유 수량을 초과했습니다.",
+    "sentTo": "{{name}}님에게 보냈습니다",
+    "sendAnother": "한 번 더 보내기",
+    "confirm": {
+      "consume": "이 자산을 지금 사용하시겠습니까? 남은 수량이 줄어들 수 있습니다.",
+      "revoke": "이 자산을 회수하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+    }
+  },
+  "buddy": "Buddy"
 }

--- a/apps/web/src/lib/locales/ko.json
+++ b/apps/web/src/lib/locales/ko.json
@@ -30,7 +30,8 @@
     "bot": "Buddy",
     "shrimpCoin": "쉬림프 코인",
     "done": "완료",
-    "unknown": "알 수 없음"
+    "unknown": "알 수 없음",
+    "buddy": "Buddy"
   },
   "nav": {
     "features": "기능 소개",
@@ -2448,6 +2449,5 @@
       "consume": "이 자산을 지금 사용하시겠습니까? 남은 수량이 줄어들 수 있습니다.",
       "revoke": "이 자산을 회수하시겠습니까? 이 작업은 되돌릴 수 없습니다."
     }
-  },
-  "buddy": "Buddy"
+  }
 }

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -28,7 +28,9 @@
     "close": "关闭",
     "back": "返回",
     "bot": "Buddy",
-    "shrimpCoin": "虾币"
+    "shrimpCoin": "虾币",
+    "done": "完成",
+    "unknown": "未知"
   },
   "nav": {
     "features": "特色功能",
@@ -775,6 +777,9 @@
     "deleteConfirm": "确定要删除这条消息吗？",
     "copyMessage": "复制消息",
     "shareLink": "分享消息链接",
+    "sendFailed": "发送失败",
+    "retry": "重试",
+    "selectMessages": "多选消息",
     "loading": "加载中...",
     "loadingOlder": "加载更早的消息...",
     "downloadFile": "下载文件",
@@ -844,7 +849,8 @@
       "manual_pending": "待人工处理",
       "failed": "发货异常"
     },
-    "copyFailed": "复制失败"
+    "copyFailed": "复制失败",
+    "typing": "正在输入..."
   },
   "member": {
     "online": "在线",
@@ -1035,7 +1041,8 @@
     "tagDeploy": "部署",
     "tagCustom": "自定义",
     "tagMcp": "MCP",
-    "tagApi": "API"
+    "tagApi": "API",
+    "owner": "所有者"
   },
   "pricing": {
     "pageTitle": "简单透明的定价",
@@ -1738,7 +1745,8 @@
     "tipSearch": "搜索",
     "tipSearchDesc": "输入用户名快速定位联系人",
     "tipAdd": "添加",
-    "tipAddDesc": "点击 + 图标通过用户名添加好友"
+    "tipAddDesc": "点击 + 图标通过用户名添加好友",
+    "inputPlaceholderToUser": "给 @{{name}} 发送消息"
   },
   "openclaw": {
     "nav": {
@@ -2089,7 +2097,8 @@
     "expense": "支出",
     "transactionNote": "备注",
     "balanceAfter": "余额",
-    "rechargeBtn": "去充值"
+    "rechargeBtn": "去充值",
+    "frozen": "冻结"
   },
   "commerce": {
     "myShop": "我的店铺",
@@ -2200,6 +2209,8 @@
     "cancelFailed": "取消失败",
     "noOrders": "暂无发货记录",
     "buyer": "买家",
+    "buyerPreview": "买家预览",
+    "serviceDeliveryHint": "买家会获得创作者描述的服务权益或人工交付。",
     "entitlementGroups": {
       "active": "可用权益",
       "expiring": "即将到期",
@@ -2214,6 +2225,7 @@
       "service": "虚拟服务",
       "workspace_file": "付费文件",
       "digital_asset": "数字资产",
+      "community_asset": "社区资产",
       "subscription": "订阅权益",
       "external_resource": "外部资源"
     },
@@ -2328,5 +2340,114 @@
       "pricingTitle": "算力你全有。",
       "pricingDesc": "Shop 的收入覆盖算力成本 — 创作者承担基础设施，同时保留资源归属。"
     }
-  }
+  },
+  "communityEconomy": {
+    "assets": "社区资产",
+    "settlements": "结算",
+    "actions": "打赏与赠送",
+    "assetCount": "{{count}} 个资产",
+    "noAssets": "暂无资产",
+    "noAssetsHint": "购买、发放或收到的社区资产会显示在这里。",
+    "quantity": "数量",
+    "remaining": "剩余",
+    "type": "类型",
+    "expiresAt": "到期时间",
+    "never": "永久",
+    "consume": "消费",
+    "lock": "锁定",
+    "unlock": "解锁",
+    "revoke": "撤销",
+    "settleAvailable": "结算可用项",
+    "totalLines": "总数",
+    "availableLines": "可结算",
+    "pendingNet": "待入账净额",
+    "noSettlements": "暂无结算记录",
+    "noSettlementsHint": "打赏、赠送和创作者收入会先进入这里，再按周期结算。",
+    "availableAt": "可用时间",
+    "notAvailable": "暂不可用",
+    "settledAt": "结算时间",
+    "gross": "总额",
+    "fee": "费用",
+    "net": "净额",
+    "sendTip": "发送打赏",
+    "sendGift": "发送赠送",
+    "recipientUserId": "接收方用户 ID",
+    "amount": "金额",
+    "message": "留言",
+    "tipSent": "打赏已发送",
+    "giftSent": "赠送已发送",
+    "operationFailed": "操作失败",
+    "currencyGiftAmount": "虾币赠送金额",
+    "assetGift": "资产赠送",
+    "noAssetGift": "不赠送资产",
+    "assetQuantity": "资产数量",
+    "source": {
+      "tip": "打赏",
+      "gift": "赠送",
+      "purchase": "购买",
+      "settlement": "结算",
+      "asset": "资产"
+    },
+    "status": {
+      "active": "可用",
+      "locked": "已锁定",
+      "consumed": "已消费",
+      "revoked": "已撤销",
+      "expired": "已过期",
+      "pending": "待结算",
+      "available": "可结算",
+      "settled": "已结算",
+      "held": "暂挂",
+      "frozen": "冻结",
+      "reversed": "已冲正",
+      "failed": "失败",
+      "canceled": "已取消",
+      "provisioned": "已发放",
+      "processing": "处理中"
+    },
+    "allAssetTypes": "全部类型",
+    "viewAssets": "查看资产",
+    "purchaseDeliveryStatus": "购买发放状态",
+    "deliveryTarget": "发放对象",
+    "chooseRecipient": "选择接收人",
+    "searchRecipient": "搜索好友或最近聊天",
+    "noRecipients": "暂无可选联系人。可以从用户主页或聊天窗口直接发起。",
+    "sendTo": "发送给",
+    "customAmount": "自定义金额",
+    "chooseAsset": "选择资产",
+    "noGiftableAssets": "暂无可赠送资产",
+    "confirmation": "确认发送",
+    "deliveryType": "买家将获得",
+    "assetDelivery": "资产发放",
+    "assetDeliveryHint": "购买完成后，资产会进入买家的资产库。",
+    "assetDefinitionsCount": "{{count}} 个资产模板",
+    "assetNamePlaceholder": "买家看到的资产名称",
+    "assetDescriptionPlaceholder": "这份资产的简短说明",
+    "deliveryPreset": {
+      "service": "服务权益",
+      "badge": "身份徽章",
+      "gift": "数字礼物",
+      "service_ticket": "服务券"
+    },
+    "deliveryPresetHint": {
+      "service": "适合访问权限、会员、文件或人工服务交付。",
+      "badge": "适合粉丝、成员或早鸟身份的永久徽章。",
+      "gift": "适合可转赠、可收藏的数字礼物。",
+      "service_ticket": "适合可核销的一次性服务或活动凭证。"
+    },
+    "tipEntryTitle": "快速表达支持",
+    "tipEntryHint": "选择好友或最近聊天，点选金额并附上一句留言即可发送。",
+    "giftEntryTitle": "赠送虾币和已有资产",
+    "giftEntryHint": "可以把虾币、徽章、数字礼物或服务券从资产库中赠送给对方。",
+    "estimatedBalanceAfter": "发送后余额",
+    "insufficientBalance": "当前余额不足，无法完成发送。",
+    "assetQuantityExceeded": "赠送数量超过当前可用资产数量。",
+    "sentTo": "已发送给 {{name}}",
+    "sendAnother": "再发一笔",
+    "confirm": {
+      "consume": "确认现在使用这份资产吗？可用数量会减少。",
+      "revoke": "确认撤销这份资产吗？该操作不可恢复。"
+    }
+  },
+  "buddy": "Buddy"
 }

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -30,7 +30,8 @@
     "bot": "Buddy",
     "shrimpCoin": "虾币",
     "done": "完成",
-    "unknown": "未知"
+    "unknown": "未知",
+    "buddy": "Buddy"
   },
   "nav": {
     "features": "特色功能",
@@ -2448,6 +2449,5 @@
       "consume": "确认现在使用这份资产吗？可用数量会减少。",
       "revoke": "确认撤销这份资产吗？该操作不可恢复。"
     }
-  },
-  "buddy": "Buddy"
+  }
 }

--- a/apps/web/src/lib/locales/zh-TW.json
+++ b/apps/web/src/lib/locales/zh-TW.json
@@ -28,7 +28,9 @@
     "close": "關閉",
     "back": "返回",
     "bot": "Buddy",
-    "shrimpCoin": "蝦幣"
+    "shrimpCoin": "蝦幣",
+    "done": "完成",
+    "unknown": "未知"
   },
   "nav": {
     "features": "特色功能",
@@ -587,6 +589,9 @@
     "deleteConfirm": "確定要刪除此訊息嗎？",
     "copyMessage": "複製訊息",
     "shareLink": "分享訊息連結",
+    "sendFailed": "發送失敗",
+    "retry": "重試",
+    "selectMessages": "多選訊息",
     "loading": "載入中...",
     "loadingOlder": "載入更早的訊息...",
     "downloadFile": "下載檔案",
@@ -656,7 +661,8 @@
       "manual_pending": "待人工處理",
       "failed": "發貨異常"
     },
-    "copyFailed": "複製失敗"
+    "copyFailed": "複製失敗",
+    "typing": "正在輸入..."
   },
   "member": {
     "online": "線上",
@@ -847,7 +853,8 @@
     "tagDeploy": "部署",
     "tagCustom": "自訂",
     "tagMcp": "MCP",
-    "tagApi": "API"
+    "tagApi": "API",
+    "owner": "擁有者"
   },
   "pricing": {
     "pageTitle": "簡單透明的定價",
@@ -1550,7 +1557,8 @@
     "tipSearch": "搜尋",
     "tipSearchDesc": "輸入使用者名稱快速定位聯絡人",
     "tipAdd": "新增",
-    "tipAddDesc": "點擊 + 圖示透過使用者名稱新增好友"
+    "tipAddDesc": "點擊 + 圖示透過使用者名稱新增好友",
+    "inputPlaceholderToUser": "傳送訊息給 @{{name}}"
   },
   "openclaw": {
     "nav": {
@@ -1891,7 +1899,8 @@
     "expense": "支出",
     "transactionNote": "備註",
     "balanceAfter": "餘額",
-    "rechargeBtn": "去充值"
+    "rechargeBtn": "去充值",
+    "frozen": "凍結"
   },
   "commerce": {
     "myShop": "我的店鋪",
@@ -2002,6 +2011,8 @@
     "cancelFailed": "取消失敗",
     "noOrders": "暫無發貨記錄",
     "buyer": "買家",
+    "buyerPreview": "買家預覽",
+    "serviceDeliveryHint": "買家會獲得創作者描述的服務權益或人工交付。",
     "entitlementGroups": {
       "active": "可用權益",
       "expiring": "即將到期",
@@ -2016,6 +2027,7 @@
       "service": "虛擬服務",
       "workspace_file": "付費檔案",
       "digital_asset": "數位資產",
+      "community_asset": "社群資產",
       "subscription": "訂閱權益",
       "external_resource": "外部資源"
     },
@@ -2328,5 +2340,114 @@
       "deployInfrastructureFailed": "部署服務暫時遇到環境問題，蝦幣會自動退回。你可以稍後再試，或從 Cloud 頁面查看部署記錄。",
       "deployTimeout": "部署還在進行中，請稍後從 Cloud 頁面查看。"
     }
-  }
+  },
+  "communityEconomy": {
+    "assets": "社群資產",
+    "settlements": "結算",
+    "actions": "打賞與贈送",
+    "assetCount": "{{count}} 個資產",
+    "noAssets": "暫無資產",
+    "noAssetsHint": "購買、發放或收到的社群資產會顯示在這裡。",
+    "quantity": "數量",
+    "remaining": "剩餘",
+    "type": "類型",
+    "expiresAt": "到期時間",
+    "never": "永久",
+    "consume": "消耗",
+    "lock": "鎖定",
+    "unlock": "解鎖",
+    "revoke": "撤銷",
+    "settleAvailable": "結算可用項",
+    "totalLines": "總數",
+    "availableLines": "可結算",
+    "pendingNet": "待入帳淨額",
+    "noSettlements": "暫無結算記錄",
+    "noSettlementsHint": "打賞、贈送和創作者收入會先進入這裡，再按週期結算。",
+    "availableAt": "可用時間",
+    "notAvailable": "暫不可用",
+    "settledAt": "結算時間",
+    "gross": "總額",
+    "fee": "費用",
+    "net": "淨額",
+    "sendTip": "發送打賞",
+    "sendGift": "發送贈送",
+    "recipientUserId": "接收方使用者 ID",
+    "amount": "金額",
+    "message": "留言",
+    "tipSent": "打賞已發送",
+    "giftSent": "贈送已發送",
+    "operationFailed": "操作失敗",
+    "currencyGiftAmount": "蝦幣贈送金額",
+    "assetGift": "資產贈送",
+    "noAssetGift": "不贈送資產",
+    "assetQuantity": "資產數量",
+    "source": {
+      "tip": "打賞",
+      "gift": "贈送",
+      "purchase": "購買",
+      "settlement": "結算",
+      "asset": "資產"
+    },
+    "status": {
+      "active": "可用",
+      "locked": "已鎖定",
+      "consumed": "已消耗",
+      "revoked": "已撤銷",
+      "expired": "已過期",
+      "pending": "待結算",
+      "available": "可結算",
+      "settled": "已結算",
+      "held": "暫掛",
+      "frozen": "凍結",
+      "reversed": "已沖正",
+      "failed": "失敗",
+      "canceled": "已取消",
+      "provisioned": "已發放",
+      "processing": "處理中"
+    },
+    "allAssetTypes": "全部類型",
+    "viewAssets": "查看資產",
+    "purchaseDeliveryStatus": "購買發放狀態",
+    "deliveryTarget": "發放對象",
+    "chooseRecipient": "選擇接收人",
+    "searchRecipient": "搜尋好友或最近聊天",
+    "noRecipients": "暫無可選聯絡人。可以從使用者主頁或聊天視窗直接發起。",
+    "sendTo": "發送給",
+    "customAmount": "自訂金額",
+    "chooseAsset": "選擇資產",
+    "noGiftableAssets": "暫無可贈送資產",
+    "confirmation": "確認發送",
+    "deliveryType": "買家將獲得",
+    "assetDelivery": "資產發放",
+    "assetDeliveryHint": "購買完成後，資產會進入買家的資產庫。",
+    "assetDefinitionsCount": "{{count}} 個資產模板",
+    "assetNamePlaceholder": "買家看到的資產名稱",
+    "assetDescriptionPlaceholder": "這份資產的簡短說明",
+    "deliveryPreset": {
+      "service": "服務權益",
+      "badge": "身份徽章",
+      "gift": "數位禮物",
+      "service_ticket": "服務券"
+    },
+    "deliveryPresetHint": {
+      "service": "適合存取權限、會員、檔案或人工服務交付。",
+      "badge": "適合粉絲、成員或早鳥身份的永久徽章。",
+      "gift": "適合可轉贈、可收藏的數位禮物。",
+      "service_ticket": "適合可核銷的一次性服務或活動憑證。"
+    },
+    "tipEntryTitle": "快速表達支持",
+    "tipEntryHint": "選擇好友或最近聊天，點選金額並附上一句留言即可發送。",
+    "giftEntryTitle": "贈送蝦幣和已有資產",
+    "giftEntryHint": "可以把蝦幣、徽章、數位禮物或服務券從資產庫中贈送給對方。",
+    "estimatedBalanceAfter": "發送後餘額",
+    "insufficientBalance": "目前餘額不足，無法完成發送。",
+    "assetQuantityExceeded": "贈送數量超過目前可用資產數量。",
+    "sentTo": "已發送給 {{name}}",
+    "sendAnother": "再發一筆",
+    "confirm": {
+      "consume": "確認現在使用這份資產嗎？可用數量會減少。",
+      "revoke": "確認撤銷這份資產嗎？此操作不可復原。"
+    }
+  },
+  "buddy": "Buddy"
 }

--- a/apps/web/src/lib/locales/zh-TW.json
+++ b/apps/web/src/lib/locales/zh-TW.json
@@ -30,7 +30,8 @@
     "bot": "Buddy",
     "shrimpCoin": "蝦幣",
     "done": "完成",
-    "unknown": "未知"
+    "unknown": "未知",
+    "buddy": "Buddy"
   },
   "nav": {
     "features": "特色功能",
@@ -2448,6 +2449,5 @@
       "consume": "確認現在使用這份資產嗎？可用數量會減少。",
       "revoke": "確認撤銷這份資產嗎？此操作不可復原。"
     }
-  },
-  "buddy": "Buddy"
+  }
 }

--- a/apps/web/src/pages/commerce.tsx
+++ b/apps/web/src/pages/commerce.tsx
@@ -1,13 +1,15 @@
-import { Button, GlassPanel, Input } from '@shadowob/ui'
+import { Button, cn, GlassPanel, Input } from '@shadowob/ui'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from '@tanstack/react-router'
 import {
+  Award,
   CalendarClock,
   CheckCircle2,
   ChevronRight,
   Clock3,
   ExternalLink,
   FileText,
+  Gem,
   Loader2,
   Package,
   ReceiptText,
@@ -16,6 +18,7 @@ import {
   ShieldCheck,
   ShoppingBag,
   Store,
+  Ticket,
   Trash2,
   UserRound,
   WalletCards,
@@ -111,6 +114,15 @@ type Provisioning = {
   capability?: string | null
 }
 
+type FulfillmentJob = {
+  id: string
+  deliverableId?: string | null
+  status: string
+  resultMessageId?: string | null
+  lastErrorCode?: string | null
+  metadata?: Record<string, unknown> | null
+}
+
 type ProductEntitlementConfig = {
   resourceType?: string
   resourceId?: string
@@ -122,9 +134,39 @@ type ProductEntitlementConfig = {
 
 type EntitlementFilter = 'all' | 'openable' | 'expiring' | 'history'
 type ShopSettingsSection = 'shop' | 'orders'
+type DeliveryPreset = 'service' | 'badge' | 'gift' | 'service_ticket'
+type CommunityAssetType =
+  | 'badge'
+  | 'gift'
+  | 'coupon'
+  | 'service_ticket'
+  | 'collectible'
+  | 'content_pass'
+  | 'reward'
+
+interface ShopAssetDefinition {
+  id: string
+  assetType: CommunityAssetType
+  name: string
+  description?: string | null
+  imageUrl?: string | null
+  giftable: boolean
+  consumable: boolean
+  status: string
+}
 
 const BILLING_MODES: BillingMode[] = ['one_time', 'fixed_duration', 'subscription']
 const RESOURCE_CAPABILITIES: ResourceCapability[] = ['use', 'view', 'download', 'redeem', 'manage']
+const DELIVERY_PRESETS: Array<{
+  value: DeliveryPreset
+  icon: typeof ShieldCheck
+  assetType?: CommunityAssetType
+}> = [
+  { value: 'service', icon: ShieldCheck },
+  { value: 'badge', icon: Award, assetType: 'badge' },
+  { value: 'gift', icon: Gem, assetType: 'gift' },
+  { value: 'service_ticket', icon: Ticket, assetType: 'service_ticket' },
+]
 
 const selectClassName =
   'h-11 rounded-xl border border-border-subtle bg-bg-secondary px-3 text-sm font-bold text-text-primary outline-none transition focus:border-primary/60'
@@ -231,13 +273,19 @@ function ProductMeta({ product }: { product: Product }) {
   const config = firstEntitlementConfig(product)
   const durationSeconds = config?.durationSeconds ?? config?.renewalPeriodSeconds ?? null
   const durationDays = durationSeconds ? Math.ceil(durationSeconds / 86400) : null
+  const isCommunityAsset = config?.resourceType === 'community_asset'
 
   return (
     <div className="flex flex-wrap items-center gap-2 text-xs font-bold text-text-muted">
-      <CommercePill tone="primary" icon={<ShieldCheck size={13} />}>
-        {t(`commerce.resourceTypes.${config?.resourceType ?? 'service'}`, {
-          defaultValue: config?.resourceType ?? t('commerce.resourceEntitlement'),
-        })}
+      <CommercePill
+        tone="primary"
+        icon={isCommunityAsset ? <Package size={13} /> : <ShieldCheck size={13} />}
+      >
+        {isCommunityAsset
+          ? t('communityEconomy.assetDelivery')
+          : t(`commerce.resourceTypes.${config?.resourceType ?? 'service'}`, {
+              defaultValue: t('commerce.resourceEntitlement'),
+            })}
       </CommercePill>
       <CommercePill icon={<Clock3 size={13} />}>
         {t(`commerce.billingModes.${product.billingMode ?? 'one_time'}`)}
@@ -245,6 +293,52 @@ function ProductMeta({ product }: { product: Product }) {
       <CommercePill icon={<CalendarClock size={13} />}>
         {durationDays ? t('commerce.validDays', { count: durationDays }) : t('commerce.permanent')}
       </CommercePill>
+    </div>
+  )
+}
+
+function ProductDeliverySummary({
+  product,
+  compact = false,
+}: {
+  product: Product
+  compact?: boolean
+}) {
+  const { t } = useTranslation()
+  const config = firstEntitlementConfig(product)
+  const isCommunityAsset = config?.resourceType === 'community_asset'
+  const title = isCommunityAsset
+    ? t('communityEconomy.assetDelivery')
+    : t(`commerce.resourceTypes.${config?.resourceType ?? 'service'}`, {
+        defaultValue: t('commerce.resourceEntitlement'),
+      })
+  const description =
+    config?.privilegeDescription ||
+    product.summary ||
+    (isCommunityAsset ? t('communityEconomy.assetDeliveryHint') : t('commerce.serviceDeliveryHint'))
+  const Icon = isCommunityAsset ? Package : ShieldCheck
+
+  if (compact) {
+    return (
+      <div className="mt-2 flex items-start gap-2 rounded-xl bg-bg-secondary/60 px-3 py-2 text-xs leading-5 text-text-secondary">
+        <Icon size={15} className="mt-0.5 shrink-0 text-primary" />
+        <span className="min-w-0">
+          <span className="font-black text-text-primary">{title}</span>
+          <span className="mx-1 text-text-muted">·</span>
+          <span>{description}</span>
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-border-subtle bg-bg-secondary/60 p-3">
+      <div className="flex items-center gap-2 text-xs font-bold text-text-muted">
+        <Icon size={15} className="text-primary" />
+        {t('communityEconomy.deliveryType')}
+      </div>
+      <div className="mt-2 text-sm font-black text-text-primary">{title}</div>
+      <p className="mt-1 text-sm leading-6 text-text-secondary">{description}</p>
     </div>
   )
 }
@@ -263,6 +357,58 @@ function ProvisioningPill({ provisioning }: { provisioning?: Provisioning | null
         defaultValue: provisioning.status,
       })}
     </CommercePill>
+  )
+}
+
+function PurchaseDeliveryStatus({
+  provisioning,
+  fulfillmentJobs,
+}: {
+  provisioning?: Provisioning | null
+  fulfillmentJobs: FulfillmentJob[]
+}) {
+  const { t } = useTranslation()
+  const primaryJob = fulfillmentJobs[0]
+  const status = primaryJob?.status ?? provisioning?.status ?? 'provisioned'
+  const isCommunityAsset = provisioning?.resourceType === 'community_asset'
+  const resourceType = isCommunityAsset
+    ? t('communityEconomy.assetDelivery')
+    : t(`commerce.resourceTypes.${provisioning?.resourceType ?? 'service'}`, {
+        defaultValue: t('commerce.resourceEntitlement'),
+      })
+  const resourceId = provisioning?.resourceId
+  const deliveryTarget = isCommunityAsset
+    ? t('communityEconomy.assets')
+    : (resourceId ?? primaryJob?.resultMessageId ?? primaryJob?.id ?? t('common.unknown'))
+
+  return (
+    <div className="rounded-xl border border-success/20 bg-success/5 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="text-xs font-black uppercase tracking-[0.16em] text-success/80">
+            {t('communityEconomy.purchaseDeliveryStatus')}
+          </p>
+          <p className="mt-1 text-sm font-bold text-text-primary">
+            {t(`communityEconomy.status.${status}`, status)}
+          </p>
+        </div>
+        <ProvisioningPill provisioning={provisioning} />
+      </div>
+      <div className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
+        <div className="rounded-lg bg-bg-secondary/60 px-3 py-2">
+          <p className="font-black uppercase tracking-[0.12em] text-text-muted/60">
+            {t('communityEconomy.type')}
+          </p>
+          <p className="mt-1 truncate font-bold text-text-primary">{resourceType}</p>
+        </div>
+        <div className="rounded-lg bg-bg-secondary/60 px-3 py-2">
+          <p className="font-black uppercase tracking-[0.12em] text-text-muted/60">
+            {t('communityEconomy.deliveryTarget')}
+          </p>
+          <p className="mt-1 truncate font-bold text-text-primary">{deliveryTarget}</p>
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -296,6 +442,9 @@ export function PersonalShopPage({
   const [durationDays, setDurationDays] = useState('30')
   const [billingMode, setBillingMode] = useState<BillingMode>('fixed_duration')
   const [privilegeDescription, setPrivilegeDescription] = useState('')
+  const [deliveryPreset, setDeliveryPreset] = useState<DeliveryPreset>('service')
+  const [assetName, setAssetName] = useState('')
+  const [assetDescription, setAssetDescription] = useState('')
   const [activeSection, setActiveSection] = useState<ShopSettingsSection>(initialSection)
   const [shopSheet, setShopSheet] = useState<'store' | 'product' | null>(null)
   const numericPrice = Number(price)
@@ -339,6 +488,16 @@ export function PersonalShopPage({
     setActiveSection(initialSection)
   }, [initialSection])
 
+  useEffect(() => {
+    if (deliveryPreset === 'service') {
+      setResourceType('service')
+      setCapability('use')
+      return
+    }
+    setResourceType('community_asset')
+    setCapability('redeem')
+  }, [deliveryPreset])
+
   const { data: productsData, isFetching: isFetchingProducts } = useQuery({
     queryKey: ['personal-shop-products', shop?.id, keyword],
     queryFn: () =>
@@ -348,6 +507,13 @@ export function PersonalShopPage({
     enabled: Boolean(shop?.id),
   })
   const products = productsData?.products ?? []
+
+  const { data: shopAssetsData } = useQuery({
+    queryKey: ['shop-community-assets', shop?.id],
+    queryFn: () => fetchApi<{ assets: ShopAssetDefinition[] }>(`/api/shops/${shop!.id}/assets`),
+    enabled: Boolean(canManage && shop?.id),
+  })
+  const shopAssets = shopAssetsData?.assets ?? []
 
   const saveShop = useMutation({
     mutationFn: () => {
@@ -372,9 +538,30 @@ export function PersonalShopPage({
   })
 
   const createProduct = useMutation({
-    mutationFn: () => {
+    mutationFn: async () => {
       const durationSeconds = numericDurationDays > 0 ? numericDurationDays * 24 * 60 * 60 : null
-      return fetchApi<Product>(`/api/shops/${shop!.id}/products`, {
+      const selectedPreset = DELIVERY_PRESETS.find((preset) => preset.value === deliveryPreset)
+      let assetDefinition: ShopAssetDefinition | null = null
+      if (selectedPreset?.assetType) {
+        assetDefinition = await fetchApi<ShopAssetDefinition>(`/api/shops/${shop!.id}/assets`, {
+          method: 'POST',
+          body: JSON.stringify({
+            assetType: selectedPreset.assetType,
+            name: assetName.trim() || name.trim(),
+            description: assetDescription.trim() || summary.trim() || null,
+            giftable: true,
+            transferable: true,
+            consumable: selectedPreset.assetType === 'service_ticket',
+            revocable: true,
+            expiresAfterDays:
+              billingMode === 'one_time' || !numericDurationDays ? null : numericDurationDays,
+            status: 'active',
+            metadata: { createdFrom: 'creator_product', deliveryPreset },
+          }),
+        })
+      }
+
+      const product = await fetchApi<Product>(`/api/shops/${shop!.id}/products`, {
         method: 'POST',
         body: JSON.stringify({
           name: name.trim(),
@@ -385,23 +572,48 @@ export function PersonalShopPage({
           summary: summary.trim() || undefined,
           basePrice: Math.round(numericPrice),
           entitlementConfig: {
-            resourceType: resourceType.trim() || 'service',
-            resourceId: resourceId.trim() || undefined,
-            capability,
+            resourceType: assetDefinition ? 'community_asset' : resourceType.trim() || 'service',
+            resourceId: assetDefinition?.id ?? (resourceId.trim() || undefined),
+            capability: assetDefinition ? 'redeem' : capability,
             durationSeconds: billingMode === 'one_time' ? null : durationSeconds,
             renewalPeriodSeconds: billingMode === 'subscription' ? durationSeconds : undefined,
-            privilegeDescription: privilegeDescription.trim() || undefined,
+            privilegeDescription:
+              privilegeDescription.trim() ||
+              assetDescription.trim() ||
+              (assetDefinition ? assetDefinition.description : undefined),
           },
         }),
       })
+      if (assetDefinition) {
+        const offers = await fetchApi<{ offers: Array<{ id: string; productId: string }> }>(
+          `/api/shops/${shop!.id}/offers?keyword=${encodeURIComponent(name.trim())}`,
+        )
+        const offer = offers.offers.find((item) => item.productId === product.id)
+        if (offer) {
+          await fetchApi(`/api/shops/${shop!.id}/offers/${offer.id}/deliverables`, {
+            method: 'POST',
+            body: JSON.stringify({
+              kind: 'community_asset',
+              resourceType: 'community_asset',
+              resourceId: assetDefinition.id,
+              metadata: { deliveryPreset, productId: product.id },
+            }),
+          })
+        }
+      }
+      return product
     },
     onSuccess: async () => {
       setName('')
       setSummary('')
       setResourceId('')
       setPrivilegeDescription('')
+      setAssetName('')
+      setAssetDescription('')
+      setDeliveryPreset('service')
       setShopSheet(null)
       await queryClient.invalidateQueries({ queryKey: ['personal-shop-products', shop?.id] })
+      await queryClient.invalidateQueries({ queryKey: ['shop-community-assets', shop?.id] })
       showToast(t('commerce.productCreated'), 'success')
     },
     onError: (err) =>
@@ -440,6 +652,13 @@ export function PersonalShopPage({
       icon: <ReceiptText size={13} />,
     },
   ]
+  const selectedDeliveryPreset = DELIVERY_PRESETS.find((preset) => preset.value === deliveryPreset)
+  const PreviewDeliveryIcon = selectedDeliveryPreset?.icon ?? ShieldCheck
+  const selectedDeliveryLabel = t(`communityEconomy.deliveryPreset.${deliveryPreset}`)
+  const selectedDeliveryHint = t(`communityEconomy.deliveryPresetHint.${deliveryPreset}`)
+  const buyerPreviewName = name.trim() || t('commerce.productName')
+  const buyerPreviewSummary =
+    summary.trim() || privilegeDescription.trim() || assetDescription.trim() || selectedDeliveryHint
 
   if (isLoading) {
     return (
@@ -475,6 +694,9 @@ export function PersonalShopPage({
                 <span>
                   <span className="text-text-primary tabular-nums">{products.length}</span>{' '}
                   {t('commerce.activeProducts')}
+                </span>
+                <span>
+                  {t('communityEconomy.assetDefinitionsCount', { count: shopAssets.length })}
                 </span>
                 <span>
                   {t('commerce.currentSection')}{' '}
@@ -596,7 +818,9 @@ export function PersonalShopPage({
                           )}
                         </>
                       }
-                    />
+                    >
+                      <ProductDeliverySummary product={product} compact />
+                    </CommerceListItem>
                   )
                 })
               )}
@@ -668,11 +892,39 @@ export function PersonalShopPage({
                 onChange={(e) => setSummary(e.target.value)}
                 placeholder={t('commerce.productSummary')}
               />
-              <Input
-                value={resourceType}
-                onChange={(e) => setResourceType(e.target.value)}
-                placeholder={t('commerce.resourceType')}
-              />
+              <div className="grid gap-2">
+                <span className="text-xs font-black uppercase tracking-[0.12em] text-text-muted">
+                  {t('communityEconomy.deliveryType')}
+                </span>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {DELIVERY_PRESETS.map((preset) => {
+                    const Icon = preset.icon
+                    return (
+                      <button
+                        key={preset.value}
+                        type="button"
+                        onClick={() => setDeliveryPreset(preset.value)}
+                        className={cn(
+                          'rounded-2xl border p-3 text-left transition',
+                          deliveryPreset === preset.value
+                            ? 'border-primary/50 bg-primary/10 text-primary'
+                            : 'border-border-subtle bg-bg-secondary/50 text-text-secondary hover:border-primary/30',
+                        )}
+                      >
+                        <span className="mb-2 flex h-9 w-9 items-center justify-center rounded-xl bg-bg-primary/70">
+                          <Icon size={18} />
+                        </span>
+                        <span className="block text-sm font-black">
+                          {t(`communityEconomy.deliveryPreset.${preset.value}`)}
+                        </span>
+                        <span className="mt-1 block text-xs leading-5 text-text-muted">
+                          {t(`communityEconomy.deliveryPresetHint.${preset.value}`)}
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
               <select
                 className={selectClassName}
                 value={billingMode}
@@ -699,28 +951,81 @@ export function PersonalShopPage({
                   inputMode="numeric"
                 />
               </div>
-              <select
-                className={selectClassName}
-                value={capability}
-                onChange={(e) => setCapability(e.target.value as ResourceCapability)}
-                aria-label={t('commerce.capability')}
-              >
-                {RESOURCE_CAPABILITIES.map((item) => (
-                  <option key={item} value={item}>
-                    {t(`commerce.capabilities.${item}`)}
-                  </option>
-                ))}
-              </select>
-              <Input
-                value={resourceId}
-                onChange={(e) => setResourceId(e.target.value)}
-                placeholder={t('commerce.resourceId')}
-              />
+              {deliveryPreset === 'service' ? (
+                <>
+                  <select
+                    className={selectClassName}
+                    value={capability}
+                    onChange={(e) => setCapability(e.target.value as ResourceCapability)}
+                    aria-label={t('commerce.capability')}
+                  >
+                    {RESOURCE_CAPABILITIES.map((item) => (
+                      <option key={item} value={item}>
+                        {t(`commerce.capabilities.${item}`)}
+                      </option>
+                    ))}
+                  </select>
+                  <Input
+                    value={resourceId}
+                    onChange={(e) => setResourceId(e.target.value)}
+                    placeholder={t('commerce.resourceId')}
+                  />
+                </>
+              ) : (
+                <div className="grid gap-3 rounded-2xl border border-border-subtle bg-bg-secondary/50 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-xs font-black uppercase tracking-[0.12em] text-text-muted">
+                      {t('communityEconomy.assetDelivery')}
+                    </span>
+                    <span className="text-xs font-bold text-text-muted">
+                      {t('communityEconomy.assetDefinitionsCount', { count: shopAssets.length })}
+                    </span>
+                  </div>
+                  <Input
+                    value={assetName}
+                    onChange={(e) => setAssetName(e.target.value)}
+                    placeholder={t('communityEconomy.assetNamePlaceholder')}
+                  />
+                  <Input
+                    value={assetDescription}
+                    onChange={(e) => setAssetDescription(e.target.value)}
+                    placeholder={t('communityEconomy.assetDescriptionPlaceholder')}
+                  />
+                </div>
+              )}
               <Input
                 value={privilegeDescription}
                 onChange={(e) => setPrivilegeDescription(e.target.value)}
                 placeholder={t('commerce.privilegeDescription')}
               />
+              <div className="rounded-2xl border border-primary/20 bg-primary/[0.06] p-4">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <span className="text-xs font-black uppercase tracking-[0.12em] text-primary">
+                    {t('commerce.buyerPreview')}
+                  </span>
+                  <CommercePill tone="primary" icon={<PreviewDeliveryIcon size={13} />}>
+                    {selectedDeliveryLabel}
+                  </CommercePill>
+                </div>
+                <div className="text-base font-black text-text-primary">{buyerPreviewName}</div>
+                <p className="mt-1 text-sm leading-6 text-text-secondary">{buyerPreviewSummary}</p>
+                <div className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
+                  <div className="rounded-xl bg-bg-primary/55 px-3 py-2">
+                    <div className="font-black uppercase tracking-[0.12em] text-text-muted">
+                      {t('commerce.productPrice')}
+                    </div>
+                    <div className="mt-1">
+                      <PriceBadge amount={Number.isFinite(numericPrice) ? numericPrice : 0} />
+                    </div>
+                  </div>
+                  <div className="rounded-xl bg-bg-primary/55 px-3 py-2">
+                    <div className="font-black uppercase tracking-[0.12em] text-text-muted">
+                      {t('communityEconomy.deliveryType')}
+                    </div>
+                    <div className="mt-1 font-black text-text-primary">{selectedDeliveryLabel}</div>
+                  </div>
+                </div>
+              </div>
             </div>
           </CommerceDrawer>
         </>
@@ -742,16 +1047,18 @@ export function ProductDetailPage() {
 
   const purchase = useMutation({
     mutationFn: () =>
-      fetchApi<{ entitlement: Entitlement; provisioning?: Provisioning }>(
-        `/api/shops/${product!.shopId}/products/${product!.id}/purchase`,
-        {
-          method: 'POST',
-          body: JSON.stringify({ idempotencyKey: crypto.randomUUID() }),
-        },
-      ),
+      fetchApi<{
+        entitlement: Entitlement
+        provisioning?: Provisioning
+        fulfillmentJobs?: FulfillmentJob[]
+      }>(`/api/shops/${product!.shopId}/products/${product!.id}/purchase`, {
+        method: 'POST',
+        body: JSON.stringify({ idempotencyKey: crypto.randomUUID() }),
+      }),
     onSuccess: async () => {
       setPurchaseError(null)
       await queryClient.invalidateQueries({ queryKey: ['entitlements'] })
+      await queryClient.invalidateQueries({ queryKey: ['community-assets'] })
       showToast(t('commerce.purchaseCompleted'), 'success')
     },
     onError: (err) => {
@@ -774,6 +1081,7 @@ export function ProductDetailPage() {
   const provisioning = purchase.data?.provisioning
   const durationSeconds = config?.durationSeconds ?? config?.renewalPeriodSeconds ?? null
   const durationDays = durationSeconds ? Math.ceil(durationSeconds / 86400) : null
+  const productIsCommunityAsset = config?.resourceType === 'community_asset'
   const modalDetails = {
     name: product.name,
     summary: product.summary,
@@ -786,8 +1094,12 @@ export function ProductDetailPage() {
     durationLabel: durationDays
       ? t('commerce.validDays', { count: durationDays })
       : t('commerce.permanent'),
-    targetLabel: config?.resourceId ?? product.id,
-    deliveryLabel: t('commerce.immediateDelivery'),
+    targetLabel: productIsCommunityAsset
+      ? t('communityEconomy.assets')
+      : (config?.resourceId ?? product.id),
+    deliveryLabel: productIsCommunityAsset
+      ? t('communityEconomy.assetDelivery')
+      : t('commerce.immediateDelivery'),
   }
 
   return (
@@ -822,32 +1134,40 @@ export function ProductDetailPage() {
                   <PriceBadge amount={product.basePrice} />
                 </div>
               </div>
-              <div className="rounded-xl border border-border-subtle bg-bg-secondary/60 p-3">
-                <div className="text-xs font-bold text-text-muted">
-                  {t('commerce.entitlementResource')}
-                </div>
-                <div className="mt-2 truncate text-sm font-bold text-text-primary">
-                  {config?.resourceId ?? product.id}
-                </div>
-              </div>
+              <ProductDeliverySummary product={product} />
             </div>
             {product.description && (
               <div className="rounded-xl border border-border-subtle bg-bg-secondary/60 p-3 text-sm leading-6 text-text-secondary">
                 {product.description}
               </div>
             )}
+            {purchase.data && (
+              <PurchaseDeliveryStatus
+                provisioning={provisioning}
+                fulfillmentJobs={purchase.data.fulfillmentJobs ?? []}
+              />
+            )}
             <div className="mt-auto flex flex-wrap items-center gap-3">
               <Button onClick={() => setShowPurchaseModal(true)} disabled={purchase.isPending}>
                 {purchase.isPending ? t('commerce.purchasing') : t('commerce.buyNow')}
               </Button>
               {purchase.data && (
-                <a
-                  href="/app/settings?tab=wallet&section=entitlements"
-                  className="inline-flex items-center gap-2 text-sm font-bold text-success"
-                >
-                  <ShieldCheck size={16} />
-                  {t('commerce.viewEntitlement')}
-                </a>
+                <div className="flex flex-wrap items-center gap-3">
+                  <a
+                    href="/app/settings?tab=wallet&section=entitlements"
+                    className="inline-flex items-center gap-2 text-sm font-bold text-success"
+                  >
+                    <ShieldCheck size={16} />
+                    {t('commerce.viewEntitlement')}
+                  </a>
+                  <a
+                    href="/app/settings?tab=wallet&section=assets"
+                    className="inline-flex items-center gap-2 text-sm font-bold text-primary"
+                  >
+                    <Package size={16} />
+                    {t('communityEconomy.viewAssets')}
+                  </a>
+                </div>
               )}
               <ProvisioningPill provisioning={provisioning} />
             </div>

--- a/apps/web/src/pages/dm-chat.tsx
+++ b/apps/web/src/pages/dm-chat.tsx
@@ -6,6 +6,8 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   ArrowLeft,
   FileText,
+  Gift,
+  HandCoins,
   Image as ImageIcon,
   Loader2,
   Paperclip,
@@ -32,6 +34,7 @@ import { FilePreviewPanel } from '../components/chat/file-preview-panel'
 import { type Message, MessageBubble, type ReactionGroup } from '../components/chat/message-bubble'
 import { UserAvatar } from '../components/common/avatar'
 import { EmojiPicker } from '../components/common/emoji-picker'
+import { CommunityEconomySendModal } from '../components/community-economy/community-economy-send-modal'
 import { useSocketEvent } from '../hooks/use-socket'
 import { fetchApi } from '../lib/api'
 import { addDmReaction, joinDm, leaveDm, sendDmMessage, sendDmTyping } from '../lib/socket'
@@ -104,7 +107,7 @@ function getCommerceCardPrice(
   t?: (key: string, options?: Record<string, unknown>) => string,
 ): string {
   if (card.snapshot.currency === 'shrimp_coin') {
-    const unit = t?.('common.shrimpCoin', { defaultValue: '虾币' }) ?? 'shrimp_coin'
+    const unit = t?.('common.shrimpCoin') ?? 'shrimp_coin'
     return `${card.snapshot.price.toLocaleString()} ${unit}`
   }
   return new Intl.NumberFormat(undefined, {
@@ -142,6 +145,7 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
   const [typingUsers, setTypingUsers] = useState<string[]>([])
   const [showEmoji, setShowEmoji] = useState(false)
   const [showProductPicker, setShowProductPicker] = useState(false)
+  const [economyModal, setEconomyModal] = useState<'tip' | 'gift' | null>(null)
   const [showAttachMenu, setShowAttachMenu] = useState(false)
   const [productQuery, setProductQuery] = useState('')
   const [selectedCommerceCards, setSelectedCommerceCards] = useState<CommerceProductCard[]>([])
@@ -653,7 +657,7 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
           </div>
           <div className="flex-1 min-w-0">
             <h3 className="font-black text-text-primary text-sm truncate">
-              {otherUser?.displayName ?? otherUser?.username ?? t('friends.chat', '聊天')}
+              {otherUser?.displayName ?? otherUser?.username ?? t('friends.chat')}
             </h3>
             {otherUser?.isBot && (
               <span className="text-[11px] font-black text-primary bg-primary/10 rounded-full px-1.5 py-0.5">
@@ -661,6 +665,48 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
               </span>
             )}
           </div>
+          {otherUser?.id && (
+            <div className="flex items-center gap-1.5 sm:hidden">
+              <Button
+                variant="ghost"
+                size="icon"
+                type="button"
+                icon={HandCoins}
+                aria-label={t('communityEconomy.sendTip')}
+                onClick={() => setEconomyModal('tip')}
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                type="button"
+                icon={Gift}
+                aria-label={t('communityEconomy.sendGift')}
+                onClick={() => setEconomyModal('gift')}
+              />
+            </div>
+          )}
+          {otherUser?.id && (
+            <div className="hidden items-center gap-2 sm:flex">
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                icon={HandCoins}
+                onClick={() => setEconomyModal('tip')}
+              >
+                {t('communityEconomy.sendTip')}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                icon={Gift}
+                onClick={() => setEconomyModal('gift')}
+              >
+                {t('communityEconomy.sendGift')}
+              </Button>
+            </div>
+          )}
         </div>
 
         {/* Messages Area — virtual list */}
@@ -680,9 +726,7 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
               <div className="w-12 h-12 rounded-2xl bg-bg-tertiary/60 flex items-center justify-center mb-3">
                 <Send size={20} className="text-text-muted/60" />
               </div>
-              <p className="text-sm">
-                {t('dm.noMessages', '还没有消息，发送第一条消息开始聊天吧！')}
-              </p>
+              <p className="text-sm">{t('dm.noMessages')}</p>
             </div>
           ) : shouldVirtualize ? (
             <div
@@ -725,7 +769,7 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
         {typingUsers.length > 0 && (
           <div className="px-4 py-1 text-[12px] text-text-muted">
             <span className="font-medium text-primary">{typingUsers.join(', ')}</span>{' '}
-            {t('chat.typing', '正在输入...')}
+            {t('chat.typing')}
           </div>
         )}
 
@@ -739,16 +783,12 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
             return (
               <div className="mx-4 mb-1 flex items-center justify-between gap-2 px-3 py-2 bg-warning/5 border border-warning/40 rounded-lg text-xs text-warning">
                 <span>
-                  {t(
-                    'dm.rentalCostTip',
-                    '🦐 今日费用警：基础日费 {{baseDailyRate}}🦐 + 消息费 {{messageFee}}🦐/条，累计花费 {{totalCost}}🦐，已发送 {{messageCount}} 条消息',
-                    {
-                      baseDailyRate: rental.baseDailyRate,
-                      messageFee: rental.messageFee,
-                      totalCost: rental.totalCost,
-                      messageCount: rental.messageCount,
-                    },
-                  )}
+                  {t('dm.rentalCostTip', {
+                    baseDailyRate: rental.baseDailyRate,
+                    messageFee: rental.messageFee,
+                    totalCost: rental.totalCost,
+                    messageCount: rental.messageCount,
+                  })}
                 </span>
                 <button
                   type="button"
@@ -772,10 +812,10 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
             <div className="flex items-center justify-center gap-2 px-4 py-3 bg-bg-tertiary/50 backdrop-blur-md rounded-xl border border-border-subtle text-text-muted text-sm">
               <span>
                 {agentChatStatus?.reason === 'rented_out'
-                  ? t('dm.chatDisabledRentedOut', '该 Buddy 已出租给其他用户，暂时无法聊天')
+                  ? t('dm.chatDisabledRentedOut')
                   : agentChatStatus?.reason === 'expired'
-                    ? t('dm.chatDisabledExpired', '使用权已到期，请续租后再使用')
-                    : t('dm.chatDisabledListed', '该 Buddy 已在集市挂单中，暂时无法聊天')}
+                    ? t('dm.chatDisabledExpired')
+                    : t('dm.chatDisabledListed')}
               </span>
             </div>
           ) : (
@@ -787,7 +827,7 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
                   return (
                     <div className="flex items-center gap-2 mb-2 px-3 py-2 bg-primary/5 border-l-2 border-primary rounded-lg text-xs">
                       <Reply size={14} className="text-primary shrink-0" />
-                      <span className="text-text-muted">{t('chat.replyingTo', '回复')}</span>
+                      <span className="text-text-muted">{t('chat.replyingTo')}</span>
                       <span className="font-medium text-text-primary truncate">
                         {replyMsg?.author?.displayName ??
                           replyMsg?.author?.username ??
@@ -995,11 +1035,10 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
                   }}
                   placeholder={
                     otherUser
-                      ? t(
-                          'dm.inputPlaceholder',
-                          `给 @${otherUser.displayName ?? otherUser.username} 发送消息`,
-                        )
-                      : t('dm.inputPlaceholderDefault', '发送消息')
+                      ? t('dm.inputPlaceholderToUser', {
+                          name: otherUser.displayName ?? otherUser.username,
+                        })
+                      : t('dm.inputPlaceholderDefault')
                   }
                   rows={1}
                   className="flex-1 bg-transparent text-text-primary text-sm px-4 py-3 outline-none resize-none max-h-[160px]"
@@ -1142,6 +1181,21 @@ export function DmChatView({ dmChannelId, onBack }: { dmChannelId: string; onBac
       {previewFile && (
         <FilePreviewPanel attachment={previewFile} onClose={() => setPreviewFile(null)} />
       )}
+      <CommunityEconomySendModal
+        open={economyModal !== null}
+        mode={economyModal ?? 'tip'}
+        recipient={
+          otherUser
+            ? {
+                id: otherUser.id,
+                username: otherUser.username,
+                displayName: otherUser.displayName,
+                avatarUrl: otherUser.avatarUrl,
+              }
+            : undefined
+        }
+        onClose={() => setEconomyModal(null)}
+      />
     </div>
   )
 }

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -25,10 +25,16 @@ import { DmChatView } from '../dm-chat'
 import { UnifiedContactSidebar } from '../friends'
 import { SettingsModal } from './settings-modal'
 import { TaskSettings } from './tasks'
-import { WalletSettings } from './wallet'
+import { WalletSettings, type WalletSettingsSection } from './wallet'
 
 type SettingsTab = 'dm' | 'buddy' | 'tasks' | 'wallet' | 'shop'
-type MergedSettingsSection = 'invite' | 'entitlements' | 'orders'
+type MergedSettingsSection =
+  | 'invite'
+  | 'entitlements'
+  | 'assets'
+  | 'settlements'
+  | 'actions'
+  | 'orders'
 
 interface NavItem {
   id: SettingsTab
@@ -53,12 +59,23 @@ function normalizeSettingsLocation(
   if (tab === 'entitlements') {
     return { tab: 'wallet' as const, section: 'entitlements' as const }
   }
+  if (tab === 'community-assets') return { tab: 'wallet' as const, section: 'assets' as const }
+  if (tab === 'community-settlements') {
+    return { tab: 'wallet' as const, section: 'settlements' as const }
+  }
+  if (tab === 'community-actions') return { tab: 'wallet' as const, section: 'actions' as const }
   if (tab === 'commerce-orders') return { tab: 'shop' as const, section: 'orders' as const }
   if (tab === 'tasks' && section === 'invite') {
     return { tab: 'tasks' as const, section: 'invite' as const }
   }
   if (tab === 'wallet' && section === 'entitlements') {
     return { tab: 'wallet' as const, section: 'entitlements' as const }
+  }
+  if (
+    tab === 'wallet' &&
+    (section === 'assets' || section === 'settlements' || section === 'actions')
+  ) {
+    return { tab: 'wallet' as const, section }
   }
   if (tab === 'shop' && section === 'orders') {
     return { tab: 'shop' as const, section: 'orders' as const }
@@ -288,9 +305,7 @@ export function SettingsPage() {
                 )}
                 {activeTab === 'wallet' && (
                   <WalletSettings
-                    initialSection={
-                      activeSection === 'entitlements' ? 'entitlements' : 'transactions'
-                    }
+                    initialSection={(activeSection as WalletSettingsSection) ?? 'transactions'}
                   />
                 )}
                 {activeTab === 'shop' && (

--- a/apps/web/src/pages/settings/wallet.tsx
+++ b/apps/web/src/pages/settings/wallet.tsx
@@ -1,18 +1,39 @@
 import { Button, cn } from '@shadowob/ui'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
+import type { LucideIcon } from 'lucide-react'
 import {
   ArrowDownLeft,
   ArrowUpRight,
+  Ban,
+  Coins,
   CreditCard,
   Filter,
+  Gift,
+  HandCoins,
+  LockKeyhole,
+  Package,
   RefreshCw,
   Target,
+  UnlockKeyhole,
   Wallet,
 } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { CommunityEconomySendModal } from '../../components/community-economy/community-economy-send-modal'
 import { ShrimpCoinIcon } from '../../components/shop/ui/currency'
+import {
+  type CommunityAsset,
+  type SettlementLine,
+  useCommunityAssets,
+  useConsumeCommunityAsset,
+  useLockCommunityAsset,
+  useRevokeCommunityAsset,
+  useSettleAvailableLines,
+  useSettlementLines,
+  useUnlockCommunityAsset,
+} from '../../hooks/use-community-economy'
 import { fetchApi } from '../../lib/api'
 import { useRechargeStore } from '../../stores/recharge.store'
 import { EntitlementsPage } from '../commerce'
@@ -28,7 +49,12 @@ type TransactionType =
   | 'settlement'
 
 type FilterType = 'all' | 'income' | 'expense'
-type WalletSettingsSection = 'transactions' | 'entitlements'
+export type WalletSettingsSection =
+  | 'transactions'
+  | 'entitlements'
+  | 'assets'
+  | 'settlements'
+  | 'actions'
 
 interface WalletTransaction {
   id: string
@@ -83,6 +109,26 @@ const TYPE_COLORS: Record<TransactionType, string> = {
 }
 
 const PAGE_SIZE = 20
+
+function createIdempotencyKey(prefix: string) {
+  return `${prefix}_${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}_${Math.random().toString(36).slice(2)}`}`
+}
+
+function formatApiError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function formatOptionalDate(dateStr?: string | null) {
+  if (!dateStr) return null
+  const d = new Date(dateStr)
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
 
 export function WalletSettings({
   initialSection = 'transactions',
@@ -161,7 +207,7 @@ export function WalletSettings({
             </div>
             {(wallet?.frozenAmount ?? 0) > 0 && (
               <p className="text-xs text-text-muted mt-1 inline-flex items-center gap-1">
-                {t('wallet.frozen', '冻结')}: {wallet?.frozenAmount?.toLocaleString()}{' '}
+                {t('wallet.frozen')}: {wallet?.frozenAmount?.toLocaleString()}{' '}
                 <ShrimpCoinIcon size={12} />
               </p>
             )}
@@ -186,7 +232,7 @@ export function WalletSettings({
                 }
                 icon={Target}
               >
-                {t('wallet.earnByTasks', '做任务赚虾币')}
+                {t('wallet.earnByTasks')}
               </Button>
             )}
           </div>
@@ -194,7 +240,15 @@ export function WalletSettings({
       </SettingsCard>
 
       <div className="flex flex-wrap items-center gap-1 rounded-full bg-bg-tertiary/30 p-1">
-        {(['transactions', 'entitlements'] as WalletSettingsSection[]).map((section) => (
+        {(
+          [
+            ['transactions', t('wallet.transactionHistory')],
+            ['entitlements', t('commerce.entitlements')],
+            ['assets', t('communityEconomy.assets')],
+            ['settlements', t('communityEconomy.settlements')],
+            ['actions', t('communityEconomy.actions')],
+          ] as Array<[WalletSettingsSection, string]>
+        ).map(([section, label]) => (
           <button
             key={section}
             type="button"
@@ -207,15 +261,19 @@ export function WalletSettings({
                 : 'text-text-muted hover:text-text-primary',
             )}
           >
-            {section === 'transactions'
-              ? t('wallet.transactionHistory')
-              : t('commerce.entitlements')}
+            {label}
           </button>
         ))}
       </div>
 
       {activeSection === 'entitlements' ? (
         <EntitlementsPage embedded />
+      ) : activeSection === 'assets' ? (
+        <CommunityAssetsSection />
+      ) : activeSection === 'settlements' ? (
+        <CommunitySettlementsSection />
+      ) : activeSection === 'actions' ? (
+        <CommunityActionsSection />
       ) : (
         <>
           {/* Transaction History */}
@@ -350,5 +408,491 @@ export function WalletSettings({
         </>
       )}
     </SettingsPanel>
+  )
+}
+
+function CommunityAssetsSection() {
+  const { t } = useTranslation()
+  const { data, isLoading } = useCommunityAssets()
+  const consumeMutation = useConsumeCommunityAsset()
+  const lockMutation = useLockCommunityAsset()
+  const unlockMutation = useUnlockCommunityAsset()
+  const revokeMutation = useRevokeCommunityAsset()
+  const assets = data?.assets ?? []
+  const assetTypes = Array.from(new Set(assets.map((asset) => asset.definition.assetType))).sort()
+  const [assetTypeFilter, setAssetTypeFilter] = useState('all')
+  const [giftGrantId, setGiftGrantId] = useState<string | null>(null)
+  const displayedAssets =
+    assetTypeFilter === 'all'
+      ? assets
+      : assets.filter((asset) => asset.definition.assetType === assetTypeFilter)
+
+  const runGrantAction = (
+    action: 'consume' | 'lock' | 'unlock' | 'revoke',
+    grantId: string,
+    reason?: string,
+  ) => {
+    if (
+      (action === 'consume' || action === 'revoke') &&
+      !window.confirm(t(`communityEconomy.confirm.${action}`))
+    ) {
+      return
+    }
+    const idempotencyKey = createIdempotencyKey(`asset-${action}`)
+    if (action === 'consume') consumeMutation.mutate({ grantId, idempotencyKey })
+    if (action === 'lock') lockMutation.mutate({ grantId, idempotencyKey })
+    if (action === 'unlock') unlockMutation.mutate({ grantId, idempotencyKey })
+    if (action === 'revoke') revokeMutation.mutate({ grantId, idempotencyKey, reason })
+  }
+
+  const pending =
+    consumeMutation.isPending ||
+    lockMutation.isPending ||
+    unlockMutation.isPending ||
+    revokeMutation.isPending
+  const error =
+    consumeMutation.error ?? lockMutation.error ?? unlockMutation.error ?? revokeMutation.error
+
+  return (
+    <SettingsSectionBlock
+      titleKey="communityEconomy.assets"
+      titleFallback="Community Assets"
+      actions={
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {assetTypes.length > 0 && (
+            <select
+              value={assetTypeFilter}
+              onChange={(event) => setAssetTypeFilter(event.target.value)}
+              className="rounded-full border border-border-subtle bg-bg-secondary px-3 py-1.5 text-xs font-bold text-text-primary outline-none focus:border-primary"
+            >
+              <option value="all">{t('communityEconomy.allAssetTypes')}</option>
+              {assetTypes.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </select>
+          )}
+          <span className="text-xs font-bold text-text-muted">
+            {t('communityEconomy.assetCount', { count: displayedAssets.length })}
+          </span>
+        </div>
+      }
+    >
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <RefreshCw size={24} className="animate-spin text-text-muted" />
+        </div>
+      ) : displayedAssets.length === 0 ? (
+        <EmptyState
+          icon={Package}
+          title={t('communityEconomy.noAssets')}
+          description={t('communityEconomy.noAssetsHint')}
+        />
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2">
+          {displayedAssets.map((asset) => (
+            <CommunityAssetCard
+              key={asset.grant.id}
+              asset={asset}
+              pending={pending}
+              onAction={runGrantAction}
+              onGift={setGiftGrantId}
+            />
+          ))}
+        </div>
+      )}
+      {error && <MutationError message={formatApiError(error)} />}
+      <CommunityEconomySendModal
+        open={!!giftGrantId}
+        mode="gift"
+        initialAssetGrantId={giftGrantId ?? undefined}
+        onClose={() => setGiftGrantId(null)}
+      />
+    </SettingsSectionBlock>
+  )
+}
+
+function CommunityAssetCard({
+  asset,
+  pending,
+  onAction,
+  onGift,
+}: {
+  asset: CommunityAsset
+  pending: boolean
+  onAction: (
+    action: 'consume' | 'lock' | 'unlock' | 'revoke',
+    grantId: string,
+    reason?: string,
+  ) => void
+  onGift: (grantId: string) => void
+}) {
+  const { t } = useTranslation()
+  const { grant, definition } = asset
+  const expiresAt = formatOptionalDate(grant.expiresAt)
+  const isActive = grant.status === 'active'
+  const isLocked = grant.status === 'locked'
+
+  return (
+    <div className="rounded-2xl border border-border-subtle bg-bg-secondary/30 p-4 space-y-3">
+      <div className="flex items-start gap-3">
+        {definition.imageUrl ? (
+          <img
+            src={definition.imageUrl}
+            alt=""
+            className="h-12 w-12 rounded-2xl object-cover border border-border-subtle"
+          />
+        ) : (
+          <div className="h-12 w-12 rounded-2xl bg-primary/10 text-primary flex items-center justify-center">
+            <Package size={20} />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h4 className="truncate text-sm font-black text-text-primary">{definition.name}</h4>
+            <StatusPill status={grant.status} />
+          </div>
+          {definition.description && (
+            <p className="mt-1 line-clamp-2 text-xs text-text-muted">{definition.description}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <AssetMeta label={t('communityEconomy.quantity')} value={String(grant.quantity)} />
+        <AssetMeta
+          label={t('communityEconomy.remaining')}
+          value={String(grant.remainingQuantity)}
+        />
+        <AssetMeta label={t('communityEconomy.type')} value={definition.assetType} />
+        <AssetMeta
+          label={t('communityEconomy.expiresAt')}
+          value={expiresAt ?? t('communityEconomy.never')}
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {definition.consumable && isActive && grant.remainingQuantity > 0 && (
+          <Button
+            variant="secondary"
+            size="sm"
+            type="button"
+            icon={Coins}
+            disabled={pending}
+            onClick={() => onAction('consume', grant.id)}
+          >
+            {t('communityEconomy.consume')}
+          </Button>
+        )}
+        {definition.giftable && isActive && grant.remainingQuantity > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            icon={Gift}
+            disabled={pending}
+            onClick={() => onGift(grant.id)}
+          >
+            {t('communityEconomy.sendGift')}
+          </Button>
+        )}
+        {isActive && (
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            icon={LockKeyhole}
+            disabled={pending}
+            onClick={() => onAction('lock', grant.id)}
+          >
+            {t('communityEconomy.lock')}
+          </Button>
+        )}
+        {isLocked && (
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            icon={UnlockKeyhole}
+            disabled={pending}
+            onClick={() => onAction('unlock', grant.id)}
+          >
+            {t('communityEconomy.unlock')}
+          </Button>
+        )}
+        {(isActive || isLocked) && (
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            icon={Ban}
+            disabled={pending}
+            onClick={() => onAction('revoke', grant.id, 'user_requested')}
+          >
+            {t('communityEconomy.revoke')}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CommunitySettlementsSection() {
+  const { t } = useTranslation()
+  const { data, isLoading } = useSettlementLines({ limit: 50, offset: 0 })
+  const settleMutation = useSettleAvailableLines()
+  const settlements = data?.settlements ?? []
+  const availableCount = settlements.filter((line) => line.status === 'available').length
+  const pendingNet = settlements
+    .filter((line) => line.status === 'pending' || line.status === 'held')
+    .reduce((sum, line) => sum + line.netAmount, 0)
+
+  return (
+    <SettingsSectionBlock
+      titleKey="communityEconomy.settlements"
+      titleFallback="Settlements"
+      actions={
+        <Button
+          variant="primary"
+          size="sm"
+          type="button"
+          icon={HandCoins}
+          disabled={availableCount === 0 || settleMutation.isPending}
+          onClick={() => settleMutation.mutate()}
+        >
+          {t('communityEconomy.settleAvailable')}
+        </Button>
+      }
+    >
+      <div className="grid gap-3 md:grid-cols-3">
+        <SummaryMetric
+          label={t('communityEconomy.totalLines')}
+          value={String(settlements.length)}
+        />
+        <SummaryMetric
+          label={t('communityEconomy.availableLines')}
+          value={String(availableCount)}
+        />
+        <SummaryMetric
+          label={t('communityEconomy.pendingNet')}
+          value={pendingNet.toLocaleString()}
+          icon={<ShrimpCoinIcon size={14} />}
+        />
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <RefreshCw size={24} className="animate-spin text-text-muted" />
+        </div>
+      ) : settlements.length === 0 ? (
+        <EmptyState
+          icon={HandCoins}
+          title={t('communityEconomy.noSettlements')}
+          description={t('communityEconomy.noSettlementsHint')}
+        />
+      ) : (
+        <div className="space-y-2">
+          {settlements.map((line) => (
+            <SettlementRow key={line.id} line={line} />
+          ))}
+        </div>
+      )}
+
+      {settleMutation.error && <MutationError message={formatApiError(settleMutation.error)} />}
+    </SettingsSectionBlock>
+  )
+}
+
+function SettlementRow({ line }: { line: SettlementLine }) {
+  const { t } = useTranslation()
+  const availableAt = formatOptionalDate(line.availableAt)
+  const settledAt = formatOptionalDate(line.settledAt)
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-border-subtle bg-bg-secondary/30 p-3 md:flex-row md:items-center">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-black text-text-primary">
+            {t(`communityEconomy.source.${line.sourceType}`, line.sourceType)}
+          </span>
+          <StatusPill status={line.status} />
+        </div>
+        <p className="mt-1 truncate text-xs text-text-muted">
+          {t('communityEconomy.availableAt')}: {availableAt ?? t('communityEconomy.notAvailable')}
+          {settledAt ? ` · ${t('communityEconomy.settledAt')}: ${settledAt}` : ''}
+        </p>
+      </div>
+      <div className="grid grid-cols-3 gap-2 text-right text-xs md:w-72">
+        <AmountMeta label={t('communityEconomy.gross')} amount={line.grossAmount} />
+        <AmountMeta label={t('communityEconomy.fee')} amount={line.platformFee} />
+        <AmountMeta label={t('communityEconomy.net')} amount={line.netAmount} emphasis />
+      </div>
+    </div>
+  )
+}
+
+function CommunityActionsSection() {
+  const { t } = useTranslation()
+  const [modalMode, setModalMode] = useState<'tip' | 'gift' | null>(null)
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <SettingsSectionBlock titleKey="communityEconomy.sendTip" titleFallback="Send tip">
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-border-subtle bg-bg-secondary/50 p-4">
+            <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <HandCoins size={22} />
+            </div>
+            <p className="text-sm font-black text-text-primary">
+              {t('communityEconomy.tipEntryTitle')}
+            </p>
+            <p className="mt-1 text-xs leading-5 text-text-muted">
+              {t('communityEconomy.tipEntryHint')}
+            </p>
+          </div>
+          <Button
+            variant="primary"
+            size="md"
+            type="button"
+            icon={HandCoins}
+            onClick={() => setModalMode('tip')}
+          >
+            {t('communityEconomy.sendTip')}
+          </Button>
+        </div>
+      </SettingsSectionBlock>
+      <SettingsSectionBlock titleKey="communityEconomy.sendGift" titleFallback="Send gift">
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-border-subtle bg-bg-secondary/50 p-4">
+            <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <Gift size={22} />
+            </div>
+            <p className="text-sm font-black text-text-primary">
+              {t('communityEconomy.giftEntryTitle')}
+            </p>
+            <p className="mt-1 text-xs leading-5 text-text-muted">
+              {t('communityEconomy.giftEntryHint')}
+            </p>
+          </div>
+          <Button
+            variant="primary"
+            size="md"
+            type="button"
+            icon={Gift}
+            onClick={() => setModalMode('gift')}
+          >
+            {t('communityEconomy.sendGift')}
+          </Button>
+        </div>
+      </SettingsSectionBlock>
+      <CommunityEconomySendModal
+        open={modalMode !== null}
+        mode={modalMode ?? 'tip'}
+        onClose={() => setModalMode(null)}
+      />
+    </div>
+  )
+}
+
+function EmptyState({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: LucideIcon
+  title: string
+  description: string
+}) {
+  return (
+    <div className="flex flex-col items-center py-12 text-center text-text-muted">
+      <Icon size={48} className="mb-3 opacity-30" />
+      <p className="text-sm font-bold text-text-secondary">{title}</p>
+      <p className="mt-1 max-w-sm text-xs leading-relaxed">{description}</p>
+    </div>
+  )
+}
+
+function StatusPill({ status }: { status: string }) {
+  const { t } = useTranslation()
+  const tone =
+    status === 'active' || status === 'available' || status === 'settled'
+      ? 'bg-success/10 text-success'
+      : status === 'pending' || status === 'held' || status === 'locked'
+        ? 'bg-warning/10 text-warning'
+        : 'bg-text-muted/10 text-text-muted'
+
+  return (
+    <span className={cn('rounded-full px-2 py-0.5 text-[10px] font-black uppercase', tone)}>
+      {t(`communityEconomy.status.${status}`, status)}
+    </span>
+  )
+}
+
+function AssetMeta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl bg-bg-tertiary/40 px-3 py-2">
+      <p className="text-[10px] font-black uppercase tracking-[0.16em] text-text-muted/60">
+        {label}
+      </p>
+      <p className="mt-1 truncate text-xs font-bold text-text-primary">{value}</p>
+    </div>
+  )
+}
+
+function SummaryMetric({ label, value, icon }: { label: string; value: string; icon?: ReactNode }) {
+  return (
+    <div className="rounded-2xl bg-bg-secondary/50 px-4 py-3">
+      <p className="text-[10px] font-black uppercase tracking-[0.16em] text-text-muted/60">
+        {label}
+      </p>
+      <p className="mt-1 flex items-center gap-1 text-lg font-black text-text-primary">
+        {value}
+        {icon}
+      </p>
+    </div>
+  )
+}
+
+function AmountMeta({
+  label,
+  amount,
+  emphasis = false,
+}: {
+  label: string
+  amount: number
+  emphasis?: boolean
+}) {
+  return (
+    <div>
+      <p className="text-[10px] font-black uppercase tracking-[0.16em] text-text-muted/60">
+        {label}
+      </p>
+      <p
+        className={cn(
+          'mt-1 inline-flex items-center justify-end gap-1 font-black tabular-nums',
+          emphasis ? 'text-success' : 'text-text-primary',
+        )}
+      >
+        {amount.toLocaleString()} <ShrimpCoinIcon size={12} />
+      </p>
+    </div>
+  )
+}
+
+function MutationError({ message }: { message: string }) {
+  const { t } = useTranslation()
+  return (
+    <p className="rounded-2xl border border-danger/20 bg-danger/10 px-3 py-2 text-xs font-bold text-danger">
+      {t('communityEconomy.operationFailed')}: {message}
+    </p>
+  )
+}
+
+function MutationSuccess({ message }: { message: string }) {
+  return (
+    <p className="rounded-2xl border border-success/20 bg-success/10 px-3 py-2 text-xs font-bold text-success">
+      {message}
+    </p>
   )
 }

--- a/apps/web/src/pages/user-profile.tsx
+++ b/apps/web/src/pages/user-profile.tsx
@@ -216,7 +216,7 @@ export function UserProfilePage() {
                     </h1>
                     {profile.isBot && (
                       <Badge variant="info" size="xs">
-                        {t('buddy')}
+                        {t('common.buddy')}
                       </Badge>
                     )}
                   </div>
@@ -324,7 +324,7 @@ export function UserProfilePage() {
                           <UserAvatar
                             userId={agent.userId}
                             avatarUrl={agent.botUser?.avatarUrl ?? null}
-                            displayName={agent.botUser?.displayName ?? t('buddy')}
+                            displayName={agent.botUser?.displayName ?? t('common.buddy')}
                             size="sm"
                             className="rounded-xl group-hover:scale-105 transition-transform"
                           />
@@ -334,7 +334,9 @@ export function UserProfilePage() {
                         </div>
                         <div className="flex-1 min-w-0">
                           <span className="text-sm font-black text-text-primary truncate group-hover:text-primary transition-colors block">
-                            {agent.botUser?.displayName ?? agent.botUser?.username ?? t('buddy')}
+                            {agent.botUser?.displayName ??
+                              agent.botUser?.username ??
+                              t('common.buddy')}
                           </span>
                           {agent.totalOnlineSeconds > 0 && (
                             <span className="text-[9px] font-black text-text-muted uppercase tracking-tighter">

--- a/apps/web/src/pages/user-profile.tsx
+++ b/apps/web/src/pages/user-profile.tsx
@@ -1,7 +1,17 @@
 import { Badge, Button, GlassPanel, Tabs, TabsContent, TabsList, TabsTrigger } from '@shadowob/ui'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useParams } from '@tanstack/react-router'
-import { ArrowRight, Calendar, ChevronLeft, QrCode, Shield, UserPlus, X } from 'lucide-react'
+import {
+  ArrowRight,
+  Calendar,
+  ChevronLeft,
+  Gift,
+  HandCoins,
+  QrCode,
+  Shield,
+  UserPlus,
+  X,
+} from 'lucide-react'
 import { QRCodeSVG } from 'qrcode.react'
 import { useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -16,6 +26,7 @@ import {
 } from '../components/buddy-dashboard'
 import { UserAvatar } from '../components/common/avatar'
 import { formatDuration, OnlineRank } from '../components/common/online-rank'
+import { CommunityEconomySendModal } from '../components/community-economy/community-economy-send-modal'
 import { ProfileCommentSection } from '../components/profile/ProfileCommentSection'
 import { fetchApi } from '../lib/api'
 import { useAuthStore } from '../stores/auth.store'
@@ -101,6 +112,7 @@ export function UserProfilePage() {
   const [dashboardTab, setDashboardTab] = useState<
     'weekly' | 'hourly' | 'monthly' | 'recent' | 'rental'
   >('weekly')
+  const [economyModal, setEconomyModal] = useState<'tip' | 'gift' | null>(null)
 
   const { data: profile, isLoading } = useQuery({
     queryKey: ['user-profile', userId],
@@ -162,9 +174,27 @@ export function UserProfilePage() {
                     {t('profile.myQrCard')}
                   </Button>
                 ) : (
-                  <Button size="sm" variant="outline" icon={UserPlus}>
-                    {t('friends.addFriend')}
-                  </Button>
+                  <div className="flex flex-wrap items-center justify-end gap-2">
+                    <Button
+                      size="sm"
+                      variant="glass"
+                      icon={HandCoins}
+                      onClick={() => setEconomyModal('tip')}
+                    >
+                      {t('communityEconomy.sendTip')}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="glass"
+                      icon={Gift}
+                      onClick={() => setEconomyModal('gift')}
+                    >
+                      {t('communityEconomy.sendGift')}
+                    </Button>
+                    <Button size="sm" variant="outline" icon={UserPlus}>
+                      {t('friends.addFriend')}
+                    </Button>
+                  </div>
                 )}
               </div>
 
@@ -520,6 +550,17 @@ export function UserProfilePage() {
           </div>,
           document.body,
         )}
+      <CommunityEconomySendModal
+        open={economyModal !== null}
+        mode={economyModal ?? 'tip'}
+        recipient={{
+          id: profile.id,
+          username: profile.username,
+          displayName: profile.displayName,
+          avatarUrl: profile.avatarUrl,
+        }}
+        onClose={() => setEconomyModal(null)}
+      />
     </div>
   )
 }

--- a/docs/decisions/shadow-community-economy-implementation-plan-v2.md
+++ b/docs/decisions/shadow-community-economy-implementation-plan-v2.md
@@ -1,0 +1,1332 @@
+# Shadow 社区虾币经济系统调整方案
+
+版本：2026-05-09  
+适用范围：`buggyblues/shadow` 后端交易、钱包、商城、权益、付费内容、社区赠送、创作者收入、审计与风控能力建设。  
+目标定位：在社区中引入基于虾币的灵活交易能力，形成可运营、可审计、可扩展的游戏化社区经济系统。
+
+## 0. 执行摘要
+
+Shadow 当前已经具备一套可复用的交易底座：店铺、商品、SKU、Offer、订单、钱包、充值、权益、付费文件、履约任务、通知和幂等表。下一步不应重写，而应把现有能力收敛成统一经济系统。
+
+本方案的核心顺序是：
+
+1. 先补 P0：账务一致性、充值安全、幂等、履约去重、权限边界、元数据可信边界。
+2. 再做 P1：社区资产、虾币赠送、打赏、商品购买、权益/付费内容发放、基础结算。
+3. 再做 P2：优惠、轻量服务单、创作者中心、社区活动奖励、订阅续费、争议处理。
+4. 最后做 P3：多币种、轻量社区市场、开放 API、数据报表、风控模型和运营扩展。
+
+系统建设原则：
+
+- 所有余额变化必须进入统一账务入口。
+- 所有经济资产变化必须有可追踪来源。
+- 所有交易行为必须有幂等键。
+- 所有商品卡片和消息 metadata 只能作为展示入口，不能作为价格、权限、交付依据。
+- 所有结算、退款、赠送、管理员调整必须进入审计。
+- 先实现核心闭环，再扩展附属玩法。
+- 保留向多币种、多资产、创作者市场、社区治理扩展的能力。
+
+## 1. 当前可复用能力
+
+### 1.1 已有基础
+
+当前项目已经有以下交易基础：
+
+| 模块 | 现有能力 | 后续策略 |
+| --- | --- | --- |
+| `shops` | 服务器店铺、个人店铺 scope | 保留，作为社区店铺、创作者店铺、平台店铺统一容器 |
+| `products` / `skus` | 商品目录、SKU、价格、库存、媒体 | 保留，但 SKU 需要稳定 ID 和软下架 |
+| `commerceOffers` | 商品销售上下文、价格覆盖、可见面、seller | 保留，作为频道、DM、主页、卡片销售的统一入口 |
+| `commerceDeliverables` | 购买后交付配置，目前偏 paid file/message/external | 扩展为 entitlement、asset、currency、paid_file、message |
+| `orders` / `orderItems` | 订单和订单项 | 保留，扩展支付状态、履约状态、结算状态 |
+| `wallets` / `walletTransactions` | 虾币余额和流水 | 保留兼容，逐步升级为多账户账本 |
+| `LedgerService` | 统一 credit/debit 入口雏形 | 升级为所有经济变更的唯一写入口 |
+| `paymentOrders` / `RechargeService` | Stripe 充值、本地支付订单、webhook 入账 | 加固 currency、webhook secret、provider event、争议处理 |
+| `entitlements` | 权益发放、资源授权、到期、撤销 | 保留，用于付费内容、服务资格、订阅、权限凭证 |
+| `commerceFulfillmentJobs` | 购买后履约任务 | 加固 claim、重试、幂等、交付记录 |
+| `commerceIdempotencyKeys` | 购买幂等 | 扩展到充值确认、赠送、打赏、履约、管理员调整 |
+| `notification_*` | 通知事件和投递 | 复用到充值成功、购买成功、赠送、退款、结算、争议 |
+
+### 1.2 当前不宜继续扩大的路径
+
+以下路径需要收敛，不应在新能力中复制：
+
+| 问题 | 风险 | 处理方式 |
+| --- | --- | --- |
+| `OrderService.createOrder` 内直接更新钱包余额和写流水 | 绕过统一账务，容易导致账不平 | P0 改为只调用 `LedgerService` |
+| 充值接口允许客户端传入 `currency` | 可能造成金额单位错配或低价充值 | P0 限制为服务端白名单，默认 USD，禁止任意币种 |
+| `STRIPE_WEBHOOK_SECRET` 可为空字符串 | webhook 配置失误时安全边界不明确 | P0 启动时强校验，生产环境为空直接失败 |
+| 商品 metadata 使用 `.passthrough()` | 客户端可能注入未定义字段，被前端或机器人错误消费 | P0 改为白名单 schema，额外字段进入受限 `custom` |
+| DM 发送 metadata 仅 `z.record(z.unknown())` | 绕过商品卡片正规化、大小限制和权限检查 | P0 复用统一 message metadata validator |
+| thread 消息链路没有统一 commerce card normalize | 可能绕过频道消息卡片校验 | P0 所有消息入口统一走 `CommerceCardService` |
+| SKU 更新删除并重建全部 SKU | 历史订单、商品卡片、购买链接、库存追踪被破坏 | P0 改为 update/upsert/soft deactivate |
+| 履约任务先查询再更新状态 | 多 worker 可能重复处理同一 job | P0 改为原子 claim + 唯一交付记录 |
+| 订单完成时结算失败被吞掉 | 订单和收入状态不一致 | P0/P1 引入结算任务与可重试状态 |
+| 充值 dispute 只改状态和日志 | 争议后虾币可能已消费，无法追踪和冻结 | P1 引入 provider event、冻结、风险案例 |
+| 付费文件 token 放在 query string | 可能被日志、Referer、截图泄露 | P1 改成一次性 token 或短期 grant header/cookie 方案 |
+| PAT 权限仅按读写粗分 | 金融写接口可能被泛写 scope 误放行 | P0 建立经济接口显式 scope |
+
+## 2. 目标架构
+
+### 2.1 总体结构
+
+```text
+用户动作
+  ↓
+Route Validator
+  ↓
+EconomyPolicyService：身份、权限、scope、风控、限额
+  ↓
+EconomyCommandService：幂等、事务、业务编排
+  ↓
+LedgerService / AssetService / OrderService / FulfillmentService / SettlementService
+  ↓
+AuditService / NotificationService / RiskService
+```
+
+核心约束：
+
+- Route 层只做输入校验和身份提取，不直接改余额、不直接发权益、不直接改资产归属。
+- Service 层必须显式接收 actor、resource、action、idempotencyKey。
+- Ledger、Asset、Order、Fulfillment、Settlement 的写操作必须在事务或可靠 outbox 中串联。
+- Audit 不依赖业务方手写散落日志，必须在经济命令执行框架中自动写入。
+
+### 2.2 能力分层
+
+| 层级 | 能力 | 描述 |
+| --- | --- | --- |
+| L0 安全地基 | 账务入口、支付校验、幂等、权限、审计 | 任何交易能力上线前必须完成 |
+| L1 核心交易 | 充值、商城购买、权益/付费内容发放、打赏、赠送 | 社区经济 MVP |
+| L2 社区运营 | 创作者店铺、优惠、服务单、活动奖励、基础结算 | 支持运营增长 |
+| L3 扩展生态 | 轻量市场、多币种、开放 API、风控模型、报表 | 前瞻性扩展 |
+
+### 2.3 关键领域模型
+
+#### 2.3.1 账务模型
+
+短期兼容：
+
+- 保留 `wallets`。
+- 保留 `walletTransactions` 作为前端展示兼容层。
+- 所有余额变化统一通过 `LedgerService`。
+
+中期升级：
+
+```ts
+wallets
+  id
+  userId
+  status
+  createdAt
+  updatedAt
+
+walletBalances
+  walletId
+  currencyCode
+  availableAmount
+  frozenAmount
+  updatedAt
+
+ledgerTransactions
+  id
+  txNo
+  actorKind
+  actorId
+  action
+  referenceType
+  referenceId
+  idempotencyKey
+  status
+  metadata
+  createdAt
+
+ledgerEntries
+  id
+  transactionId
+  walletId
+  accountType
+  currencyCode
+  amount
+  balanceAfter
+  direction
+  createdAt
+```
+
+账户类型建议：
+
+| accountType | 用途 |
+| --- | --- |
+| `user_available` | 用户可用虾币 |
+| `user_frozen` | 交易冻结、争议冻结 |
+| `system_mint` | 充值铸币、奖励发放来源 |
+| `platform_fee` | 平台手续费 |
+| `seller_pending` | 待结算收入 |
+| `seller_available` | 已结算收入 |
+| `escrow` | 交易托管 |
+| `admin_adjustment` | 管理员调整 |
+
+P1 可以先实现单币种 `shrimp_coin`，但字段必须保留 `currencyCode`。
+
+#### 2.3.2 社区资产模型
+
+社区资产用于表示 Badge、服务券、数字收藏物、付费内容凭证、活动奖励、创作者礼物等。它不替代 `entitlements`，而是和 `entitlements` 分工：
+
+| 类型 | 用途 |
+| --- | --- |
+| `entitlement` | 访问权限、订阅、时限服务、付费内容授权 |
+| `communityAsset` | 可展示、可赠送、可转移、可收藏的社区资产 |
+| `currency` | 虾币和未来代币 |
+
+建议新增：
+
+```ts
+communityAssetDefinitions
+  id
+  code
+  name
+  description
+  category              // badge | voucher | collectible | gift | coupon | creator_service
+  media
+  transferable          // 是否可转赠/转让
+  giftable              // 是否可赠送
+  consumable            // 是否可使用后消耗
+  expiresPolicy
+  maxSupply
+  metadata
+  status
+  createdAt
+  updatedAt
+
+communityAssetGrants
+  id
+  definitionId
+  ownerUserId
+  sourceType            // order | gift | reward | admin | migration
+  sourceId
+  status                // active | locked | consumed | revoked | expired
+  quantity
+  expiresAt
+  metadata
+  createdAt
+  updatedAt
+
+communityAssetLocks
+  id
+  grantId
+  lockedByType          // gift | transfer | settlement | moderation
+  lockedById
+  quantity
+  reason
+  expiresAt
+  createdAt
+
+communityAssetTransferLogs
+  id
+  assetGrantId
+  fromUserId
+  toUserId
+  quantity
+  reason
+  referenceType
+  referenceId
+  createdAt
+```
+
+#### 2.3.3 订单模型
+
+保留 `orders` 和 `orderItems`，但拆分状态语义：
+
+```ts
+orders
+  status                // created | reserved | paid | fulfilling | completed | cancelled | failed | refunded | disputed
+  paymentStatus         // unpaid | authorized | paid | failed | refunded | disputed
+  fulfillmentStatus     // pending | processing | fulfilled | partially_failed | failed
+  settlementStatus      // none | pending | settled | held | failed
+  riskStatus            // normal | review_required | frozen
+```
+
+短期不一定立刻加所有字段，但新服务设计必须按这四类状态思考，不再让单个 `status` 同时表达支付、发货、结算和争议。
+
+#### 2.3.4 履约模型
+
+扩展 `commerceDeliverables.kind`：
+
+| kind | 说明 |
+| --- | --- |
+| `entitlement` | 发放资源访问权益 |
+| `community_asset` | 发放 Badge、礼物、服务券、收藏物 |
+| `currency` | 发放虾币或奖励币 |
+| `paid_file` | 发放付费文件访问 |
+| `message` | 发送系统消息或 Buddy 消息 |
+| `external` | 外部交付，占位 |
+
+新增：
+
+```ts
+commerceFulfillmentRecords
+  id
+  jobId
+  orderId
+  orderItemId
+  deliverableId
+  recipientUserId
+  idempotencyKey
+  resultType
+  resultId
+  status
+  createdAt
+```
+
+唯一约束：
+
+```sql
+unique (order_item_id, deliverable_id, recipient_user_id)
+unique (idempotency_key)
+```
+
+## 3. 分阶段落地计划
+
+## P0：交易安全与账务地基
+
+目标：先阻止刷币、重复扣款、重复发货、权限越界和审计缺失。P0 必须优先完成，不依赖前端大改。
+
+### P0.1 统一余额变更入口
+
+改动点：
+
+- `OrderService.createOrder` 不再直接更新 `wallets.balance`。
+- `OrderService.createOrder` 不再直接插入 `walletTransactions`。
+- 所有购买、退款、结算、赠送、打赏、管理员加币都调用 `LedgerService`。
+- `WalletDao.credit/debit/updateBalance` 标记为 internal，仅允许 `LedgerService` 或测试使用。
+- `scripts/check-security-pr.mjs` 增加对 `db.update(wallets)` 的扫描，不只扫描 `walletDao.credit/debit/updateBalance`。
+
+验收：
+
+- 搜索 `wallets.balance} +` 和 `wallets.balance} -`，除 `LedgerService` 外无余额写入。
+- 下单扣款、充值入账、退款、管理员 grant 均产生 ledger 记录。
+- 重复调用同一 idempotencyKey 不重复扣款。
+
+### P0.2 加固充值
+
+改动点：
+
+- `POST /api/v1/recharge/create-intent` 不再接受任意 `currency`。
+- 服务端配置允许币种，例如 `SUPPORTED_STRIPE_CURRENCIES=usd`。
+- 生产环境 `STRIPE_WEBHOOK_SECRET` 为空直接启动失败。
+- 新增 `paymentProviderEvents` 表，保存 Stripe event id、type、payload hash、processedAt、status。
+- webhook 先写 provider event，event id 唯一。
+- dispute/chargeback 进入 `riskCases`，不只打日志。
+- 自定义充值金额增加日限额、单笔限额、用户状态检查。
+
+验收：
+
+- 传 `currency=jpy`、`krw`、`cny` 等非白名单币种返回 400。
+- 重复 webhook event id 只处理一次。
+- 空 webhook secret 在 production 下无法启动。
+- dispute 产生 risk case 和通知。
+
+### P0.3 所有经济写操作接入幂等
+
+改动点：
+
+- 扩展 `commerceIdempotencyKeys` 或新增 `economyIdempotencyKeys`。
+- 强制以下操作必须带 idempotencyKey：
+  - 购买 Offer
+  - 充值确认
+  - 打赏
+  - 赠送
+  - 管理员 grant/adjustment
+  - 退款
+  - 履约
+  - 结算
+- Route 层拒绝缺失 idempotencyKey 的经济写请求。
+- 幂等键作用域为 `actorUserId + action + key`。
+- 完成后保存响应摘要，不保存敏感完整 payload。
+
+验收：
+
+- 同一个 idempotencyKey 重试返回同一结果。
+- 并发 20 次同一购买请求只生成一个订单、一笔扣款、一组交付。
+
+### P0.4 履约任务原子 claim
+
+当前风险：`processJob` 先 select，再 update `status='sending'`。多个 worker 可能同时读到 pending job，然后重复发送消息或重复发放资产。
+
+改动点：
+
+- 使用一条 update claim：
+
+```ts
+const [claimed] = await db
+  .update(commerceFulfillmentJobs)
+  .set({
+    status: 'sending',
+    attempts: sql`${commerceFulfillmentJobs.attempts} + 1`,
+    updatedAt: new Date(),
+  })
+  .where(and(
+    eq(commerceFulfillmentJobs.id, jobId),
+    inArray(commerceFulfillmentJobs.status, ['pending', 'failed']),
+  ))
+  .returning()
+```
+
+- claim 失败直接返回已有状态。
+- 新增 `commerceFulfillmentRecords`，用唯一约束防重复交付。
+- 对 `paid_file`、`entitlement`、`community_asset`、`currency` 每种交付都必须写 record。
+
+验收：
+
+- 两个 worker 同时处理同一 job，不会重复发消息或重复发资产。
+- 失败重试不会重复发已成功的 deliverable。
+
+### P0.5 消息 metadata 可信边界
+
+改动点：
+
+- 移除经济相关 metadata 的 `.passthrough()`。
+- `commerceCards.snapshot` 只允许服务端生成。
+- `purchase`、`action` 等字段不接受客户端任意对象。
+- DM 消息发送复用统一 `sendMessageSchema` 或抽出 `messageMetadataSchema`。
+- 频道、DM、thread、socket 消息入口全部走同一个 `CommerceCardService.normalizeMessageMetadata`。
+- 对 metadata 总字节、数组数量、字段长度统一限制。
+- 对 unknown metadata 放入 `metadata.custom`，并限制 key 数量和总大小。
+
+验收：
+
+- 客户端伪造 `snapshot.price=1` 不影响购买价格。
+- 客户端伪造 `shopId/productId/offerId` 不通过服务端可见性和 surface 检查。
+- thread/DM 发送商品卡片与频道发送执行同样校验。
+
+### P0.6 SKU 稳定性
+
+当前风险：`ProductService.updateProduct` 会删除商品所有 SKU 再重建。
+
+改动点：
+
+- SKU 更新改为：
+  - 有 id：update。
+  - 无 id：insert。
+  - 未出现在请求中：`isActive=false`，不删除。
+- 订单项保留 SKU snapshot。
+- 商品卡片购买时使用实时 SKU 状态，但历史订单不依赖当前 SKU 可用性。
+- 删除产品改为 `status='archived'`，默认不物理删除有订单的商品。
+
+验收：
+
+- 已产生订单的 SKU 更新后，历史订单仍可查到 SKU 关联或快照。
+- 商品卡片引用老 SKU 时，若 SKU 已下架，返回明确错误，不错发其他 SKU。
+
+### P0.7 经济权限最小化
+
+改动点：
+
+- 增加 `EconomyPolicyService`。
+- 所有经济写操作必须显式传入：
+  - actor
+  - resource
+  - action
+  - scope
+  - dataClass
+- PAT 默认不能执行经济写操作。
+- 如需开放 PAT，必须使用明确 scope：
+  - `economy:wallet:read`
+  - `economy:orders:read`
+  - `economy:offers:write`
+  - `economy:tips:write`
+  - `economy:gifts:write`
+  - `economy:admin:adjust`
+- 经济类管理员操作不只检查 `isAdmin`，还要检查细粒度 admin capability。
+- 增加用户风险状态：
+  - `normal`
+  - `economy_restricted`
+  - `frozen`
+  - `banned`
+
+验收：
+
+- 普通 PAT 不能发起购买、赠送、打赏、退款、管理员加币。
+- 被 economy_restricted 的用户不能转出虾币或资产。
+- 管理员 grant 必须写 audit event。
+
+### P0.8 最小审计表
+
+新增：
+
+```ts
+economyAuditEvents
+  id
+  actorKind
+  actorId
+  actorTokenKind
+  action
+  resourceKind
+  resourceId
+  scopeKind
+  scopeId
+  idempotencyKey
+  requestHash
+  result
+  errorCode
+  ipHash
+  userAgentHash
+  metadata
+  createdAt
+```
+
+P0 先覆盖：
+
+- 充值 create-intent
+- 充值 webhook
+- 购买
+- 管理员 grant
+- 退款
+- 履约 job
+- 权益发放/撤销
+- 结算尝试
+
+验收：
+
+- 任意订单可追溯到支付、扣款、履约、结算、通知。
+- 任意管理员调整可追溯到 actor、目标用户、金额、原因。
+
+## P1：社区经济核心闭环
+
+目标：形成社区内基于虾币的“购买、赠送、打赏、发放、结算、查询”闭环。
+
+### P1.1 社区资产
+
+新增资产定义和资产发放表：
+
+- Badge
+- 服务券
+- 付费内容凭证
+- 数字礼物
+- 创作者服务兑换券
+- 活动奖励
+- 优惠券或折扣券
+
+关键字段：
+
+- 是否可赠送
+- 是否可转让
+- 是否可消费
+- 是否可过期
+- 是否可撤销
+- 来源订单或来源活动
+- 当前 owner
+- 锁定状态
+
+先不做复杂市场。P1 只要求资产能被购买、发放、展示、赠送或消费。
+
+### P1.2 商品交付扩展
+
+改动点：
+
+- `commerceDeliverables.kind` 增加 `entitlement`、`community_asset`、`currency`。
+- `CommerceFulfillmentService` 拆分 handler：
+  - `EntitlementFulfillmentHandler`
+  - `CommunityAssetFulfillmentHandler`
+  - `CurrencyFulfillmentHandler`
+  - `PaidFileFulfillmentHandler`
+  - `MessageFulfillmentHandler`
+- 购买流程只创建 order 和 fulfillment jobs，不在购买服务中直接写具体资产。
+
+验收：
+
+- 一个商品可以同时发 Badge + 付费文件权益 + 系统消息。
+- 某个 deliverable 失败不导致已成功 deliverable 重复发放。
+- 订单详情能展示履约状态。
+
+### P1.3 虾币打赏
+
+新增 API：
+
+```http
+POST /api/economy/tips
+```
+
+请求：
+
+```json
+{
+  "recipientUserId": "uuid",
+  "amount": 100,
+  "message": "谢谢你的内容",
+  "context": {
+    "kind": "message",
+    "id": "uuid"
+  },
+  "idempotencyKey": "..."
+}
+```
+
+规则：
+
+- 不允许给自己打赏。
+- 打赏金额受单笔、每日、每对象频率限制。
+- 打赏先扣打赏者虾币。
+- 收款进入 `seller_pending` 或直接进入 `user_available`，由配置决定。
+- 平台可配置手续费。
+- 被风控限制用户不能转出。
+- 打赏消息和通知不影响账务事务结果。
+
+验收：
+
+- 并发重复打赏不会重复扣款。
+- 删除消息不影响已完成打赏记录。
+- 收款人封禁时收入可进入 held 状态。
+
+### P1.4 资产赠送
+
+新增 API：
+
+```http
+POST /api/economy/gifts
+```
+
+请求：
+
+```json
+{
+  "recipientUserId": "uuid",
+  "assets": [
+    { "assetGrantId": "uuid", "quantity": 1 }
+  ],
+  "currencies": [
+    { "currencyCode": "shrimp_coin", "amount": 100 }
+  ],
+  "message": "送你一个徽章",
+  "idempotencyKey": "..."
+}
+```
+
+规则：
+
+- 可赠送性由 asset definition 决定。
+- 赠送时先锁定资产和虾币。
+- 接收可以设计为：
+  - P1：直接到账。
+  - P2：收件箱领取，可过期退回。
+- 赠送成功写 asset transfer log 和 ledger transaction。
+- 赠送失败必须释放锁。
+
+验收：
+
+- 同一资产不能同时被赠送两次。
+- 已锁定或已消费资产不能赠送。
+- 接收方被封禁时赠送失败或进入人工审核。
+
+### P1.5 创作者/个人店铺增强
+
+复用现有个人店铺：
+
+- `GET /api/me/shop`
+- `POST /api/me/shop`
+- `GET /api/users/:userId/shop`
+- `POST /api/shops/:shopId/products`
+- `POST /api/commerce/offers/:offerId/purchase`
+
+增强：
+
+- 商品类型模板：
+  - 付费内容
+  - 数字礼物
+  - 服务券
+  - Badge
+  - 订阅权益
+- 商品创建时必须配置 deliverables。
+- 默认商品状态为 draft，发布前做校验。
+- 店铺 owner、server admin、platform admin 权限分离。
+- 商品销售统计、收入统计、履约失败统计进入创作者后台。
+
+验收：
+
+- 创作者可以创建一个“数字礼物”商品，用户购买后得到资产并通知创作者。
+- 创作者可以创建一个“付费内容”商品，用户购买后得到 entitlement 和短期访问 grant。
+
+### P1.6 基础结算
+
+新增：
+
+```ts
+settlementAccounts
+settlementBatches
+settlementLines
+```
+
+基础规则：
+
+- 平台销售、创作者销售、打赏都进入 settlement line。
+- P1 可以配置为即时结算或 T+N 延迟结算。
+- 结算失败不能吞掉，必须进入 `settlementStatus='failed'` 并可重试。
+- 退款和 dispute 可冻结未结算收入。
+- 平台手续费单独记录，不能只写 note。
+
+验收：
+
+- 每笔订单能查到 seller gross、platform fee、seller net、settlement status。
+- 结算失败可重试。
+- 退款能关联原结算行。
+
+## P1.5：权限与安全专项
+
+该阶段可以与 P1 并行，但所有 P1 公开功能上线前必须通过。
+
+### 4.1 Actor / Resource / Action 表
+
+经济系统统一使用以下动作表：
+
+| 场景 | Actor | Resource | Action | Data class |
+| --- | --- | --- | --- | --- |
+| 查看钱包 | user | wallet | read | financial |
+| 充值创建 | user | payment_order | create | financial |
+| webhook 入账 | provider/system | payment_order | settle | financial |
+| 商品购买 | user | offer/order/wallet | purchase | financial |
+| 商品发布 | shop_manager | product/offer | publish | commercial |
+| 打赏 | user | wallet/user/context | tip | financial |
+| 赠送 | user | asset/wallet/user | gift | financial |
+| 发放资产 | system | fulfillment/asset | grant | financial |
+| 退款 | user/admin/system | order/wallet | refund | financial |
+| 结算 | system/admin | settlement/wallet | settle | financial |
+| 管理员调整 | platform_admin | wallet/asset | adjust | financial |
+| 审计查询 | admin/auditor | audit_event | read | restricted |
+
+### 4.2 Route 安全要求
+
+所有经济 route 必须：
+
+- 使用 auth middleware。
+- 使用 zod schema。
+- 要求 idempotencyKey。
+- 调用 `EconomyPolicyService`.
+- 调用 `AuditService`.
+- 不直接调用 DAO 改余额或资产。
+- 不信任客户端价格、快照、seller、fee。
+- 不接受客户端指定 `paidAt`、`completedAt`、`settlementStatus`。
+- 对金额使用整数，禁止浮点。
+- 对 amount 设置 min/max。
+- 对频率设置 rate limit。
+- 对 IP、设备、异常重试进入风控信号。
+
+### 4.3 金额安全
+
+统一规则：
+
+- 所有金额都是整数。
+- 所有金额有币种。
+- 所有金额由服务端计算。
+- 客户端只能提交要购买的 offer、sku、数量、接收人。
+- 手续费、折扣、税费、补贴都必须有明细。
+- 订单金额快照保存到订单项。
+- 任何扣款前先校验余额和冻结状态。
+- 任何退款不得超过可退基数。
+
+### 4.4 元数据安全
+
+消息和商品 metadata 规则：
+
+- 客户端提交的商品卡片只允许 `offerId` 或 `productId + skuId`。
+- `snapshot` 必须由服务端生成。
+- `purchase` 行为必须由服务端生成。
+- metadata 总大小限制为 24KB 或更低。
+- 自定义 metadata 进入 `custom`，且 key 数量、深度、总大小受限。
+- 禁止 metadata 携带 HTML、script、内联事件、外部跳转 URL，除非经过专门 URL 安全校验。
+- 所有商品卡片点击购买必须重新读取实时 Offer/Product/SKU/Shop。
+
+## P2：附属能力和运营能力
+
+目标：在核心闭环稳定后，增加运营效率和社区玩法。
+
+### P2.1 优惠与促销
+
+能力：
+
+- 优惠券
+- 折扣码
+- 限时 Offer
+- 首购优惠
+- 平台补贴
+- 店铺补贴
+- 活动奖励
+
+数据模型：
+
+```ts
+promotions
+promotionRules
+promotionRedemptions
+```
+
+要求：
+
+- 优惠只影响订单价格明细，不直接改商品价格。
+- 退款时能区分实付、补贴、赠送余额、手续费。
+- 优惠使用必须幂等。
+
+### P2.2 服务券和轻量服务单
+
+社区经济中有些交易不是立即发内容，而是创作者提供一次服务。P2 支持轻量服务单：
+
+```ts
+serviceOrders
+  id
+  orderId
+  providerUserId
+  buyerUserId
+  status        // requested | accepted | delivered | confirmed | cancelled | disputed
+  deliverBefore
+  metadata
+```
+
+适用：
+
+- 创作者答疑
+- 内容定制
+- 社区任务
+- 一次性服务兑换
+- Buddy 服务兑换
+
+规则：
+
+- 购买后先发服务券或创建 service order。
+- 收入进入 pending。
+- 完成或超时后结算。
+- 争议进入人工处理。
+
+### P2.3 订阅和续费加固
+
+现有续费能力需要升级：
+
+- 续费幂等键：`entitlementId + renewalPeriodStart`.
+- 创建续费订单、扣款、扩展 entitlement、写通知使用事务或 outbox。
+- 失败不重试或有限重试由配置决定。
+- 失败通知进入 notification outbox。
+- 取消订阅、比例退款、撤销权益必须写 audit。
+- 续费失败不应生成重复订单。
+
+### P2.4 争议和退款
+
+新增：
+
+```ts
+refundRequests
+disputeCases
+riskCases
+```
+
+场景：
+
+- 充值争议
+- 商品退款
+- 服务未履约
+- 资产误发
+- 管理员撤销
+- 用户举报交易
+
+要求：
+
+- 退款有状态流。
+- 退款金额不得超过可退金额。
+- 退款关联原 ledger transaction。
+- 退款可能触发资产撤销或 entitlement revoke。
+- dispute 可冻结用户余额或卖家待结算金额。
+
+### P2.5 创作者中心
+
+能力：
+
+- 销售列表
+- 打赏收入
+- 结算状态
+- 履约失败提醒
+- 商品状态检查
+- 退款/争议提醒
+- 资产发放记录
+- 收入导出
+
+后端 API：
+
+```http
+GET /api/economy/creator/summary
+GET /api/economy/creator/sales
+GET /api/economy/creator/settlements
+GET /api/economy/creator/disputes
+```
+
+## P3：前瞻扩展
+
+目标：保留更大社区经济生态的演进空间，但不阻塞核心功能。
+
+### P3.1 多币种
+
+支持：
+
+- `shrimp_coin`
+- 绑定虾币
+- 活动点数
+- 创作者积分
+- 社区贡献值
+- 未来平台奖励币
+
+要求：
+
+- 多币种不影响现有单币种接口。
+- 所有 ledger entries 必须带 currencyCode。
+- 不同币种不可默认互换。
+- 兑换必须走明确 exchange order。
+
+### P3.2 轻量社区市场
+
+不是第一阶段目标。P3 可支持用户出售可转让资产或服务券：
+
+```ts
+communityListings
+  id
+  sellerUserId
+  assetGrantId
+  quantity
+  priceCurrency
+  priceAmount
+  status
+  expiresAt
+```
+
+要求：
+
+- listing 创建时锁定资产。
+- 购买时扣买家虾币、转移资产、收手续费、卖家入 pending。
+- listing 取消时释放锁。
+- 不做复杂竞价，先做定价购买。
+
+### P3.3 开放 API 和 SDK
+
+开放前提：
+
+- 经济 scope 完成。
+- webhook/outbox 完成。
+- 审计完成。
+- 限流完成。
+- 风控完成。
+
+候选 API：
+
+```http
+GET /api/economy/wallet
+GET /api/economy/assets
+POST /api/economy/tips
+POST /api/economy/gifts
+GET /api/economy/orders
+GET /api/economy/audit-events
+```
+
+### P3.4 数据报表和风控模型
+
+报表：
+
+- 每日充值
+- 每日消费
+- 虾币流入流出
+- 活跃打赏用户
+- 创作者收入
+- 退款率
+- 争议率
+- 履约失败率
+- 管理员调整统计
+- 异常转账网络
+
+风控模型：
+
+- 短时高频赠送
+- 新账号大额充值后快速转出
+- 重复小额打赏刷榜
+- 同 IP 多账号互转
+- 争议用户高消费
+- 管理员异常 grant
+- 价格异常商品
+- 重复履约风险
+
+## 5. API 草案
+
+### 5.1 钱包
+
+```http
+GET /api/economy/wallet
+GET /api/economy/wallet/transactions?direction=&limit=&offset=
+```
+
+返回：
+
+```json
+{
+  "wallet": {
+    "currencyCode": "shrimp_coin",
+    "availableAmount": 1000,
+    "frozenAmount": 0
+  }
+}
+```
+
+### 5.2 打赏
+
+```http
+POST /api/economy/tips
+```
+
+```json
+{
+  "recipientUserId": "uuid",
+  "amount": 100,
+  "context": {
+    "kind": "message",
+    "id": "uuid"
+  },
+  "message": "感谢分享",
+  "idempotencyKey": "tip-..."
+}
+```
+
+### 5.3 赠送
+
+```http
+POST /api/economy/gifts
+```
+
+```json
+{
+  "recipientUserId": "uuid",
+  "assets": [
+    { "assetGrantId": "uuid", "quantity": 1 }
+  ],
+  "currencies": [],
+  "message": "送你一个徽章",
+  "idempotencyKey": "gift-..."
+}
+```
+
+### 5.4 资产
+
+```http
+GET /api/economy/assets
+GET /api/economy/assets/:id
+POST /api/economy/assets/:id/consume
+```
+
+### 5.5 管理员调整
+
+```http
+POST /api/admin/economy/adjustments
+```
+
+```json
+{
+  "targetUserId": "uuid",
+  "currencyCode": "shrimp_coin",
+  "amount": 1000,
+  "reasonCode": "support_compensation",
+  "note": "客服补偿",
+  "idempotencyKey": "admin-adjust-..."
+}
+```
+
+要求：
+
+- 只允许平台经济管理员。
+- 必须写 audit。
+- 必须写 ledger。
+- 必须支持负向调整，但不能绕过冻结/风控规则，除非更高权限。
+
+## 6. 推荐代码组织
+
+建议新增目录：
+
+```text
+apps/server/src/services/economy/
+  economy-command.service.ts
+  economy-policy.service.ts
+  economy-audit.service.ts
+  community-asset.service.ts
+  gift.service.ts
+  tip.service.ts
+  settlement.service.ts
+  refund.service.ts
+  risk.service.ts
+  fulfillment-handlers/
+    entitlement.handler.ts
+    community-asset.handler.ts
+    currency.handler.ts
+    paid-file.handler.ts
+```
+
+建议新增 schema 文件：
+
+```text
+apps/server/src/db/schema/economy.ts
+apps/server/src/db/schema/settlements.ts
+apps/server/src/db/schema/audit.ts
+apps/server/src/db/schema/risk.ts
+```
+
+建议新增 handler：
+
+```text
+apps/server/src/handlers/economy.handler.ts
+apps/server/src/handlers/economy-admin.handler.ts
+```
+
+容器注册：
+
+- `economyCommandService`
+- `economyPolicyService`
+- `economyAuditService`
+- `communityAssetService`
+- `giftService`
+- `tipService`
+- `settlementService`
+- `refundService`
+- `riskService`
+
+## 7. 安全漏洞和问题清单
+
+| 编号 | 优先级 | 问题 | 修复 |
+| --- | --- | --- | --- |
+| S-01 | P0 | 充值接受任意 currency | 服务端白名单，生产默认只允许 USD |
+| S-02 | P0 | webhook secret 可为空 | 生产启动强校验 |
+| S-03 | P0 | 余额变更路径分裂 | 所有余额变化通过 LedgerService |
+| S-04 | P0 | OrderService 直接扣款 | 改成 LedgerService.debit |
+| S-05 | P0 | 经济写操作缺统一幂等 | 全部经济写要求 idempotencyKey |
+| S-06 | P0 | 履约 job 可能重复 claim | 原子 claim + fulfillment records 唯一约束 |
+| S-07 | P0 | metadata passthrough | 经济 metadata 白名单化 |
+| S-08 | P0 | DM metadata 过宽 | DM 复用统一 message metadata schema |
+| S-09 | P0 | thread 商品卡片可能绕过正规化 | 所有消息入口统一 normalize |
+| S-10 | P0 | SKU 更新删除重建 | 改为 update/upsert/soft deactivate |
+| S-11 | P0 | PAT scope 粗放 | 经济接口使用显式 scope |
+| S-12 | P0 | 管理员 grant 缺强审计 | admin adjustment 独立模型 + audit |
+| S-13 | P1 | dispute 只记录日志 | risk case + 冻结 + 通知 |
+| S-14 | P1 | 结算失败被吞 | settlement job + retry + failed 状态 |
+| S-15 | P1 | 付费文件 token 在 query | 一次性 token 或短期安全 grant |
+| S-16 | P1 | 续费事务边界分裂 | 续费订单、扣款、扩权使用事务/outbox |
+| S-17 | P1 | 商品价格来源可能混乱 | 购买时只信任服务端实时 Offer/Product/SKU |
+| S-18 | P1 | 收入和手续费无明细 | settlement lines 分离 gross/fee/net |
+| S-19 | P1 | 风控状态缺失 | user economy status + risk rules |
+| S-20 | P2 | 退款可退基数不完整 | 订单金额明细和退款基数快照 |
+
+## 8. 测试计划
+
+### 8.1 单元测试
+
+- `LedgerService`
+  - credit
+  - debit
+  - refund
+  - settlement
+  - insufficient balance
+  - repeated idempotency
+- `CommerceFulfillmentService`
+  - atomic claim
+  - repeated worker
+  - failed retry
+  - fulfillment record uniqueness
+- `CommunityAssetService`
+  - grant
+  - lock
+  - unlock
+  - transfer
+  - consume
+- `GiftService`
+  - duplicate request
+  - locked asset
+  - non-giftable asset
+  - recipient restricted
+- `TipService`
+  - self tip forbidden
+  - daily limit
+  - repeated idempotency
+  - fee split
+
+### 8.2 集成测试
+
+- 充值成功 webhook 重复投递。
+- 充值 dispute 后创建 risk case。
+- 购买商品后生成订单、扣款、履约、通知、审计。
+- 商品同时包含 entitlement、asset、paid file deliverables。
+- 并发购买同一限量 SKU。
+- 赠送同一资产并发请求。
+- 管理员 grant 后审计可查。
+- 订单退款后资产撤销或权益撤销。
+- 结算失败后可重试。
+
+### 8.3 安全测试
+
+- PAT 无经济 scope 不能执行经济写。
+- 客户端伪造价格无效。
+- 客户端伪造 seller 无效。
+- 客户端伪造 fulfillment status 无效。
+- metadata 超大小被拒绝。
+- metadata 注入未知 action 被拒绝。
+- 非店铺 owner 无法发布商品。
+- 被冻结用户无法转出资产或虾币。
+- webhook 签名错误被拒绝。
+- 空 webhook secret 在生产不允许启动。
+
+### 8.4 不变量测试
+
+必须持续验证：
+
+- 用户余额不能为负，除非显式允许负债账户。
+- 每笔 ledger transaction 分录平衡。
+- 每个 idempotencyKey 只产生一次经济结果。
+- 每个 fulfillment record 只产生一次交付。
+- 每个 asset grant 同一数量不能同时被多个 lock 占用。
+- 退款金额不能超过可退金额。
+- 结算金额 = gross - fee - refund - hold。
+- 管理员调整必须有 audit event。
+
+## 9. 迁移策略
+
+### 9.1 不做大爆炸迁移
+
+迁移顺序：
+
+1. 增加新表。
+2. 让新服务写新表，同时保留旧展示表。
+3. 老接口内部调用新服务。
+4. 前端逐步切换到新 API。
+5. 旧路径加 deprecation warning。
+6. 安全检查脚本禁止新增旧路径写法。
+7. 稳定后再清理旧兼容逻辑。
+
+### 9.2 数据兼容
+
+- 现有 `wallets.balance` 迁移为 `walletBalances.availableAmount`。
+- 现有 `walletTransactions` 可作为历史流水保留。
+- 现有 `orders` 继续可查。
+- 现有 `entitlements` 继续有效。
+- 已存在商品 SKU 不删除，只补 `isActive` 语义。
+- 已有 paid file grants 保持可用。
+
+### 9.3 前端兼容
+
+先保持现有页面可用：
+
+- 钱包页继续读 wallet summary。
+- 店铺页继续购买商品。
+- 商品卡片继续展示。
+- 付费文件继续打开。
+
+逐步新增：
+
+- 资产页。
+- 打赏按钮。
+- 赠送弹窗。
+- 创作者收入页。
+- 审计/交易详情页。
+- 风控/争议后台页。
+
+## 10. 里程碑和验收标准
+
+### M0：P0 安全地基完成
+
+验收：
+
+- 充值 currency 和 webhook secret 已加固。
+- 所有余额变化经过 LedgerService。
+- 经济写操作要求 idempotencyKey。
+- 履约原子 claim。
+- 商品卡片 metadata 白名单化。
+- SKU 稳定更新。
+- PAT 经济写权限收紧。
+- 最小审计表上线。
+- P0 测试通过。
+- `pnpm check:security-pr` 扩展并通过。
+
+### M1：核心社区经济 MVP
+
+验收：
+
+- 用户可充值。
+- 用户可购买社区商品。
+- 商品可发 entitlement、community asset、paid file。
+- 用户可打赏。
+- 用户可赠送资产。
+- 创作者可查看收入。
+- 订单可查看支付、履约、结算状态。
+- 基础结算可重试。
+- 审计可追踪完整链路。
+
+### M2：运营增强
+
+验收：
+
+- 优惠券和补贴可用。
+- 服务单可用。
+- 退款和争议流程可用。
+- 订阅续费幂等可用。
+- 风控冻结可用。
+- 创作者中心可用。
+
+### M3：扩展生态
+
+验收：
+
+- 多币种模型可用。
+- 轻量社区市场可用。
+- 经济 API/SDK 可用。
+- 报表和风控模型上线。
+- 审计导出和对账稳定。
+
+## 11. 最小可落地任务清单
+
+建议第一批 PR 拆分：
+
+1. `P0-ledger-boundary`
+   - 禁止 OrderService 直接改余额。
+   - 扩展 security check。
+   - 增加测试。
+
+2. `P0-recharge-hardening`
+   - currency 白名单。
+   - webhook secret 生产强校验。
+   - provider event 表。
+   - webhook 幂等测试。
+
+3. `P0-idempotency-and-audit`
+   - economy audit 表。
+   - 经济写 idempotency 中间件或 helper。
+   - 管理员 grant 审计。
+
+4. `P0-fulfillment-claim`
+   - 原子 claim。
+   - fulfillment record。
+   - 并发测试。
+
+5. `P0-message-metadata-boundary`
+   - 统一 metadata schema。
+   - DM/thread/socket 统一 normalize。
+   - 禁止客户端 snapshot/action 注入。
+
+6. `P0-sku-stability`
+   - SKU update/upsert/soft deactivate。
+   - 历史订单兼容测试。
+
+7. `P1-community-assets`
+   - asset definition/grant/lock/transfer log。
+   - asset fulfillment handler。
+   - asset 查询 API。
+
+8. `P1-tips-and-gifts`
+   - 打赏 API。
+   - 赠送 API。
+   - 限流和风控状态。
+   - 通知和审计。
+
+9. `P1-settlement`
+   - settlement lines。
+   - platform fee。
+   - seller pending。
+   - retry job。
+
+## 12. 结论
+
+Shadow 需要建设的是一个社区经济平台，而不是单一商城功能。最可靠的路线是先把账务、幂等、权限、履约、审计做牢，再把商品、权益、付费内容、社区资产、打赏、赠送和结算串成闭环。
+
+P0 的价值最大：它不增加太多产品 UI，却能显著降低刷币、重复发货、错价、越权、结算丢失和审计缺口风险。P1 再开始交付用户可见的社区经济能力。P2 和 P3 提供运营增长和生态扩展，但不应抢在安全地基之前上线。

--- a/docs/development/community-economy-phase-1-technical-plan.md
+++ b/docs/development/community-economy-phase-1-technical-plan.md
@@ -1,0 +1,515 @@
+# Shadow 社区经济第一期技术实现规划
+
+版本：2026-05-10
+
+关联方案：[shadow-community-economy-implementation-plan-v2.md](../decisions/shadow-community-economy-implementation-plan-v2.md)
+
+## 0. 查漏补缺记录
+
+2026-05-10 第一轮实现后复查结论：
+
+- 普通商城下单、Offer 购买、权益取消退款、不可抗力退款、充值 create-intent 都进入 `EconomyPolicyService` / `EconomyAuditService` 覆盖范围。
+- `WalletDao` 不再暴露 `credit`、`debit`、`updateBalance`、`addTransaction` 这类直接余额写入口；直接余额更新只允许在 `LedgerService` 内部。
+- `scripts/check-security-pr.mjs` 已扩展为扫描 DAO 和 service 中的 `wallets.balance` 直接算术与 `db.update(wallets)`。
+- 充值 create-intent 必须传 `idempotencyKey`，服务端用同一 key 约束本地幂等记录和 Stripe PaymentIntent idempotency。
+- TS SDK、Python SDK、web 充值弹窗、web/mobile 普通商城下单已同步 idempotency 请求体。
+- Docker Compose 干净数据库已验证迁移、关键后端测试和安全检查。
+
+仍保留到第二期处理：
+
+- 完整 `settlement_*` 表、结算批次、结算失败重试。
+- 社区资产定义、资产 grant、资产赠送和资产展示。
+- 打赏、赠送公开 API 和 web/mobile 用户界面。
+- 付费文件 query token 的 header/cookie 化。
+- 续费事务边界/outbox 化。
+
+## 1. 第一期范围
+
+这里的“第一期”指第一个可落地工程包，不等同于原方案里的 `P1`。实施顺序应先完成原方案 `P0：交易安全与账务地基`，再开放 `P1：社区经济核心闭环` 的用户可见功能。
+
+第一期交付目标：
+
+- 收敛所有虾币余额写入到 `LedgerService`。
+- 为充值、购买、履约、退款、管理员调整建立幂等、审计和 provider event 记录。
+- 修复已确认的交易安全缺口：普通商城下单直接扣余额、SKU 更新删除重建、履约任务非原子 claim、thread 消息绕过商品卡片标准化。
+- 建立 `EconomyPolicyService` 和最小经济审计表，为后续打赏、赠送、社区资产、结算打基础。
+- 只做必要的 web/mobile 兼容更新，不在第一期推出完整打赏和赠送 UI。
+
+非目标：
+
+- 不做多币种。
+- 不做开放市场。
+- 不做复杂优惠、争议工作台、创作者中心。
+- 不重写现有 shop/order/entitlement/paid-file 能力。
+
+## 2. 当前代码调研结论
+
+### 2.1 可复用能力
+
+- `apps/server/src/db/schema/shops.ts` 已有 `shops`、`products`、`skus`、`commerce_offers`、`commerce_deliverables`、`orders`、`order_items`、`wallets`、`wallet_transactions`、`entitlements`、`paid_file_grants`、`commerce_fulfillment_jobs`、`commerce_idempotency_keys`。
+- `apps/server/src/services/ledger.service.ts` 已提供 `credit`、`debit`、`settleReservedMicros`，充值和部分虚拟权益购买已经复用它。
+- `apps/server/src/services/entitlement-purchase.service.ts` 已有 Offer 购买幂等、订单、扣款、权益发放、履约 job 创建。
+- `apps/server/src/services/commerce-card.service.ts` 已能把 channel/DM 的商品 metadata 标准化为服务端生成的 snapshot。
+- `apps/server/src/security/actor.ts` 和 auth middleware 已经能输出显式 `Actor`，可直接作为经济权限层输入。
+- TS SDK、Python SDK 已覆盖当前 commerce、wallet、recharge、entitlement API。
+- web 和 mobile 都已有 shop、chat commerce card、wallet 查询、基础购买入口。
+
+### 2.2 第一期开工前必须修的缺口
+
+- `OrderService.createOrder` 仍直接 `db.update(wallets)` 并插入 `walletTransactions`，绕过 `LedgerService`。
+- `OrderService.updateOrderStatus` 完成订单时结算失败会被吞掉，没有 `settlementStatus` 或可重试记录。
+- `ProductService.updateProduct` 更新 SKU 时会删除商品全部 SKU 再重建，历史订单、商品卡片和库存引用会断。
+- `ProductService.deleteProduct` 是物理删除，应优先改为 `status='archived'`。
+- `CommerceFulfillmentService.processJob` 是先 select 再 update，多 worker 下可能重复交付。
+- `commerce_deliverables.kind` 目前只有 `paid_file | message | external`，不能承载 `entitlement | community_asset | currency`。
+- `message.schema.ts` 的 metadata 仍 `.passthrough()`，DM route 也使用 `z.record(z.unknown())`。
+- thread 消息入口没有调用 `CommerceCardService.inferMessageMetadata`，会绕过 channel/DM 的商品卡片标准化。
+- 充值 `create-intent` 接受客户端 `currency`，`STRIPE_WEBHOOK_SECRET` 默认空字符串，且没有 `paymentProviderEvents` 去重表。
+- Stripe dispute 只更新 payment order 并打日志，没有风险案例或冻结/审计记录。
+- 现有 `PolicyService` 偏 server/channel 权限，没有经济动作、数据分级、PAT 经济写限制。
+- `scripts/check-security-pr.mjs` 只拦截 `walletDao.credit/debit/updateBalance`，还没有扫描直接 `db.update(wallets)`。
+
+## 3. 数据模型计划
+
+第一期新增迁移建议命名为 `0058_community_economy_foundation.sql`，并同步 Drizzle schema。
+
+### 3.1 经济审计
+
+新增 `economy_audit_events`：
+
+- `id`
+- `actor_kind`
+- `actor_id`
+- `actor_token_kind`
+- `action`
+- `resource_kind`
+- `resource_id`
+- `scope_kind`
+- `scope_id`
+- `idempotency_key`
+- `request_hash`
+- `result`
+- `error_code`
+- `ip_hash`
+- `user_agent_hash`
+- `metadata`
+- `created_at`
+
+第一期覆盖：充值 create-intent、Stripe webhook、普通商城下单、Offer 购买、退款、履约 job、管理员 grant/adjustment。
+
+### 3.2 支付 provider event
+
+新增 `payment_provider_events`：
+
+- `id`
+- `provider`，第一期固定 `stripe`
+- `provider_event_id`，唯一
+- `event_type`
+- `payload_hash`
+- `payment_order_id`
+- `status`：`received | processing | processed | failed | ignored`
+- `processed_at`
+- `error_code`
+- `created_at`
+- `updated_at`
+
+webhook 处理流程先写 event，再基于 `provider_event_id` 幂等处理。
+
+### 3.3 风险案例
+
+新增 `risk_cases`：
+
+- `id`
+- `user_id`
+- `resource_type`
+- `resource_id`
+- `kind`：`payment_dispute | chargeback | economy_restricted | fraud_signal`
+- `status`：`open | reviewing | resolved | dismissed`
+- `severity`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+第一期只写入 dispute/chargeback，不做完整后台。
+
+### 3.4 履约记录
+
+新增 `commerce_fulfillment_records`：
+
+- `id`
+- `job_id`
+- `order_id`
+- `order_item_id`
+- `deliverable_id`
+- `recipient_user_id`
+- `idempotency_key`
+- `result_type`
+- `result_id`
+- `status`
+- `created_at`
+
+唯一约束：
+
+- `(order_item_id, deliverable_id, recipient_user_id)`
+- `(idempotency_key)`
+
+### 3.5 用户经济状态
+
+新增独立 enum 和字段，不复用在线状态：
+
+- `user_economy_status`: `normal | economy_restricted | frozen | banned`
+- `users.economy_status default 'normal'`
+
+`EconomyPolicyService` 在转出类动作中检查该字段。
+
+### 3.6 后续 P1 预留
+
+第一期可以只加 enum 和服务接口，不必开放 route：
+
+- `commerce_deliverable_kind` 增加 `entitlement`、`community_asset`、`currency`。
+- 如迁移风险可控，新增 `community_asset_definitions`、`community_asset_grants`、`community_asset_locks`、`community_asset_transfer_logs`，但不接 UI。
+- `settlement_*` 表建议放到第二个工程包，第一期先保留订单结算审计和失败可追踪状态。
+
+## 4. 服务层设计
+
+### 4.1 EconomyPolicyService
+
+新增 `apps/server/src/services/economy-policy.service.ts`。
+
+输入：
+
+- `actor`
+- `resource: { kind, id }`
+- `action`
+- `scope`
+- `dataClass`
+- `amount?`
+
+第一期规则：
+
+- `actor.kind === 'pat'` 默认拒绝经济写动作。
+- PAT 只有显式 `economy:*` scope 才能访问对应经济能力。
+- OAuth 同样需要显式经济 scope。
+- 普通用户可读自己的 wallet/order/entitlement。
+- 普通用户可购买、退款自己订单、发起充值。
+- `economy_restricted`、`frozen`、`banned` 用户不能转出虾币、购买、赠送、打赏。
+- 管理员调整必须要求 platform admin capability，不只看 `isAdmin`。
+
+### 4.2 EconomyAuditService
+
+新增 `apps/server/src/services/economy-audit.service.ts`。
+
+职责：
+
+- 统一写 `economy_audit_events`。
+- 对 request body 只写 hash 和安全摘要。
+- 对 IP、User-Agent 写 hash，不存原值。
+- 被业务 service 调用失败时，不应吞掉业务事务内的审计失败；审计缺失等同经济写失败。
+
+### 4.3 EconomyIdempotencyService
+
+先复用 `commerce_idempotency_keys`，服务名抽象为 `EconomyIdempotencyService`。
+
+第一期动作：
+
+- `shop.order.create`
+- `commerce.offer.purchase`
+- `recharge.confirm`
+- `wallet.refund`
+- `admin.wallet.adjust`
+- `fulfillment.process`
+
+行为：
+
+- scope 为 `actorUserId + action + key`。
+- completed 时保存安全响应摘要。
+- in-progress 返回 `409`。
+- failed 可在有限时间后重试，需记录 error。
+
+### 4.4 LedgerService 收敛
+
+扩展 `LedgerService` 入参：
+
+- `actor`
+- `action`
+- `currencyCode`
+- `idempotencyKey`
+- `referenceType`
+- `referenceId`
+- `metadata`
+
+第一期仍保留 `wallets.balance` 和 `wallet_transactions` 作为兼容层，不急于拆 `ledger_transactions/ledger_entries`。但所有余额变更必须从 `LedgerService` 进入。
+
+改造点：
+
+- `OrderService.createOrder` 使用 `LedgerService.debit`。
+- `OrderService.cancelOrder` 使用 `LedgerService.credit` 并接幂等。
+- `EntitlementPurchaseService` 保留 `LedgerService`，增加 policy/audit/idempotency 统一框架。
+- 结算 credit 不能静默失败，至少写审计和失败状态。
+- `scripts/check-security-pr.mjs` 扫描 `db.update(wallets)`、`wallets.balance +`、`wallets.balance -`，允许名单仅 `ledger.service.ts` 和测试。
+
+### 4.5 ProductService SKU 稳定化
+
+改造 `updateProduct`：
+
+- 有 `sku.id`：校验属于当前 product 后 update。
+- 无 `sku.id`：insert。
+- 请求里未出现的旧 SKU：`isActive=false`，不删除。
+- 已有关联订单的 product 删除改为 `status='archived'`。
+- 订单项继续保存当前 snapshot。
+
+### 4.6 CommerceFulfillmentService 原子化
+
+改造 `processJob`：
+
+- 单条 `update ... where id=? and status in ('pending','failed') returning` claim。
+- claim 失败直接返回当前 job。
+- 每个 deliverable 写 `commerce_fulfillment_records`。
+- paid file/message 发送前检查 fulfillment record 唯一约束。
+- 失败重试只重试未成功记录的 deliverable。
+
+### 4.7 消息 metadata 边界
+
+改造点：
+
+- 抽出共享 `messageMetadataSchema`，channel、DM、thread、WS 共用。
+- 移除经济相关 metadata 的 `.passthrough()`。
+- 保留非经济扩展放入 `custom`，限制 key 数、深度、总字节。
+- `thread` POST 消息入口调用 `CommerceCardService.inferMessageMetadata`。
+- `CommerceCardService.normalizeMessageMetadata` 继续只信任 `offerId` 或 `productId + skuId`，snapshot/purchase 永远服务端生成。
+
+## 5. API 和 SDK 影响
+
+### 5.1 后端 API
+
+第一期不新增公开打赏/赠送 API，只调整现有经济写接口：
+
+- `POST /api/servers/:serverId/shop/orders` 增加 `idempotencyKey`。
+- `POST /api/v1/recharge/create-intent` 移除客户端任意 `currency`，或只接受白名单币种。
+- `POST /api/v1/recharge/confirm` 增加幂等保护。
+- `POST /api/commerce/offers/:offerId/purchase` 保持现有 `idempotencyKey`，补 policy/audit。
+- 管理员 wallet grant/adjustment 如已有入口，必须补 policy/audit/idempotency；如没有，先不新增。
+
+兼容策略：
+
+- web/mobile 当前普通商城下单没有传 `idempotencyKey`。第一期可先让服务端在缺失时返回 400，同时同步 web/mobile/SDK；不建议服务端自动生成，因为重试无法幂等。
+- TS SDK、Python SDK 的 `createOrder`/`purchase` 类型需要增加 `idempotencyKey`。
+- API 文档同步 `docs/wiki/en/API-Reference.md` 和 `docs/wiki/en/SDK-Usage.md`。
+
+### 5.2 Web
+
+必须同步：
+
+- 普通购物车 checkout 生成稳定 idempotency key，并在请求失败可重试时复用同一 key。
+- 商品详情直接购买同样传 key。
+- 商品管理 SKU 编辑要保留已有 SKU id。
+- 所有新增 copy 使用 `apps/web/src/lib/locales/*.json`。
+
+### 5.3 Mobile
+
+必须同步：
+
+- `apps/mobile/app/(main)/servers/[serverSlug]/shop.tsx` checkout 请求增加 idempotency key。
+- chat commerce card 购买继续传 key，但需要区分 channel 与 DM purchase endpoint。
+- shop-admin 当前创建商品 payload 与服务端 `createProductSchema` 不完全一致，第一期只做必要兼容修复，完整移动端创作者商品管理放到后续。
+- 所有新增 copy 使用 `apps/mobile/src/i18n/locales/*.json`。
+
+### 5.4 SDK
+
+TS SDK：
+
+- `ShadowClient.createOrder` 参数加入 `idempotencyKey`。
+- `ShadowOrder` 如新增状态字段，需要类型同步。
+- 新增 provider/risk/audit 不暴露给普通 SDK，除非后续开放管理员接口。
+
+Python SDK：
+
+- `purchase_shop_product`、`purchase_commerce_offer` 已有 key。
+- `create_order` 增加 `idempotency_key`。
+- 类型字段保持 snake_case 映射。
+
+## 6. 实施顺序
+
+### Step 1：数据模型和容器注册
+
+文件：
+
+- `apps/server/src/db/schema/shops.ts`
+- `apps/server/src/db/schema/recharge.ts`
+- `apps/server/src/db/schema/users.ts`
+- `apps/server/src/db/schema/index.ts`
+- `apps/server/src/db/migrations/0058_community_economy_foundation.sql`
+- `apps/server/src/container.ts`
+
+产出：
+
+- 新表和 enum。
+- 新服务注册。
+- 迁移检查通过。
+
+### Step 2：经济 policy/audit/idempotency 框架
+
+文件：
+
+- `apps/server/src/services/economy-policy.service.ts`
+- `apps/server/src/services/economy-audit.service.ts`
+- `apps/server/src/services/economy-idempotency.service.ts`
+- `apps/server/src/security/actor.ts` 如需补 system/provider actor helper。
+
+产出：
+
+- 购买、充值、退款、履约可调用统一 policy/audit/idempotency。
+- 单元测试覆盖 PAT/OAuth/风险状态拒绝。
+
+### Step 3：账务入口收敛
+
+文件：
+
+- `apps/server/src/services/ledger.service.ts`
+- `apps/server/src/services/order.service.ts`
+- `apps/server/src/services/wallet.service.ts`
+- `apps/server/src/dao/wallet.dao.ts`
+- `scripts/check-security-pr.mjs`
+
+产出：
+
+- 普通商城下单、取消退款、结算全部走 `LedgerService`。
+- 安全脚本能拦截直接写 `wallets.balance`。
+- 并发余额不足和重复请求测试通过。
+
+### Step 4：充值加固
+
+文件：
+
+- `apps/server/src/lib/stripe.ts`
+- `apps/server/src/handlers/recharge.handler.ts`
+- `apps/server/src/handlers/stripe-webhook.handler.ts`
+- `apps/server/src/services/recharge.service.ts`
+- `apps/server/src/dao/recharge.dao.ts`
+
+产出：
+
+- production 空 webhook secret 启动失败。
+- `SUPPORTED_STRIPE_CURRENCIES` 白名单。
+- webhook event id 幂等。
+- dispute 写 risk case 和 audit。
+
+### Step 5：SKU 和履约稳定化
+
+文件：
+
+- `apps/server/src/services/product.service.ts`
+- `apps/server/src/dao/product.dao.ts`
+- `apps/server/src/services/commerce-fulfillment.service.ts`
+- `apps/server/src/services/entitlement-purchase.service.ts`
+
+产出：
+
+- SKU update/upsert/soft deactivate。
+- product archive 替代危险物理删除。
+- fulfillment 原子 claim 和 record 去重。
+
+### Step 6：metadata 边界
+
+文件：
+
+- `apps/server/src/validators/message.schema.ts`
+- `apps/server/src/handlers/message.handler.ts`
+- `apps/server/src/handlers/dm.handler.ts`
+- `apps/server/src/ws/chat.gateway.ts`
+- `apps/server/src/services/commerce-card.service.ts`
+
+产出：
+
+- channel/DM/thread/WS 入口统一 metadata 规则。
+- 伪造 snapshot/price/purchase 不影响真实购买。
+- custom metadata 有大小和结构限制。
+
+### Step 7：客户端、SDK、文档同步
+
+文件：
+
+- `apps/web/src/components/shop/shop-cart.tsx`
+- `apps/web/src/components/shop/order-confirm.tsx`
+- `apps/web/src/components/shop/product-detail.tsx`
+- `apps/mobile/app/(main)/servers/[serverSlug]/shop.tsx`
+- `apps/mobile/src/components/chat/message-bubble.tsx`
+- `packages/sdk/src/client.ts`
+- `packages/sdk/src/types.ts`
+- `packages/sdk-python/shadowob_sdk/client.py`
+- `packages/sdk-python/shadowob_sdk/types.py`
+- `docs/wiki/en/API-Reference.md`
+- `docs/wiki/en/SDK-Usage.md`
+
+产出：
+
+- web/mobile 普通购买请求携带 idempotency key。
+- SDK 类型和方法签名同步。
+- 文档同步 API 变更。
+
+## 7. 测试计划
+
+### Unit
+
+- `LedgerService`：credit/debit/idempotency/insufficient balance。
+- `EconomyPolicyService`：PAT/OAuth/user/system actor、风险状态、scope。
+- `EconomyAuditService`：写入字段、hash、不记录敏感 payload。
+- `ProductService`：SKU update/upsert/soft deactivate。
+- `CommerceFulfillmentService`：claim 失败、record 去重、重试不重复交付。
+- metadata validator：snapshot/purchase 伪造、custom 限制、thread 标准化。
+
+### Integration
+
+- 普通商城订单：并发同 key 只扣一次、只建一个订单。
+- Offer 购买：已有幂等路径补 policy/audit 后仍兼容。
+- 充值 webhook：重复 event id 只入账一次。
+- dispute：payment order 状态、risk case、audit 都写入。
+- 退款：不超过可退金额，重复请求不重复退款。
+
+### E2E
+
+- web 购物车结账成功，wallet/order/products query 刷新。
+- mobile 购物车结账成功，wallet/order/products query 刷新。
+- channel 商品卡购买成功。
+- DM 商品卡购买成功。
+- thread 商品卡伪造 metadata 被拒或被重建。
+
+### Security
+
+- `pnpm check:security-pr`
+- 新增测试覆盖直接 `db.update(wallets)` 扫描。
+- PAT 无经济 scope 时不能下单、退款、grant。
+- metadata 总大小、深度、字段数量限制。
+
+## 8. 本地验证命令
+
+按变更范围逐步跑：
+
+```bash
+pnpm biome format --write docs/development/community-economy-phase-1-technical-plan.md
+pnpm check:security-pr
+docker compose -f docker-compose.ci-tests.yml run --rm server pnpm test -- --runInBand apps/server/__tests__/commerce-entitlement-service.test.ts
+docker compose -f docker-compose.ci-tests.yml run --rm server pnpm test -- --runInBand apps/server/__tests__/shop-e2e.test.ts
+```
+
+如果测试命令和当前 CI runner 不一致，以 `docker-compose.ci-tests.yml` 里的实际服务命令为准。
+
+## 9. 风险和取舍
+
+- 强制普通商城下单传 `idempotencyKey` 会影响 web/mobile/SDK，必须同 PR 同步。
+- 第一期开 `community_asset_*` 表但不开放 UI 可以降低 P1 迁移压力，但会增加迁移审查成本；如果本期要压缩范围，可只加入 deliverable enum 和服务接口。
+- `wallet_transactions` 继续作为兼容展示层，短期不是完整复式账本；真正 `ledger_transactions/ledger_entries` 可在第二期升级。
+- 结算如果继续即时 credit，退款和 dispute 会更难处理；第一期至少要记录结算失败和审计，第二期再引入 `settlement_*`。
+- metadata `.passthrough()` 移除可能影响未知机器人扩展，需要把非经济扩展迁移到受限 `custom`。
+
+## 10. 第一期开工清单
+
+1. 创建 `0058_community_economy_foundation` 迁移和 schema。
+2. 新增 `EconomyPolicyService`、`EconomyAuditService`、`EconomyIdempotencyService`。
+3. 改造普通商城下单和取消退款走 `LedgerService`。
+4. 加固充值 currency/webhook/event/dispute。
+5. 改 SKU 更新和 product 删除策略。
+6. 改 fulfillment 原子 claim 和 record。
+7. 收紧 message metadata，补 thread 入口标准化。
+8. 同步 web/mobile/TS SDK/Python SDK/API 文档。
+9. 跑安全检查、服务单测、集成测试、web/mobile E2E。

--- a/docs/development/community-economy-phase-2-technical-plan.md
+++ b/docs/development/community-economy-phase-2-technical-plan.md
@@ -1,0 +1,401 @@
+# Shadow 社区经济第二期技术实现规划
+
+版本：2026-05-10
+
+关联：
+
+- [shadow-community-economy-implementation-plan-v2.md](../decisions/shadow-community-economy-implementation-plan-v2.md)
+- [community-economy-phase-1-technical-plan.md](./community-economy-phase-1-technical-plan.md)
+
+## 1. 第二期范围
+
+第二期对应原方案 `P1：社区经济核心闭环` 的第一个用户可见工程包。目标不是开放市场，而是在第一期安全底座上形成单币种虾币的购买、打赏、赠送、资产发放、基础结算和查询闭环。
+
+交付目标：
+
+- 社区资产可以被定义、发放、展示、锁定、赠送和撤销。
+- 商品 deliverable 可以发放 `entitlement`、`community_asset`、`currency`，并保留 paid file/message 能力。
+- 用户可以对用户、消息、Buddy、商品内容发起虾币打赏。
+- 用户可以赠送可赠送资产和少量虾币。
+- 创作者/卖家的收入进入可查询 settlement line，支持即时结算或 T+N 配置。
+- web 和 mobile 都具备资产列表、打赏入口、赠送入口、创作者商品发放状态展示。
+
+非目标：
+
+- 不做用户间自由挂单交易市场。
+- 不做多币种兑换。
+- 不做复杂优惠券、竞拍、订金、分账链路。
+- 不做完整人工风控后台，只落表、冻结和基础查询。
+
+## 2. 第一期开工基线
+
+可复用能力：
+
+- `LedgerService` 已经是余额写入唯一入口。
+- `EconomyPolicyService` 已覆盖 user/PAT/OAuth/agent/system actor 的经济写权限。
+- `EconomyIdempotencyService` 已复用 `commerce_idempotency_keys`。
+- `EconomyAuditService` 已有经济审计表。
+- `payment_provider_events`、`risk_cases`、`commerce_fulfillment_records` 已存在。
+- `commerce_deliverables.kind` 已预留 `entitlement`、`community_asset`、`currency`。
+- web/mobile 商品购买入口已会传 `idempotencyKey`。
+
+第二期开工前必须保持：
+
+- `pnpm check:security-pr` 通过。
+- 任何公开 API 的经济写动作都必须声明 actor、resource、action、scope、data class。
+- web/mobile UI copy 走 i18n。
+- API 变更同步 API docs、TS SDK、Python SDK。
+
+## 3. 数据模型计划
+
+建议新增迁移 `0059_community_assets_and_settlement.sql`。
+
+### 3.1 社区资产
+
+新增 `community_asset_definitions`：
+
+- `id`
+- `issuer_kind`: `platform | server | user | shop`
+- `issuer_id`
+- `asset_type`: `badge | gift | coupon | service_ticket | collectible | content_pass | reward`
+- `name`
+- `description`
+- `image_url`
+- `metadata`
+- `giftable`
+- `transferable`
+- `consumable`
+- `revocable`
+- `expires_after_days`
+- `status`: `draft | active | paused | archived`
+- `created_by`
+- `created_at`
+- `updated_at`
+
+新增 `community_asset_grants`：
+
+- `id`
+- `definition_id`
+- `owner_user_id`
+- `source_kind`: `order | gift | tip | admin | campaign | fulfillment`
+- `source_id`
+- `quantity`
+- `remaining_quantity`
+- `status`: `active | locked | consumed | revoked | expired`
+- `expires_at`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+新增 `community_asset_transfer_logs`：
+
+- `id`
+- `definition_id`
+- `grant_id`
+- `from_user_id`
+- `to_user_id`
+- `quantity`
+- `action`: `grant | gift | consume | revoke | expire | unlock`
+- `reference_type`
+- `reference_id`
+- `idempotency_key`
+- `created_at`
+
+约束：
+
+- `community_asset_grants.remaining_quantity >= 0`
+- 同一 `grant_id` 同时只能有一个 active lock。
+- `transfer_logs.idempotency_key` 唯一。
+
+### 3.2 打赏
+
+新增 `economy_tips`：
+
+- `id`
+- `sender_user_id`
+- `recipient_user_id`
+- `amount`
+- `currency_code`
+- `context_kind`: `message | dm_message | user | agent | product | server`
+- `context_id`
+- `message`
+- `platform_fee`
+- `seller_net`
+- `status`: `succeeded | failed | reversed | held`
+- `idempotency_key`
+- `created_at`
+
+唯一约束：
+
+- `(sender_user_id, idempotency_key)`
+
+### 3.3 赠送
+
+新增 `economy_gifts`：
+
+- `id`
+- `sender_user_id`
+- `recipient_user_id`
+- `message`
+- `status`: `succeeded | failed | reversed | held`
+- `idempotency_key`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+新增 `economy_gift_items`：
+
+- `id`
+- `gift_id`
+- `item_kind`: `currency | asset`
+- `asset_grant_id`
+- `asset_definition_id`
+- `quantity`
+- `currency_code`
+- `amount`
+- `status`: `succeeded | failed | reversed`
+
+### 3.4 结算
+
+新增 `settlement_accounts`：
+
+- `id`
+- `owner_kind`: `user | shop | platform`
+- `owner_id`
+- `currency_code`
+- `available_balance`
+- `pending_balance`
+- `held_balance`
+- `created_at`
+- `updated_at`
+
+新增 `settlement_lines`：
+
+- `id`
+- `seller_user_id`
+- `shop_id`
+- `source_type`: `order | tip | gift | adjustment`
+- `source_id`
+- `gross_amount`
+- `platform_fee`
+- `refund_amount`
+- `held_amount`
+- `net_amount`
+- `status`: `pending | available | settled | failed | held | reversed`
+- `available_at`
+- `settled_at`
+- `error_code`
+- `created_at`
+- `updated_at`
+
+## 4. 服务层设计
+
+### 4.1 CommunityAssetService
+
+职责：
+
+- 创建和发布 asset definition。
+- 发放 asset grant。
+- 锁定/解锁 asset grant。
+- 消费、撤销、过期资产。
+- 查询当前用户资产列表和资产详情。
+
+所有写操作必须：
+
+- 调用 `EconomyPolicyService`。
+- 使用 `EconomyIdempotencyService`。
+- 写 `EconomyAuditService`。
+- 写 `community_asset_transfer_logs`。
+
+### 4.2 CommerceFulfillmentHandler 拆分
+
+将 `CommerceFulfillmentService` 中 deliverable 处理拆成 handler registry：
+
+- `PaidFileFulfillmentHandler`
+- `MessageFulfillmentHandler`
+- `EntitlementFulfillmentHandler`
+- `CommunityAssetFulfillmentHandler`
+- `CurrencyFulfillmentHandler`
+
+规则：
+
+- `processJob` 仍负责原子 claim、重试、`commerce_fulfillment_records`。
+- handler 只处理单个 deliverable 的幂等发放。
+- 一个 job 多 deliverable 时，已成功的 deliverable 不重复执行。
+
+### 4.3 TipService
+
+API：
+
+```http
+POST /api/economy/tips
+```
+
+请求：
+
+```json
+{
+  "recipientUserId": "uuid",
+  "amount": 100,
+  "message": "谢谢你的内容",
+  "context": { "kind": "message", "id": "uuid" },
+  "idempotencyKey": "..."
+}
+```
+
+规则：
+
+- 不允许给自己打赏。
+- 金额必须在单笔上下限内。
+- 每日、每对象频率限制在 service 层执行。
+- sender 余额扣款走 `LedgerService.debit`。
+- recipient 收入进入 `SettlementService.createLine`，不直接 credit 到可用余额，除非配置为即时结算。
+- 通知和消息副作用走 outbox 或失败可重试队列，不影响账务事务结果。
+
+### 4.4 GiftService
+
+API：
+
+```http
+POST /api/economy/gifts
+```
+
+请求：
+
+```json
+{
+  "recipientUserId": "uuid",
+  "assets": [{ "assetGrantId": "uuid", "quantity": 1 }],
+  "currencies": [{ "currencyCode": "shrimp_coin", "amount": 100 }],
+  "message": "送你一个徽章",
+  "idempotencyKey": "..."
+}
+```
+
+规则：
+
+- sender 和 recipient 不能相同。
+- recipient 被 `banned` 时拒绝；`economy_restricted` 时进入 held 或拒绝。
+- asset 必须 `giftable=true`，且 grant 归 sender 所有。
+- 赠送事务内先锁资产、扣虾币，再写接收方 grant / settlement line。
+- 任一步失败必须释放锁。
+
+### 4.5 SettlementService
+
+职责：
+
+- 为 order、tip、gift、admin adjustment 创建 settlement line。
+- 计算 gross、fee、net、available_at。
+- 将 pending line 转 available。
+- 将 available line 结算到卖家 wallet。
+- 对 refund/dispute 冻结或 reverse settlement line。
+
+第二期默认策略：
+
+- 单币种 `shrimp_coin`。
+- 平台费配置：`SHADOW_COMMERCE_PLATFORM_FEE_BPS`，默认 0。
+- 结算延迟配置：`SHADOW_COMMERCE_SETTLEMENT_DELAY_DAYS`，开发默认 0，生产可配置。
+
+## 5. API 和 SDK
+
+新增 API：
+
+- `GET /api/economy/assets`
+- `GET /api/economy/assets/:grantId`
+- `POST /api/economy/assets/:grantId/consume`
+- `POST /api/economy/tips`
+- `GET /api/economy/tips`
+- `POST /api/economy/gifts`
+- `GET /api/economy/gifts`
+- `GET /api/economy/settlements`
+- `POST /api/economy/settlements/settle`
+
+管理 API：
+
+- `GET /api/shops/:shopId/assets`
+- `POST /api/shops/:shopId/assets`
+- `POST /api/shops/:shopId/offers/:offerId/deliverables` 支持 `community_asset`、`entitlement`、`currency`。
+
+SDK 同步：
+
+- TS SDK 增加 `listCommunityAssets`、`consumeCommunityAsset`、`sendTip`、`sendGift`、`listSettlements`。
+- Python SDK 增加对应方法。
+- 所有写方法必须要求 `idempotencyKey`。
+
+## 6. Web 和 Mobile
+
+Web：
+
+- 个人资产页：按 asset type/filter 展示。
+- 消息/用户/Buddy 上的打赏入口。
+- 资产赠送弹窗。
+- 创作者商品 deliverable 配置：Badge、数字礼物、服务券。
+- 创作者收入/结算列表。
+
+Mobile：
+
+- 与 web 同步资产页、打赏入口、赠送弹窗。
+- chat commerce card 支持资产发放后的状态展示。
+- 购买完成页展示发放资产和履约状态。
+
+i18n：
+
+- 所有按钮、错误、toast、空状态、状态标签走项目 i18n。
+
+## 7. 测试计划
+
+Unit：
+
+- `CommunityAssetService`：发放、锁定、赠送、消费、撤销。
+- `TipService`：自打赏拒绝、金额限制、频率限制、幂等。
+- `GiftService`：并发赠送同一资产、失败释放锁、接收方状态。
+- `SettlementService`：fee/net 计算、T+N、refund/reverse、失败重试。
+
+Integration：
+
+- 商品购买后发放 community asset + entitlement + paid file。
+- 多 deliverable 部分失败后重试不重复发放成功项。
+- tip 创建 settlement line，结算后 seller wallet 增加。
+- gift 同时转资产和虾币，重复请求不重复扣款。
+- dispute 后冻结未结算收入。
+
+E2E：
+
+- web 和 mobile 都能完成购买资产、打赏、赠送、查看资产。
+- 创作者创建数字礼物商品，买家购买后资产到账，创作者看到收入。
+
+Security：
+
+- PAT/OAuth/agent 没有显式 `economy:*` scope 时不能打赏、赠送、发资产。
+- `economy_restricted` 用户不能转出虾币或资产。
+- 资产/赠送/打赏接口都写审计。
+- `pnpm check:security-pr` 增加 asset grant 直接写 owner/lock 的扫描规则。
+
+## 8. 实施顺序
+
+1. 新增资产和 settlement 迁移/schema。
+2. 实现 `CommunityAssetService` 和 transfer log。
+3. 拆分 fulfillment handler，先接 `community_asset` 和 `entitlement` deliverable。
+4. 实现 `SettlementService`，普通订单和 Offer 购买先写 settlement line。
+5. 实现 `TipService`，接 API、SDK、web/mobile。
+6. 实现 `GiftService`，接 API、SDK、web/mobile。
+7. 创作者商品 deliverable 配置 UI。
+8. 收入/结算查询 UI。
+9. 补安全脚本、迁移检查、Docker Compose 关键测试。
+
+当前实现状态：
+
+- 已完成 schema/migration、资产定义与 grant、tip、gift、settlement line 和 destination-less fulfillment。
+- 已完成 `/api/economy/*` 用户侧 API、`/api/shops/:shopId/assets` 管理 API、资产定义 PATCH、TS/Python SDK 方法。
+- 已在 web/mobile 增加 community economy hooks；Web 已补个人资产页（含 asset type filter）、联系人选择式打赏/赠送弹窗、用户/Profile 与 DM 打赏/赠送入口、资产卡赠送入口、创作者收入/结算列表，以及购买完成后的发放状态与资产入口。创作者发布商品已改为按「服务权益 / 身份徽章 / 数字礼物 / 服务券」配置，自动创建 community asset definition 并绑定默认 offer deliverable。
+- 已补 pending settlement release、unsettled settlement hold/reverse、tip/gift 基础 rate/budget 控制、asset transfer/consume/lock/unlock/revoke/expire policy/audit，以及 asset grant 直接写安全扫描。
+- 已将 gift 货币收入改为 recipient settlement line；付费文件 viewer URL 不再携带 query token，改用 HttpOnly grant cookie 或 `X-Paid-File-Grant-Token` header；续费扣款订单和 entitlement 延期收敛到同一事务边界。
+- 待补：Mobile 页面与弹窗、已结算后的 clawback/人工争议工作台。
+
+## 9. 验收门槛
+
+- 所有第二期新增经济写接口都有 `idempotencyKey`。
+- 所有第二期新增经济写接口都有 policy、audit、rate/budget 控制。
+- 所有余额变化只经过 `LedgerService`。
+- 所有资产 owner/lock 变化只经过 `CommunityAssetService`。
+- Docker Compose 环境中迁移、server typecheck、web/mobile typecheck、核心测试、安全检查通过。

--- a/docs/wiki/en/API-Reference.md
+++ b/docs/wiki/en/API-Reference.md
@@ -302,14 +302,18 @@ Server shops continue to use `/api/servers/:serverId/shop`. Scope-neutral and pe
 | GET    | `/api/commerce/product-picker` | Return sendable Offer-backed `CommerceProductCard` records plus shop groups for `target=channel` or `target=dm`. Channel pickers include personal, server, and Buddy shops visible in the channel. |
 | GET    | `/api/commerce/offers/:offerId/checkout-preview` | Return a server-trusted checkout snapshot for an Offer, including product, seller shop, entitlement resource, paid-file metadata, `viewerState`, `primaryAction`, `displayState`, and `nextAction`. Clients call this before showing buy confirmation or opening already-owned content. Sellers and selling Buddies may pass `viewerUserId` to inspect the current conversation user's state for their own Offer; wallet balance display data is returned only when inspecting yourself. |
 | POST   | `/api/shops/:shopId/offers` | Create a managed shop Offer for a product. Offers define sales surface, seller/Buddy sender, optional price override, and metadata. |
-| POST   | `/api/shops/:shopId/offers/:offerId/deliverables` | Attach a deliverable to an Offer. Phase 4 supports `kind: "paid_file"` with `resourceType: "workspace_file"` and a workspace file id. |
-| POST   | `/api/commerce/offers/:offerId/purchase` | Buy an active Offer with `{ idempotencyKey, skuId?, destinationKind?, destinationId? }`. Orders complete immediately, grant Entitlements immediately, and enqueue fulfillment when a destination is supplied. |
+| GET    | `/api/shops/:shopId/assets` | List community asset definitions for a managed shop. |
+| POST   | `/api/shops/:shopId/assets` | Create a community asset definition for a managed shop. Supported `assetType` values include `badge`, `gift`, `coupon`, `service_ticket`, `collectible`, `content_pass`, and `reward`. |
+| PATCH  | `/api/shops/:shopId/assets/:assetDefinitionId` | Update a managed shop community asset definition, including display fields, transfer flags, metadata, and `status`. |
+| POST   | `/api/shops/:shopId/offers/:offerId/deliverables` | Attach a deliverable to an Offer. Supported `kind` values include `paid_file`, `message`, `external`, `entitlement`, `community_asset`, and `currency`. `community_asset` uses the asset definition id as `resourceId`; `currency` uses `metadata.amount`. |
+| POST   | `/api/commerce/offers/:offerId/purchase` | Buy an active Offer with `{ idempotencyKey, skuId?, destinationKind?, destinationId? }`. Orders complete immediately, grant Entitlements immediately, write seller settlement lines, and enqueue fulfillment. Destination-less fulfillment is supported for asset, entitlement, and currency deliverables. |
 | POST   | `/api/shops/:shopId/products/:productId/purchase` | Compatibility direct purchase path for an entitlement product. New chat flows should buy Offers. |
+| POST   | `/api/servers/:serverId/shop/orders` | Create a server-shop order with `{ idempotencyKey, items: [{ productId, skuId?, quantity }] }`. The idempotency key is required so retries cannot double charge the wallet. |
 | POST   | `/api/messages/:messageId/commerce-cards/:cardId/purchase` | Buy from an Offer card embedded in channel message metadata. |
 | POST   | `/api/dm/messages/:messageId/commerce-cards/:cardId/purchase` | Buy from an Offer card embedded in DM metadata. |
 | GET    | `/api/paid-files/:fileId` | Check paid file metadata and whether the current user has an active entitlement. |
-| POST   | `/api/paid-files/:fileId/open` | Mint a short-lived paid file grant for an entitled user and return a viewer URL. |
-| GET    | `/api/paid-files/:fileId/view/:grantId` | Render a grant-protected paid file. The grant is short-lived and rechecks the entitlement before serving content. |
+| POST   | `/api/paid-files/:fileId/open` | Mint a short-lived paid file grant for an entitled user, set an HttpOnly grant cookie, and return a viewer URL without query-token material. |
+| GET    | `/api/paid-files/:fileId/view/:grantId` | Render a grant-protected paid file. The grant token is accepted from the HttpOnly cookie or `X-Paid-File-Grant-Token` header, and the backing entitlement is rechecked before serving content. |
 | GET    | `/api/entitlements` | List current user's entitlements across shop scopes, enriched with linked shop/product/offer summaries and paid-file metadata when the entitlement targets a paid file. |
 | GET    | `/api/shops/:shopId/entitlements` | Merchant view of entitlements issued by a managed shop. |
 | GET    | `/api/entitlements/:entitlementId/verify` | Verify current entitlement status and provisioning state. |
@@ -321,8 +325,28 @@ Server shops continue to use `/api/servers/:serverId/shop`. Scope-neutral and pe
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
+| POST | `/api/v1/recharge/create-intent` | Create a Stripe PaymentIntent for wallet recharge with `{ tier, idempotencyKey, customAmount?, currency? }`. The idempotency key is required so retries cannot create duplicate payment intents or payment orders. |
 | GET | `/api/wallet/transactions?audience=consumer&direction=all\|income\|expense&limit=&offset=` | List the current user's wallet transactions. `audience=consumer` returns the ToC display view, excludes internal model-proxy reserve/adjustment ledger entries, and applies the `direction` filter on the server. |
 | GET | `/api/wallet/transactions/count?audience=consumer&direction=all\|income\|expense` | Return the pagination count using the same display filters as the list endpoint. |
+
+## Community Economy
+
+All community economy write endpoints require an `idempotencyKey`. User JWT writes are allowed for the authenticated user's own economy actions; PAT, OAuth, and agent actors must carry the matching `economy:*` scope.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/economy/assets` | List the current user's asset grants with their asset definitions. |
+| GET | `/api/economy/assets/:grantId` | Read one owned asset grant. |
+| POST | `/api/economy/assets/:grantId/consume` | Consume an owned consumable asset grant with `{ idempotencyKey }`. |
+| POST | `/api/economy/assets/:grantId/lock` | Lock an owned active asset grant with `{ idempotencyKey }`. |
+| POST | `/api/economy/assets/:grantId/unlock` | Unlock an owned locked asset grant with `{ idempotencyKey }`. |
+| POST | `/api/economy/assets/:grantId/revoke` | Revoke an owned active or locked asset grant with `{ idempotencyKey, reason? }`. |
+| POST | `/api/economy/tips` | Send a tip with `{ recipientUserId, amount, message?, context?, idempotencyKey }`. The sender is debited immediately and the recipient receives a settlement line. |
+| GET | `/api/economy/tips` | List tips received by the current user. |
+| POST | `/api/economy/gifts` | Send assets and/or Shrimp Coins with `{ recipientUserId, assets?, currencies?, message?, idempotencyKey }`. Asset gifts transfer owned giftable grants; currency gifts debit the sender and create a recipient settlement line. |
+| GET | `/api/economy/gifts` | List gifts received by the current user. |
+| GET | `/api/economy/settlements?limit=&offset=` | List settlement lines owed to the current user. |
+| POST | `/api/economy/settlements/settle` | Move currently available settlement lines into the user's wallet through `LedgerService`. |
 
 ## Notifications
 

--- a/docs/wiki/en/SDK-Usage.md
+++ b/docs/wiki/en/SDK-Usage.md
@@ -57,8 +57,9 @@ client.channels.join("channel-uuid")
 | `servers`   | `list`, `create`, `get`, `update`, `delete`, `join`, `leave` |
 | `channels`  | `list`, `create`, `get`, `update`, `delete`, `join`, `leave` |
 | `messages`  | `list`, `send`, `get`, `update`, `delete`     |
-| `commerce`  | `getMyShop`, `getManagedUserShop`, `listCommerceProductCards`, `getCommerceOfferCheckoutPreview`, `purchaseShopProduct`, `purchaseMessageCommerceCard`, `purchaseDmMessageCommerceCard`, `verifyEntitlement`, `getAllEntitlements`, `cancelEntitlement`, push-channel preference helpers |
-| `wallet`    | `getWallet`, `getWalletTransactions({ audience, direction, limit, offset })` |
+| `commerce`  | `getMyShop`, `getManagedUserShop`, `listCommerceProductCards`, `getCommerceOfferCheckoutPreview`, `purchaseShopProduct`, `createShopAssetDefinition`, `updateShopAssetDefinition`, `listShopAssetDefinitions`, `purchaseMessageCommerceCard`, `purchaseDmMessageCommerceCard`, `verifyEntitlement`, `getAllEntitlements`, `cancelEntitlement`, push-channel preference helpers |
+| `community economy` | `listCommunityAssets`, `consumeCommunityAsset`, `lockCommunityAsset`, `unlockCommunityAsset`, `revokeCommunityAsset`, `sendTip`, `listTips`, `sendGift`, `listGifts`, `listSettlements`, `settleAvailableSettlements` |
+| `wallet`    | `getWallet`, `getWalletTransactions({ audience, direction, limit, offset })`, `createRechargeIntent({ tier, idempotencyKey })` |
 | `members`   | `list`, `get`, `kick`, `updateRole`           |
 | `upload`    | `file`                                        |
 
@@ -78,11 +79,44 @@ await authedClient.purchaseShopProduct("shop-uuid", "product-uuid", {
   idempotencyKey: crypto.randomUUID(),
 })
 
+await authedClient.createOrder("server-uuid", {
+  idempotencyKey: crypto.randomUUID(),
+  items: [{ productId: "product-uuid", quantity: 1 }],
+})
+
+await authedClient.createRechargeIntent({
+  tier: "1000",
+  idempotencyKey: crypto.randomUUID(),
+})
+
 await authedClient.updateNotificationChannelPreference({
   kind: "commerce.renewal_failed",
   channel: "mobile_push",
   enabled: true,
 })
+```
+
+### Community Economy
+
+```typescript
+await authedClient.sendTip({
+  recipientUserId: "user-uuid",
+  amount: 100,
+  idempotencyKey: crypto.randomUUID(),
+})
+
+await authedClient.sendGift({
+  recipientUserId: "user-uuid",
+  currencies: [{ currencyCode: "shrimp_coin", amount: 50 }],
+  idempotencyKey: crypto.randomUUID(),
+})
+
+const { assets } = await authedClient.listCommunityAssets()
+if (assets[0]?.definition.consumable) {
+  await authedClient.consumeCommunityAsset(assets[0].grant.id, {
+    idempotencyKey: crypto.randomUUID(),
+  })
+}
 ```
 
 ### Membership And Play Launch
@@ -192,6 +226,12 @@ authed_client.purchase_shop_product(
     "shop-uuid",
     "product-uuid",
     idempotency_key="purchase-idempotency-key",
+)
+
+authed_client.send_tip(
+    recipient_user_id="user-uuid",
+    amount=100,
+    idempotency_key="tip-idempotency-key",
 )
 
 authed_client.update_notification_channel_preference(

--- a/packages/sdk-python/shadowob_sdk/client.py
+++ b/packages/sdk-python/shadowob_sdk/client.py
@@ -1113,6 +1113,19 @@ class ShadowClient:
             f"/api/shops/{shop_id}/offers/{offer_id}/deliverables", json=kwargs
         )
 
+    def list_shop_asset_definitions(self, shop_id: str) -> dict[str, Any]:
+        return self._get(f"/api/shops/{shop_id}/assets")
+
+    def create_shop_asset_definition(self, shop_id: str, **kwargs: Any) -> dict[str, Any]:
+        return self._post(f"/api/shops/{shop_id}/assets", json=kwargs)
+
+    def update_shop_asset_definition(
+        self, shop_id: str, asset_definition_id: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        return self._patch(
+            f"/api/shops/{shop_id}/assets/{asset_definition_id}", json=kwargs
+        )
+
     def purchase_message_commerce_card(
         self,
         message_id: str,
@@ -1242,9 +1255,17 @@ class ShadowClient:
         return self._delete(f"/api/servers/{server_id}/shop/cart/{item_id}")
 
     def create_order(
-        self, server_id: str, **kwargs: Any
+        self,
+        server_id: str,
+        *,
+        idempotency_key: str,
+        items: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
     ) -> dict[str, Any]:
-        return self._post(f"/api/servers/{server_id}/shop/orders", json=kwargs)
+        payload = {"idempotencyKey": idempotency_key, **kwargs}
+        if items is not None:
+            payload["items"] = items
+        return self._post(f"/api/servers/{server_id}/shop/orders", json=payload)
 
     def list_orders(self, server_id: str) -> list[dict[str, Any]]:
         return self._get(f"/api/servers/{server_id}/shop/orders")
@@ -1315,6 +1336,100 @@ class ShadowClient:
         if offset is not None:
             params["offset"] = offset
         return self._get("/api/wallet/transactions", params=params or None)
+
+    # ── Community Economy ──────────────────────────────────────────────
+
+    def list_community_assets(self) -> dict[str, Any]:
+        return self._get("/api/economy/assets")
+
+    def get_community_asset(self, grant_id: str) -> dict[str, Any]:
+        return self._get(f"/api/economy/assets/{grant_id}")
+
+    def consume_community_asset(self, grant_id: str, *, idempotency_key: str) -> dict[str, Any]:
+        return self._post(
+            f"/api/economy/assets/{grant_id}/consume",
+            json={"idempotencyKey": idempotency_key},
+        )
+
+    def lock_community_asset(self, grant_id: str, *, idempotency_key: str) -> dict[str, Any]:
+        return self._post(
+            f"/api/economy/assets/{grant_id}/lock",
+            json={"idempotencyKey": idempotency_key},
+        )
+
+    def unlock_community_asset(self, grant_id: str, *, idempotency_key: str) -> dict[str, Any]:
+        return self._post(
+            f"/api/economy/assets/{grant_id}/unlock",
+            json={"idempotencyKey": idempotency_key},
+        )
+
+    def revoke_community_asset(
+        self, grant_id: str, *, idempotency_key: str, reason: str | None = None
+    ) -> dict[str, Any]:
+        payload = {"idempotencyKey": idempotency_key}
+        if reason is not None:
+            payload["reason"] = reason
+        return self._post(f"/api/economy/assets/{grant_id}/revoke", json=payload)
+
+    def send_tip(
+        self,
+        *,
+        recipient_user_id: str,
+        amount: int,
+        idempotency_key: str,
+        message: str | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "recipientUserId": recipient_user_id,
+            "amount": amount,
+            "idempotencyKey": idempotency_key,
+        }
+        if message is not None:
+            payload["message"] = message
+        if context is not None:
+            payload["context"] = context
+        return self._post("/api/economy/tips", json=payload)
+
+    def list_tips(self) -> dict[str, Any]:
+        return self._get("/api/economy/tips")
+
+    def send_gift(
+        self,
+        *,
+        recipient_user_id: str,
+        idempotency_key: str,
+        assets: list[dict[str, Any]] | None = None,
+        currencies: list[dict[str, Any]] | None = None,
+        message: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "recipientUserId": recipient_user_id,
+            "idempotencyKey": idempotency_key,
+        }
+        if assets is not None:
+            payload["assets"] = assets
+        if currencies is not None:
+            payload["currencies"] = currencies
+        if message is not None:
+            payload["message"] = message
+        return self._post("/api/economy/gifts", json=payload)
+
+    def list_gifts(self) -> dict[str, Any]:
+        return self._get("/api/economy/gifts")
+
+    def list_settlements(
+        self, *, limit: int | None = None, offset: int | None = None
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        return self._get("/api/economy/settlements", params=params or None)
+
+    def settle_available_settlements(self) -> dict[str, Any]:
+        return self._post("/api/economy/settlements/settle")
 
     # ── Cloud SaaS DIY Generation ──────────────────────────────────────
 

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -670,8 +670,13 @@ def test_commerce_picker_purchase_and_entitlement_paths(monkeypatch):
         captured.append(("post", path, json))
         return {"ok": True}
 
+    def fake_patch(path, json=None):
+        captured.append(("patch", path, json))
+        return {"ok": True}
+
     monkeypatch.setattr(client, "_get", fake_get)
     monkeypatch.setattr(client, "_post", fake_post)
+    monkeypatch.setattr(client, "_patch", fake_patch)
 
     assert client.list_commerce_product_cards(
         target="dm",
@@ -683,6 +688,45 @@ def test_commerce_picker_purchase_and_entitlement_paths(monkeypatch):
         "prod-1",
         idempotency_key="idem-1",
     ) == {"ok": True}
+    assert client.create_shop_asset_definition(
+        "shop-1",
+        assetType="badge",
+        name="Founder",
+        status="active",
+    ) == {"ok": True}
+    assert client.update_shop_asset_definition(
+        "shop-1",
+        "asset-def-1",
+        status="paused",
+    ) == {"ok": True}
+    assert client.create_commerce_deliverable(
+        "shop-1",
+        "offer-1",
+        kind="community_asset",
+        resourceType="community_asset_definition",
+        resourceId="asset-def-1",
+    ) == {"ok": True}
+    assert client.lock_community_asset("grant-1", idempotency_key="lock-idem-1") == {"ok": True}
+    assert client.unlock_community_asset("grant-1", idempotency_key="unlock-idem-1") == {"ok": True}
+    assert client.revoke_community_asset(
+        "grant-1", idempotency_key="revoke-idem-1", reason="cleanup"
+    ) == {"ok": True}
+    assert client.send_tip(
+        recipient_user_id="user-2",
+        amount=10,
+        idempotency_key="tip-idem-1",
+    ) == {"ok": True}
+    assert client.send_gift(
+        recipient_user_id="user-2",
+        currencies=[{"currencyCode": "shrimp_coin", "amount": 5}],
+        idempotency_key="gift-idem-1",
+    ) == {"ok": True}
+    assert client.list_settlements(limit=20, offset=40) == {"cards": []}
+    assert client.create_order(
+        "server-1",
+        idempotency_key="order-idem-1",
+        items=[{"productId": "prod-1", "skuId": "sku-1", "quantity": 2}],
+    ) == {"ok": True}
     assert client.cancel_entitlement("ent-1", reason="user_cancelled") == {"ok": True}
     assert captured == [
         ("get", "/api/commerce/product-picker", {"target": "dm", "dmChannelId": "dm-1", "limit": 3}),
@@ -690,6 +734,63 @@ def test_commerce_picker_purchase_and_entitlement_paths(monkeypatch):
             "post",
             "/api/shops/shop-1/products/prod-1/purchase",
             {"idempotencyKey": "idem-1"},
+        ),
+        (
+            "post",
+            "/api/shops/shop-1/assets",
+            {"assetType": "badge", "name": "Founder", "status": "active"},
+        ),
+        (
+            "patch",
+            "/api/shops/shop-1/assets/asset-def-1",
+            {"status": "paused"},
+        ),
+        (
+            "post",
+            "/api/shops/shop-1/offers/offer-1/deliverables",
+            {
+                "kind": "community_asset",
+                "resourceType": "community_asset_definition",
+                "resourceId": "asset-def-1",
+            },
+        ),
+        (
+            "post",
+            "/api/economy/assets/grant-1/lock",
+            {"idempotencyKey": "lock-idem-1"},
+        ),
+        (
+            "post",
+            "/api/economy/assets/grant-1/unlock",
+            {"idempotencyKey": "unlock-idem-1"},
+        ),
+        (
+            "post",
+            "/api/economy/assets/grant-1/revoke",
+            {"idempotencyKey": "revoke-idem-1", "reason": "cleanup"},
+        ),
+        (
+            "post",
+            "/api/economy/tips",
+            {"recipientUserId": "user-2", "amount": 10, "idempotencyKey": "tip-idem-1"},
+        ),
+        (
+            "post",
+            "/api/economy/gifts",
+            {
+                "recipientUserId": "user-2",
+                "idempotencyKey": "gift-idem-1",
+                "currencies": [{"currencyCode": "shrimp_coin", "amount": 5}],
+            },
+        ),
+        ("get", "/api/economy/settlements", {"limit": 20, "offset": 40}),
+        (
+            "post",
+            "/api/servers/server-1/shop/orders",
+            {
+                "idempotencyKey": "order-idem-1",
+                "items": [{"productId": "prod-1", "skuId": "sku-1", "quantity": 2}],
+            },
         ),
         ("post", "/api/entitlements/ent-1/cancel", {"reason": "user_cancelled"}),
     ]

--- a/packages/sdk/__tests__/client.test.ts
+++ b/packages/sdk/__tests__/client.test.ts
@@ -1002,6 +1002,19 @@ describe('ShadowClient', () => {
         viewerUserId: 'user-2',
       })
       await client.purchaseShopProduct('shop-1', 'prod-1', { idempotencyKey: 'idem-1' })
+      await client.createShopAssetDefinition('shop-1', {
+        assetType: 'badge',
+        name: 'Founder',
+        status: 'active',
+      })
+      await client.updateShopAssetDefinition('shop-1', 'asset-def-1', {
+        status: 'paused',
+      })
+      await client.createCommerceDeliverable('shop-1', 'offer-1', {
+        kind: 'community_asset',
+        resourceType: 'community_asset_definition',
+        resourceId: 'asset-def-1',
+      })
 
       expect(mockFetch).toHaveBeenNthCalledWith(
         1,
@@ -1019,6 +1032,183 @@ describe('ShadowClient', () => {
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ idempotencyKey: 'idem-1' }),
+        }),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        4,
+        'https://api.example.com/api/shops/shop-1/assets',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ assetType: 'badge', name: 'Founder', status: 'active' }),
+        }),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        5,
+        'https://api.example.com/api/shops/shop-1/assets/asset-def-1',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ status: 'paused' }),
+        }),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        6,
+        'https://api.example.com/api/shops/shop-1/offers/offer-1/deliverables',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            kind: 'community_asset',
+            resourceType: 'community_asset_definition',
+            resourceId: 'asset-def-1',
+          }),
+        }),
+      )
+    })
+
+    it('should call community economy endpoints with idempotency keys', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ ok: true }),
+      })
+      globalThis.fetch = mockFetch as typeof fetch
+
+      await client.listCommunityAssets()
+      await client.consumeCommunityAsset('grant-1', { idempotencyKey: 'consume-idem-1' })
+      await client.lockCommunityAsset('grant-1', { idempotencyKey: 'lock-idem-1' })
+      await client.unlockCommunityAsset('grant-1', { idempotencyKey: 'unlock-idem-1' })
+      await client.revokeCommunityAsset('grant-1', {
+        idempotencyKey: 'revoke-idem-1',
+        reason: 'cleanup',
+      })
+      await client.sendTip({
+        recipientUserId: 'user-2',
+        amount: 10,
+        idempotencyKey: 'tip-idem-1',
+      })
+      await client.sendGift({
+        recipientUserId: 'user-2',
+        currencies: [{ currencyCode: 'shrimp_coin', amount: 5 }],
+        idempotencyKey: 'gift-idem-1',
+      })
+      await client.listSettlements({ limit: 20, offset: 40 })
+      await client.settleAvailableSettlements()
+
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://api.example.com/api/economy/assets',
+        expect.any(Object),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://api.example.com/api/economy/assets/grant-1/consume',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ idempotencyKey: 'consume-idem-1' }),
+        }),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        3,
+        'https://api.example.com/api/economy/assets/grant-1/lock',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ idempotencyKey: 'lock-idem-1' }),
+        }),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        4,
+        'https://api.example.com/api/economy/assets/grant-1/unlock',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ idempotencyKey: 'unlock-idem-1' }),
+        }),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        5,
+        'https://api.example.com/api/economy/assets/grant-1/revoke',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ idempotencyKey: 'revoke-idem-1', reason: 'cleanup' }),
+        }),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        6,
+        'https://api.example.com/api/economy/tips',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            recipientUserId: 'user-2',
+            amount: 10,
+            idempotencyKey: 'tip-idem-1',
+          }),
+        }),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        7,
+        'https://api.example.com/api/economy/gifts',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            recipientUserId: 'user-2',
+            currencies: [{ currencyCode: 'shrimp_coin', amount: 5 }],
+            idempotencyKey: 'gift-idem-1',
+          }),
+        }),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        8,
+        'https://api.example.com/api/economy/settlements?limit=20&offset=40',
+        expect.any(Object),
+      )
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        9,
+        'https://api.example.com/api/economy/settlements/settle',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    it('should create server shop orders with idempotency', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 'order-1' }),
+      })
+      globalThis.fetch = mockFetch as typeof fetch
+
+      await client.createOrder('server-1', {
+        idempotencyKey: 'order-idem-1',
+        items: [{ productId: 'prod-1', skuId: 'sku-1', quantity: 2 }],
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/api/servers/server-1/shop/orders',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            idempotencyKey: 'order-idem-1',
+            items: [{ productId: 'prod-1', skuId: 'sku-1', quantity: 2 }],
+          }),
+        }),
+      )
+    })
+
+    it('should create recharge intents with idempotency', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            clientSecret: 'secret',
+            paymentIntentId: 'pi_1',
+            orderNo: 'RC-1',
+            amount: { shrimpCoins: 1000, usdCents: 1000 },
+          }),
+      })
+      globalThis.fetch = mockFetch as typeof fetch
+
+      await client.createRechargeIntent({ tier: '1000', idempotencyKey: 'recharge-idem-1' })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/api/v1/recharge/create-intent',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ tier: '1000', idempotencyKey: 'recharge-idem-1' }),
         }),
       )
     })

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -15,12 +15,17 @@ import type {
   ShadowCommerceCheckoutPreview,
   ShadowCommerceProductCard,
   ShadowCommerceProductPickerResponse,
+  ShadowCommunityAsset,
+  ShadowCommunityAssetDefinition,
+  ShadowCommunityAssetGrant,
   ShadowContract,
   ShadowDiyCloudGenerateInput,
   ShadowDiyCloudRun,
   ShadowDiyCloudRunEvent,
   ShadowDiyCloudRunStatus,
   ShadowDmChannel,
+  ShadowEconomyGift,
+  ShadowEconomyTip,
   ShadowEntitlement,
   ShadowEntitlementProvisioning,
   ShadowEntitlementPurchaseResult,
@@ -61,6 +66,7 @@ import type {
   ShadowServerAccess,
   ShadowServerJoinRequestResult,
   ShadowServerJoinRequestStatus,
+  ShadowSettlementLine,
   ShadowShop,
   ShadowSignedMediaUrl,
   ShadowSlashCommand,
@@ -1900,7 +1906,7 @@ export class ShadowClient {
     shopId: string,
     offerId: string,
     data: {
-      kind?: 'paid_file' | 'message' | 'external'
+      kind?: 'paid_file' | 'message' | 'external' | 'entitlement' | 'community_asset' | 'currency'
       resourceType?: string
       resourceId: string
       senderBuddyUserId?: string | null
@@ -1910,6 +1916,36 @@ export class ShadowClient {
   ): Promise<Record<string, unknown>> {
     return this.request(`/api/shops/${shopId}/offers/${offerId}/deliverables`, {
       method: 'POST',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async listShopAssetDefinitions(
+    shopId: string,
+  ): Promise<{ assets: ShadowCommunityAssetDefinition[] }> {
+    return this.request(`/api/shops/${shopId}/assets`)
+  }
+
+  async createShopAssetDefinition(
+    shopId: string,
+    data: Partial<ShadowCommunityAssetDefinition> & {
+      assetType: ShadowCommunityAssetDefinition['assetType']
+      name: string
+    },
+  ): Promise<ShadowCommunityAssetDefinition> {
+    return this.request(`/api/shops/${shopId}/assets`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async updateShopAssetDefinition(
+    shopId: string,
+    assetDefinitionId: string,
+    data: Partial<Omit<ShadowCommunityAssetDefinition, 'id' | 'assetType'>>,
+  ): Promise<ShadowCommunityAssetDefinition> {
+    return this.request(`/api/shops/${shopId}/assets/${assetDefinitionId}`, {
+      method: 'PATCH',
       body: JSON.stringify(data),
     })
   }
@@ -2102,11 +2138,14 @@ export class ShadowClient {
 
   async createOrder(
     serverId: string,
-    data?: { items?: { productId: string; quantity: number }[] },
+    data: {
+      idempotencyKey: string
+      items?: { productId: string; skuId?: string; quantity: number }[]
+    },
   ): Promise<ShadowOrder> {
     return this.request(`/api/servers/${serverId}/shop/orders`, {
       method: 'POST',
-      body: JSON.stringify(data ?? {}),
+      body: JSON.stringify(data),
     })
   }
 
@@ -2180,6 +2219,105 @@ export class ShadowClient {
     if (params?.offset != null) qs.set('offset', String(params.offset))
     const suffix = qs.toString() ? `?${qs}` : ''
     return this.request(`/api/wallet/transactions${suffix}`)
+  }
+
+  // ── Community Economy ────────────────────────────────────────────────
+
+  async listCommunityAssets(): Promise<{ assets: ShadowCommunityAsset[] }> {
+    return this.request('/api/economy/assets')
+  }
+
+  async getCommunityAsset(grantId: string): Promise<ShadowCommunityAsset> {
+    return this.request(`/api/economy/assets/${grantId}`)
+  }
+
+  async consumeCommunityAsset(
+    grantId: string,
+    data: { idempotencyKey: string },
+  ): Promise<{ grant: ShadowCommunityAssetGrant }> {
+    return this.request(`/api/economy/assets/${grantId}/consume`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async lockCommunityAsset(
+    grantId: string,
+    data: { idempotencyKey: string },
+  ): Promise<{ grant: ShadowCommunityAssetGrant }> {
+    return this.request(`/api/economy/assets/${grantId}/lock`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async unlockCommunityAsset(
+    grantId: string,
+    data: { idempotencyKey: string },
+  ): Promise<{ grant: ShadowCommunityAssetGrant }> {
+    return this.request(`/api/economy/assets/${grantId}/unlock`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async revokeCommunityAsset(
+    grantId: string,
+    data: { idempotencyKey: string; reason?: string },
+  ): Promise<{ grant: ShadowCommunityAssetGrant }> {
+    return this.request(`/api/economy/assets/${grantId}/revoke`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async sendTip(data: {
+    recipientUserId: string
+    amount: number
+    message?: string
+    context?: { kind: string; id: string }
+    idempotencyKey: string
+  }): Promise<{ tip: ShadowEconomyTip }> {
+    return this.request('/api/economy/tips', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async listTips(): Promise<{ tips: ShadowEconomyTip[] }> {
+    return this.request('/api/economy/tips')
+  }
+
+  async sendGift(data: {
+    recipientUserId: string
+    assets?: Array<{ assetGrantId: string; quantity?: number }>
+    currencies?: Array<{ currencyCode: 'shrimp_coin'; amount: number }>
+    message?: string
+    idempotencyKey: string
+  }): Promise<{ gift: ShadowEconomyGift }> {
+    return this.request('/api/economy/gifts', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async listGifts(): Promise<{ gifts: ShadowEconomyGift[] }> {
+    return this.request('/api/economy/gifts')
+  }
+
+  async listSettlements(params?: {
+    limit?: number
+    offset?: number
+  }): Promise<{ settlements: ShadowSettlementLine[] }> {
+    const qs = new URLSearchParams()
+    if (params?.limit != null) qs.set('limit', String(params.limit))
+    if (params?.offset != null) qs.set('offset', String(params.offset))
+    const suffix = qs.toString() ? `?${qs}` : ''
+    return this.request(`/api/economy/settlements${suffix}`)
+  }
+
+  async settleAvailableSettlements(): Promise<{ settlements: ShadowSettlementLine[] }> {
+    return this.request('/api/economy/settlements/settle', { method: 'POST' })
   }
 
   // ── Cloud SaaS DIY Generation ───────────────────────────────────────
@@ -2304,6 +2442,7 @@ export class ShadowClient {
 
   async createRechargeIntent(params: {
     tier: '1000' | '3000' | '5000' | 'custom'
+    idempotencyKey: string
     customAmount?: number
     currency?: string
   }): Promise<ShadowRechargeIntent> {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -709,6 +709,94 @@ export interface ShadowShop {
   isEnabled: boolean
 }
 
+export type ShadowCommunityAssetType =
+  | 'badge'
+  | 'gift'
+  | 'coupon'
+  | 'service_ticket'
+  | 'collectible'
+  | 'content_pass'
+  | 'reward'
+
+export interface ShadowCommunityAssetDefinition {
+  id: string
+  issuerKind: 'platform' | 'server' | 'user' | 'shop'
+  issuerId?: string | null
+  shopId?: string | null
+  assetType: ShadowCommunityAssetType
+  name: string
+  description?: string | null
+  imageUrl?: string | null
+  giftable: boolean
+  transferable: boolean
+  consumable: boolean
+  revocable: boolean
+  expiresAfterDays?: number | null
+  status: 'draft' | 'active' | 'paused' | 'archived'
+  metadata?: Record<string, unknown> | null
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface ShadowCommunityAssetGrant {
+  id: string
+  definitionId: string
+  ownerUserId: string
+  sourceKind: string
+  sourceId?: string | null
+  quantity: number
+  remainingQuantity: number
+  status: 'active' | 'locked' | 'consumed' | 'revoked' | 'expired'
+  expiresAt?: string | null
+  metadata?: Record<string, unknown> | null
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface ShadowCommunityAsset {
+  grant: ShadowCommunityAssetGrant
+  definition: ShadowCommunityAssetDefinition
+}
+
+export interface ShadowEconomyTip {
+  id: string
+  senderUserId: string
+  recipientUserId: string
+  amount: number
+  sellerNet: number
+  status: 'succeeded' | 'failed' | 'reversed' | 'held'
+  contextKind?: string | null
+  contextId?: string | null
+  message?: string | null
+  createdAt?: string
+}
+
+export interface ShadowEconomyGift {
+  id: string
+  senderUserId: string
+  recipientUserId: string
+  status: 'succeeded' | 'failed' | 'reversed' | 'held'
+  message?: string | null
+  metadata?: Record<string, unknown> | null
+  createdAt?: string
+}
+
+export interface ShadowSettlementLine {
+  id: string
+  sellerUserId: string
+  shopId?: string | null
+  sourceType: 'order' | 'tip' | 'gift' | 'adjustment'
+  sourceId: string
+  grossAmount: number
+  platformFee: number
+  netAmount: number
+  status: 'pending' | 'available' | 'settled' | 'failed' | 'held' | 'reversed'
+  availableAt?: string | null
+  settledAt?: string | null
+  createdAt?: string
+  updatedAt?: string
+}
+
 export interface ShadowCommerceProductCard {
   id: string
   kind: 'offer' | 'product'
@@ -920,7 +1008,7 @@ export interface ShadowOrder {
   status: string
   totalAmount: number
   currency: string
-  items: { productId: string; quantity: number; price: number }[]
+  items: { productId: string; skuId?: string | null; quantity: number; price: number }[]
   createdAt: string
 }
 

--- a/scripts/check-security-pr.mjs
+++ b/scripts/check-security-pr.mjs
@@ -64,16 +64,44 @@ function checkWalletCreditBoundary() {
     )
   }
   for (const relPath of walk('apps/server/src', /\.(ts|tsx)$/)) {
-    if (
-      relPath === 'apps/server/src/dao/wallet.dao.ts' ||
-      relPath === 'apps/server/src/services/ledger.service.ts'
-    ) {
+    if (relPath === 'apps/server/src/services/ledger.service.ts') {
       continue
     }
     assertNoRegex(
       relPath,
       /walletDao\.(?:credit|debit|updateBalance)\(/g,
       'wallet balance mutations must go through LedgerService',
+    )
+    assertNoRegex(
+      relPath,
+      /db\s*\.\s*update\(\s*wallets\s*\)|tx\s*\.\s*update\(\s*wallets\s*\)/g,
+      'direct wallets table updates must go through LedgerService',
+    )
+    assertNoRegex(
+      relPath,
+      /\$\{\s*wallets\.balance\s*\}\s*[+-]/g,
+      'wallet balance arithmetic must be isolated to LedgerService',
+    )
+  }
+}
+
+function checkCommunityAssetGrantBoundary() {
+  for (const relPath of walk('apps/server/src', /\.(ts|tsx)$/)) {
+    if (
+      relPath === 'apps/server/src/services/community-asset.service.ts' ||
+      relPath.startsWith('apps/server/src/db/schema/')
+    ) {
+      continue
+    }
+    assertNoRegex(
+      relPath,
+      /(?:db|tx)\s*\.\s*(?:insert|update|delete)\(\s*communityAssetGrants\s*\)/g,
+      'community asset grant mutations must go through CommunityAssetService',
+    )
+    assertNoRegex(
+      relPath,
+      /\$\{\s*communityAssetGrants\.(?:ownerUserId|status|remainingQuantity)\s*\}\s*[+-]/g,
+      'community asset owner/status/quantity arithmetic must stay inside CommunityAssetService',
     )
   }
 }
@@ -145,6 +173,7 @@ function checkSecurityGuardsStillWired() {
 function main() {
   checkTypedJwtVerification()
   checkWalletCreditBoundary()
+  checkCommunityAssetGrantBoundary()
   checkMediaBoundary()
   checkCloudRuntimeSecrets()
   checkSecurityGuardsStillWired()


### PR DESCRIPTION
Implements community economy gifting/settlement flow end-to-end with new server services and handlers, wallet/recharge updates, web/mobile UI, and SDK/doc sync.\n\nIncludes:\n- Economy domain models, migrations, policy and idempotency safeguards\n- Gift and tip/settlement service implementations\n- Commerce and message path updates\n- UI and i18n updates on web/mobile\n- TS and Python SDK type sync\n- New security, integration, and e2e tests