### PR TITLE
fix: correct oauth authorize path to /app/oauth/authorize

### DIFF
--- a/apps/cloud/src/interfaces/http/handlers/community.handler.ts
+++ b/apps/cloud/src/interfaces/http/handlers/community.handler.ts
@@ -216,7 +216,7 @@ export function createCommunityHandler(ctx: HandlerContext): Hono {
   app.get('/community/oauth/init', (c) => {
     const cs = getCommunitySettings()
 
-    const authUrl = new URL('/oauth/authorize', cs.baseUrl)
+    const authUrl = new URL('/app/oauth/authorize', cs.baseUrl)
     authUrl.searchParams.set('client_id', 'shadowob-cloud-cli')
     authUrl.searchParams.set('response_type', 'token')
     authUrl.searchParams.set('scope', 'templates:read templates:write')

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -151,7 +151,7 @@ const oauthCallbackRoute = createRoute({
 
 const oauthAuthorizeRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: '/oauth/authorize',
+  path: '/app/oauth/authorize',
   component: OAuthAuthorizePage,
   beforeLoad: () => {
     if (!useAuthStore.getState().isAuthenticated) {

--- a/apps/server/src/services/play-launch.service.ts
+++ b/apps/server/src/services/play-launch.service.ts
@@ -1031,7 +1031,7 @@ export class PlayLaunchService {
       ok: true as const,
       playId: playId ?? null,
       status: 'launched' as const,
-      redirectUrl: `/oauth/authorize?${params.toString()}`,
+      redirectUrl: `/app/oauth/authorize?${params.toString()}`,
     }
   }
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -123,7 +123,7 @@ const oauthCallbackRoute = createRoute({
 
 const oauthAuthorizeRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: '/oauth/authorize',
+  path: '/app/oauth/authorize',
   component: OAuthAuthorizePage,
   beforeLoad: requireAuthenticatedRoute,
 })


### PR DESCRIPTION
## Summary
- Fix incorrect OAuth authorize URL path across web, desktop, server, and cloud apps
- Changed `/oauth/authorize` to `/app/oauth/authorize` in route definitions, redirect URLs, and URL construction

## Changes
| File | Change |
|------|--------|
| `apps/web/src/main.tsx` | Route path |
| `apps/desktop/src/renderer/index.tsx` | Route path |
| `apps/server/src/services/play-launch.service.ts` | Redirect URL generation |
| `apps/cloud/src/interfaces/http/handlers/community.handler.ts` | Auth URL construction |

🤖 Generated with [Claude Code](https://claude.com/claude-code)