### PR TITLE
fix: preserve runner slash command priority

### DIFF
--- a/apps/cloud/images/RUNNERS.md
+++ b/apps/cloud/images/RUNNERS.md
@@ -63,7 +63,10 @@ ShadowOB assets are installed in two explicit places:
 - Slash command index: `/etc/shadowob/slash-commands.json` exists for every
   runner. Each runner owns its own command catalog under
   `apps/cloud/src/runtimes/slash-commands/`; common packaging only serializes
-  the selected runner's catalog.
+  the selected runner's catalog. Runtime/plugin slash command artifacts are
+  additive sources. The runner catalog is loaded first, plugin artifacts are
+  loaded afterward in runtime-extension order, and duplicate command names use
+  first-wins semantics rather than overwriting an earlier command.
 
 ## Slash command catalogs
 

--- a/apps/cloud/images/openclaw-runner/RUNNER.md
+++ b/apps/cloud/images/openclaw-runner/RUNNER.md
@@ -96,6 +96,10 @@ Keep ShadowOB integration as an OpenClaw plugin concern:
   `/etc/shadowob/slash-commands.json` with `dispatch=passthrough`, registered
   with Shadow for the input picker, and then forwarded to OpenClaw as the
   original standalone `/...` message instead of being rewritten into a prompt
+- plugin-provided slash command indexes are loaded as additional runtime
+  artifacts after the official OpenClaw catalog. Duplicate command names keep
+  the first loaded definition, so plugin commands do not replace OpenClaw's
+  official commands.
 
 The OpenClaw command catalog is owned by
 `apps/cloud/src/runtimes/slash-commands/openclaw.ts`. The researched official

--- a/apps/cloud/images/openclaw-runner/entrypoint.mjs
+++ b/apps/cloud/images/openclaw-runner/entrypoint.mjs
@@ -32,6 +32,7 @@ const CONFIG_MOUNT =
 const EXTENSIONS_DIR = '/app/extensions'
 const RUNTIME_FILES_PATH = join(CONFIG_MOUNT, 'runtime-files.json')
 const RUNTIME_EXTENSIONS_PATH = join(CONFIG_MOUNT, 'runtime-extensions.json')
+const DEFAULT_SHADOW_SLASH_COMMANDS_PATH = '/etc/shadowob/slash-commands.json'
 const RUNTIME_CONFIG_DIR = process.env.OPENCLAW_RUNTIME_CONFIG_DIR || '/tmp/openclaw/config'
 const RUNTIME_CONFIG_PATH = join(RUNTIME_CONFIG_DIR, 'openclaw.json')
 const OPENCLAW_PACKAGE_DIR = '/app/node_modules/openclaw'
@@ -197,16 +198,16 @@ function runtimeArtifactPath(runtimeExtensions, kind) {
 }
 
 function applyRuntimeArtifacts(runtimeExtensions) {
+  if (!process.env.SHADOW_SLASH_COMMANDS_PATH && existsSync(DEFAULT_SHADOW_SLASH_COMMANDS_PATH)) {
+    process.env.SHADOW_SLASH_COMMANDS_PATH = DEFAULT_SHADOW_SLASH_COMMANDS_PATH
+    console.log(`[entrypoint] Slash command index: ${DEFAULT_SHADOW_SLASH_COMMANDS_PATH}`)
+  }
+
   const slashIndexPath =
     runtimeArtifactPath(runtimeExtensions, 'shadow.slashCommands') ??
     runtimeExtensions?.slashCommands?.indexPath
   if (typeof slashIndexPath === 'string' && slashIndexPath.trim()) {
-    if (!process.env.SHADOW_SLASH_COMMANDS_PATH) {
-      process.env.SHADOW_SLASH_COMMANDS_PATH = slashIndexPath.trim()
-      console.log(`[entrypoint] Slash command index: ${slashIndexPath.trim()}`)
-    } else {
-      console.log(`[entrypoint] Additional slash command index: ${slashIndexPath.trim()}`)
-    }
+    console.log(`[entrypoint] Additional slash command index: ${slashIndexPath.trim()}`)
   }
 }
 

--- a/packages/openclaw-shadowob/__tests__/slash-commands.test.ts
+++ b/packages/openclaw-shadowob/__tests__/slash-commands.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../src/monitor/slash-commands.js'
 
 const originalShadowSlashCommandsPath = process.env.SHADOW_SLASH_COMMANDS_PATH
+const originalDefaultSlashCommandsPath = process.env.SHADOW_DEFAULT_SLASH_COMMANDS_PATH
 const originalRuntimeExtensionsPath = process.env.SHADOW_RUNTIME_EXTENSIONS_PATH
 const originalOpenClawRuntimeExtensionsPath = process.env.OPENCLAW_RUNTIME_EXTENSIONS_PATH
 const tempDirs: string[] = []
@@ -17,6 +18,12 @@ afterEach(async () => {
 
   if (originalShadowSlashCommandsPath === undefined) delete process.env.SHADOW_SLASH_COMMANDS_PATH
   else process.env.SHADOW_SLASH_COMMANDS_PATH = originalShadowSlashCommandsPath
+
+  if (originalDefaultSlashCommandsPath === undefined) {
+    delete process.env.SHADOW_DEFAULT_SLASH_COMMANDS_PATH
+  } else {
+    process.env.SHADOW_DEFAULT_SLASH_COMMANDS_PATH = originalDefaultSlashCommandsPath
+  }
 
   if (originalRuntimeExtensionsPath === undefined) delete process.env.SHADOW_RUNTIME_EXTENSIONS_PATH
   else process.env.SHADOW_RUNTIME_EXTENSIONS_PATH = originalRuntimeExtensionsPath
@@ -61,6 +68,7 @@ describe('OpenClaw slash command discovery', () => {
       }),
     )
 
+    process.env.SHADOW_DEFAULT_SLASH_COMMANDS_PATH = join(dir, 'missing-default-slash.json')
     delete process.env.SHADOW_SLASH_COMMANDS_PATH
     process.env.SHADOW_RUNTIME_EXTENSIONS_PATH = manifestPath
     delete process.env.OPENCLAW_RUNTIME_EXTENSIONS_PATH
@@ -102,6 +110,7 @@ describe('OpenClaw slash command discovery', () => {
       }),
     )
 
+    process.env.SHADOW_DEFAULT_SLASH_COMMANDS_PATH = join(dir, 'missing-default-slash.json')
     process.env.SHADOW_SLASH_COMMANDS_PATH = localCommandsPath
     process.env.SHADOW_RUNTIME_EXTENSIONS_PATH = manifestPath
     delete process.env.OPENCLAW_RUNTIME_EXTENSIONS_PATH
@@ -113,6 +122,65 @@ describe('OpenClaw slash command discovery', () => {
       ['local-only', 'Local only'],
       ['official-only', 'Official only'],
     ])
+  })
+
+  it('keeps runner commands ahead of plugin slash command artifacts', async () => {
+    const dir = await createTempDir()
+    const runnerCommandsPath = join(dir, 'runner-slash.json')
+    const agentPackCommandsPath = join(dir, 'agent-pack-slash.json')
+    const claudePluginCommandsPath = join(dir, 'claude-plugin-slash.json')
+    const manifestPath = join(dir, 'runtime-extensions.json')
+    await writeFile(
+      runnerCommandsPath,
+      JSON.stringify([
+        { name: 'deploy', description: 'Runner deploy command' },
+        { name: 'model', description: 'Runner model command' },
+      ]),
+    )
+    await writeFile(
+      agentPackCommandsPath,
+      JSON.stringify([
+        { name: 'deploy', description: 'Agent pack duplicate deploy' },
+        { name: 'office-hours', description: 'Agent pack office hours' },
+      ]),
+    )
+    await writeFile(
+      claudePluginCommandsPath,
+      JSON.stringify([
+        { name: 'office-hours', description: 'Claude plugin duplicate office hours' },
+        { name: 'brainstorm', description: 'Claude plugin brainstorm' },
+      ]),
+    )
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        artifacts: [
+          { kind: 'shadow.slashCommands', path: agentPackCommandsPath },
+          { kind: 'shadow.slashCommands', path: claudePluginCommandsPath },
+        ],
+      }),
+    )
+
+    process.env.SHADOW_DEFAULT_SLASH_COMMANDS_PATH = runnerCommandsPath
+    delete process.env.SHADOW_SLASH_COMMANDS_PATH
+    process.env.SHADOW_RUNTIME_EXTENSIONS_PATH = manifestPath
+    delete process.env.OPENCLAW_RUNTIME_EXTENSIONS_PATH
+
+    const log = vi.fn()
+    const commands = await loadShadowSlashCommands({ log, error: vi.fn() })
+
+    expect(commands.map((command) => [command.name, command.description])).toEqual([
+      ['deploy', 'Runner deploy command'],
+      ['model', 'Runner model command'],
+      ['office-hours', 'Agent pack office hours'],
+      ['brainstorm', 'Claude plugin brainstorm'],
+    ])
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('Ignoring duplicate command /deploy from'),
+    )
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('Ignoring duplicate command /office-hours from'),
+    )
   })
 
   it('does not publish internal dispatch metadata to Shadow', async () => {

--- a/packages/openclaw-shadowob/src/monitor/slash-commands.ts
+++ b/packages/openclaw-shadowob/src/monitor/slash-commands.ts
@@ -3,6 +3,7 @@ import type { ShadowClient } from '@shadowob/sdk'
 import type { AgentChainMetadata, ShadowRuntimeLogger, ShadowSlashCommand } from '../types.js'
 
 const SLASH_COMMAND_RE = /^\/([a-zA-Z][a-zA-Z0-9._-]{0,63})(?:\s+([\s\S]*))?$/
+const DEFAULT_SLASH_COMMANDS_PATH = '/etc/shadowob/slash-commands.json'
 
 export type ShadowSlashCommandMatch = {
   command: ShadowSlashCommand
@@ -194,10 +195,31 @@ async function loadSlashCommandFile(indexPath: string, runtime: ShadowRuntimeLog
   }
 }
 
+function logDuplicateSlashCommands(
+  sources: Array<{ path: string; commands: ShadowSlashCommand[] }>,
+  runtime: ShadowRuntimeLogger,
+) {
+  const owners = new Map<string, string>()
+  for (const source of sources) {
+    for (const command of source.commands) {
+      const key = command.name.toLowerCase()
+      const existingPath = owners.get(key)
+      if (existingPath) {
+        runtime.log?.(
+          `[slash] Ignoring duplicate command /${command.name} from ${source.path}; already defined by ${existingPath}`,
+        )
+        continue
+      }
+      owners.set(key, source.path)
+    }
+  }
+}
+
 async function runtimeExtensionSlashCommandPaths(runtime: ShadowRuntimeLogger) {
   const candidates = [
     process.env.SHADOW_RUNTIME_EXTENSIONS_PATH,
     process.env.OPENCLAW_RUNTIME_EXTENSIONS_PATH,
+    '/etc/shadowob/runtime-extensions.json',
     '/etc/openclaw/runtime-extensions.json',
   ].filter((path): path is string => Boolean(path))
   const paths: string[] = []
@@ -229,16 +251,28 @@ export async function loadLocalSlashCommands(runtime: ShadowRuntimeLogger) {
 }
 
 export async function loadShadowSlashCommands(runtime: ShadowRuntimeLogger) {
+  const defaultIndexPath =
+    process.env.SHADOW_DEFAULT_SLASH_COMMANDS_PATH || DEFAULT_SLASH_COMMANDS_PATH
   const paths = [
+    defaultIndexPath,
     process.env.SHADOW_SLASH_COMMANDS_PATH,
     ...(await runtimeExtensionSlashCommandPaths(runtime)),
   ].filter((path): path is string => Boolean(path))
   const seenPaths = [...new Set(paths)]
-  const loaded = await Promise.all(seenPaths.map((path) => loadSlashCommandFile(path, runtime)))
-  const merged = normalizeShadowSlashCommands(loaded.flat())
-  if (seenPaths.length > 1) {
+  const existingPaths = (
+    await Promise.all(seenPaths.map(async (path) => ((await fileExists(path)) ? path : null)))
+  ).filter((path): path is string => Boolean(path))
+  const sources = await Promise.all(
+    existingPaths.map(async (path) => ({
+      path,
+      commands: await loadSlashCommandFile(path, runtime),
+    })),
+  )
+  logDuplicateSlashCommands(sources, runtime)
+  const merged = normalizeShadowSlashCommands(sources.flatMap((source) => source.commands))
+  if (existingPaths.length > 1) {
     runtime.log?.(
-      `[slash] Merged ${merged.length} slash command(s) from ${seenPaths.length} source(s)`,
+      `[slash] Merged ${merged.length} slash command(s) from ${existingPaths.length} source(s)`,
     )
   }
   return merged


### PR DESCRIPTION
## Summary
- keep the runner-owned slash command catalog ahead of plugin runtime artifacts
- load plugin slash command indexes additively and log duplicate command names instead of silently hiding the source
- document first-wins slash command semantics for runner/plugin command sources

## Tests
- pnpm test -- __tests__/slash-commands.test.ts (packages/openclaw-shadowob)
- pnpm test -- src/infra/runtime-package.test.ts (apps/cloud)
- pnpm typecheck (packages/openclaw-shadowob)
- pnpm typecheck (apps/cloud)
- pnpm check:security-pr