### PR TITLE
[codex] ci build production images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,15 @@ MINIO_ACCESS_KEY=
 # MinIO secret key (min 8 chars)
 MINIO_SECRET_KEY=
 
+# ── Production images (used by docker-compose.prod.yml) ──────────────────
+
+# CI publishes these images via .github/workflows/publish-prod-images.yml.
+# Use SHADOW_IMAGE_TAG=sha-<git-sha-prefix> for an immutable deploy/rollback,
+# or leave it as latest to track the newest verified main build.
+SHADOW_IMAGE_REGISTRY=ghcr.io
+SHADOW_IMAGE_NAMESPACE=buggyblues
+SHADOW_IMAGE_TAG=latest
+
 # ── Server ────────────────────────────────────────────────────────────────
 
 # Disable all server-side request rate limits for local debugging.

--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -1,0 +1,108 @@
+name: publish-prod-images
+
+on:
+  workflow_run:
+    workflows: [post-merge-validation]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Optional extra image tag to publish
+        required: false
+        default: ''
+      web_api_base:
+        description: Optional public web API origin, without /api. Empty uses same-origin /api.
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-prod-images-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build and push ${{ matrix.name }} image
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: server
+            image: shadow-server
+            dockerfile: apps/server/Dockerfile
+          - name: web
+            image: shadow-web
+            dockerfile: apps/web/Dockerfile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image tags
+        id: image
+        env:
+          EXTRA_TAG: ${{ inputs.tag || '' }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          IMAGE_NAME: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          image="${REGISTRY}/${owner}/${IMAGE_NAME}"
+          short_sha="$(printf '%s' "$HEAD_SHA" | cut -c1-12)"
+          branch_tag="$(printf '%s' "$HEAD_BRANCH" | tr '/[:upper:]' '-[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+|-+$//g')"
+
+          {
+            echo "ref=${image}:sha-${short_sha}"
+            echo "tags<<EOF"
+            echo "${image}:sha-${short_sha}"
+            if [ -n "$branch_tag" ]; then
+              echo "${image}:${branch_tag}"
+            fi
+            if [ "$HEAD_BRANCH" = "main" ]; then
+              echo "${image}:latest"
+            fi
+            if [ -n "$EXTRA_TAG" ]; then
+              echo "${image}:${EXTRA_TAG}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.image.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event.workflow_run.head_sha || github.sha }}
+          build-args: |
+            VITE_API_BASE=${{ inputs.web_api_base || vars.PROD_WEB_API_BASE || '' }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+
+      - name: Print deployment tag
+        run: echo "Published ${{ steps.image.outputs.ref }}"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,11 @@
-# Production docker-compose for public deployment
-# Usage: docker-compose -f docker-compose.prod.yml up -d
+# Production docker-compose for public deployment.
+#
+# Runtime hosts should pull CI-built application images instead of building
+# from source. The app image defaults match .github/workflows/publish-prod-images.yml.
+#
+# Usage:
+#   docker compose -f docker-compose.prod.yml pull server web
+#   docker compose -f docker-compose.prod.yml up -d
 #
 # ⚠️  All sensitive values MUST be provided via a .env file.
 #     See .env.example for required variables.
@@ -47,9 +53,8 @@ services:
       retries: 5
 
   server:
-    build:
-      context: .
-      dockerfile: apps/server/Dockerfile
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-server:${SHADOW_IMAGE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     ports:
       - '3002:3002'
@@ -93,11 +98,8 @@ services:
         condition: service_healthy
 
   web:
-    build:
-      context: .
-      dockerfile: apps/web/Dockerfile
-      args:
-        VITE_API_BASE: ${OAUTH_BASE_URL:?OAUTH_BASE_URL is required}/api
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-web:${SHADOW_IMAGE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     ports:
       - '3000:3000'

--- a/docs/deployment/ci-built-images.md
+++ b/docs/deployment/ci-built-images.md
@@ -1,0 +1,49 @@
+# CI-built Docker images
+
+Production hosts should not build the application images during deployment.
+GitHub Actions builds and pushes these images after `post-merge-validation`
+passes on `main`:
+
+- `ghcr.io/buggyblues/shadow-server`
+- `ghcr.io/buggyblues/shadow-web`
+
+The workflow publishes three useful tag styles:
+
+- `latest` for the newest verified `main` build
+- `main` for the newest verified `main` build
+- `sha-<12-char-sha>` for immutable deploys and rollback
+
+## GitHub setup
+
+1. Ensure GitHub Actions can write packages for the repository.
+2. If the GHCR packages are private, log in once on the server:
+
+```bash
+docker login ghcr.io
+```
+
+3. Optional: set the repository variable `PROD_WEB_API_BASE` if the web app
+   should call an API origin that differs from the web origin. Do not include
+   `/api`; use a value like `https://shadowob.com`. Leave it empty when the
+   web container proxies same-origin `/api` to the server container.
+
+## Server deploy
+
+Keep secrets in the server-side `.env` file. Choose the image tag there:
+
+```dotenv
+SHADOW_IMAGE_REGISTRY=ghcr.io
+SHADOW_IMAGE_NAMESPACE=buggyblues
+SHADOW_IMAGE_TAG=sha-0123456789ab
+```
+
+Then deploy without building on the server:
+
+```bash
+docker compose -f docker-compose.prod.yml pull server web
+docker compose -f docker-compose.prod.yml up -d --remove-orphans
+docker image prune -f
+```
+
+Rollback is just changing `SHADOW_IMAGE_TAG` back to the previous
+`sha-<12-char-sha>` tag and running the same commands again.


### PR DESCRIPTION
## Summary

- publish production server and web images from GitHub Actions after post-merge validation passes
- switch production compose to pull CI-built images instead of building on the runtime host
- document immutable image tag deploys and rollback

## Validation

- docker compose -f docker-compose.prod.yml config --quiet with required production placeholders
- docker compose -f docker-compose.prod.yml config shows GHCR images and no build entries
- ruby YAML parser for .github/workflows/publish-prod-images.yml
- git diff --check
