### PR TITLE
[codex] add admin to production compose

### DIFF
--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -42,6 +42,9 @@ jobs:
           - name: web
             image: shadow-web
             dockerfile: apps/web/Dockerfile
+          - name: admin
+            image: shadow-admin
+            dockerfile: apps/admin/Dockerfile
 
     steps:
       - name: Checkout

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,7 @@
 # from source. The app image defaults match .github/workflows/publish-prod-images.yml.
 #
 # Usage:
-#   docker compose -f docker-compose.prod.yml pull server web
+#   docker compose -f docker-compose.prod.yml pull server web admin
 #   docker compose -f docker-compose.prod.yml up -d
 #
 # ⚠️  All sensitive values MUST be provided via a .env file.
@@ -107,6 +107,15 @@ services:
     restart: unless-stopped
     ports:
       - '3000:3000'
+    depends_on:
+      - server
+
+  admin:
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-admin:${SHADOW_IMAGE_TAG:-latest}
+    pull_policy: always
+    restart: unless-stopped
+    ports:
+      - '3001:3001'
     depends_on:
       - server
 

--- a/docs/deployment/ci-built-images.md
+++ b/docs/deployment/ci-built-images.md
@@ -6,6 +6,7 @@ passes on `main`:
 
 - `ghcr.io/buggyblues/shadow-server`
 - `ghcr.io/buggyblues/shadow-web`
+- `ghcr.io/buggyblues/shadow-admin`
 
 The workflow publishes three useful tag styles:
 
@@ -40,7 +41,7 @@ SHADOW_IMAGE_TAG=sha-0123456789ab
 Then deploy without building on the server:
 
 ```bash
-docker compose -f docker-compose.prod.yml pull server web
+docker compose -f docker-compose.prod.yml pull server web admin
 docker compose -f docker-compose.prod.yml up -d --remove-orphans
 docker image prune -f
 ```


### PR DESCRIPTION
## Summary

- add the admin service to production docker-compose on port 3001
- publish a CI-built ghcr.io/buggyblues/shadow-admin image with the existing production image workflow
- update deployment docs to pull the admin image

## Validation

- docker compose -f docker-compose.prod.yml config --quiet with required production placeholders
- Ruby YAML parser for .github/workflows/publish-prod-images.yml
- git diff --check

## Deploy note

After merge and image publish, deploy with docker compose -f docker-compose.prod.yml pull server web admin && docker compose -f docker-compose.prod.yml up -d --remove-orphans.
