### PR TITLE
[codex] allow visitors to create servers

### DIFF
--- a/apps/server/__tests__/membership-service.test.ts
+++ b/apps/server/__tests__/membership-service.test.ts
@@ -33,7 +33,7 @@ describe('MembershipService', () => {
     expect(result.level).toBe(0)
     expect(result.tier.id).toBe('visitor')
     expect(result.isMember).toBe(false)
-    expect(result.capabilities).toEqual([])
+    expect(result.capabilities).toEqual(['server:create'])
   })
 
   it('grants member capabilities after invite redemption', async () => {
@@ -61,5 +61,12 @@ describe('MembershipService', () => {
       status: 403,
       code: 'INVITE_REQUIRED',
     })
+  })
+
+  it('allows visitors to create servers without an invite code', async () => {
+    const result = await service.requireMember('user-1', 'server:create')
+
+    expect(result.status).toBe('visitor')
+    expect(result.capabilities).toContain('server:create')
   })
 })

--- a/apps/server/src/services/membership.service.ts
+++ b/apps/server/src/services/membership.service.ts
@@ -28,6 +28,8 @@ export interface MembershipSnapshot {
   capabilities: MembershipCapability[]
 }
 
+const BASE_AUTHENTICATED_CAPABILITIES: MembershipCapability[] = ['server:create']
+
 export const MEMBERSHIP_TIERS = {
   visitor: {
     id: 'visitor',
@@ -39,13 +41,7 @@ export const MEMBERSHIP_TIERS = {
     id: 'member',
     level: 10,
     label: 'Member',
-    capabilities: [
-      'cloud:deploy',
-      'cloud:diy_generate',
-      'server:create',
-      'invite:create',
-      'oauth_app:create',
-    ],
+    capabilities: ['cloud:deploy', 'cloud:diy_generate', 'invite:create', 'oauth_app:create'],
   },
 } satisfies Record<string, MembershipTier>
 
@@ -74,7 +70,7 @@ export class MembershipService {
       isMember,
       memberSince: usedInvite?.usedAt ?? (user.isAdmin ? user.createdAt : null),
       inviteCodeId: usedInvite?.id ?? null,
-      capabilities: [...tier.capabilities],
+      capabilities: [...new Set([...BASE_AUTHENTICATED_CAPABILITIES, ...tier.capabilities])],
     }
   }
 


### PR DESCRIPTION
## Summary

- make server:create a base authenticated capability instead of an invite-gated member capability
- keeps cloud:deploy and cloud:diy_generate behind invite membership
- adds coverage for visitor server creation through MembershipService

## Validation

- Biome format on changed files
- git diff --check
- attempted focused Vitest test, but this worktree has no node_modules and Vitest could not resolve vitest/config

## Hotfix note

This fixes INVITE_REQUIRED responses when ordinary users create servers.
