### PR TITLE
[codex] fix production env passthrough

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,6 +55,9 @@ services:
   server:
     image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-server:${SHADOW_IMAGE_TAG:-latest}
     pull_policy: always
+    env_file:
+      - path: .env
+        required: false
     restart: unless-stopped
     ports:
       - '3002:3002'


### PR DESCRIPTION
## Summary

- load the production .env file into the server container
- fixes missing runtime envs such as Google/GitHub OAuth and email provider settings after the CI-image compose split

## Validation

- git diff --check

## Hotfix note

This is a compose-only change and does not require rebuilding application images.
