### PR TITLE
fix(web): recover voice permission failures

### DIFF
--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -28,27 +28,27 @@ server {
     # Web app SPA — mounted under /app
     # Exact match: serve SPA directly without any redirect (avoids :3000 port leak)
     location = /app {
-        add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://js.stripe.com; connect-src 'self' http: https: ws: wss: https://api.stripe.com https://*.stripe.com; frame-src 'self' http: https: https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:;" always;
+        add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; connect-src 'self' http: https: ws: wss: https://api.stripe.com https://*.stripe.com; frame-src 'self' http: https: https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:;" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Permissions-Policy "camera=(self), microphone=(self), display-capture=(self), geolocation=()" always;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         try_files /app/index.html =404;
     }
     location ^~ /app/static/ {
         try_files $uri =404;
         expires 1y;
-        add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://js.stripe.com; connect-src 'self' http: https: ws: wss: https://api.stripe.com https://*.stripe.com; frame-src 'self' http: https: https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:;" always;
+        add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; connect-src 'self' http: https: ws: wss: https://api.stripe.com https://*.stripe.com; frame-src 'self' http: https: https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:;" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Permissions-Policy "camera=(self), microphone=(self), display-capture=(self), geolocation=()" always;
         add_header Cache-Control "public, immutable" always;
     }
     location ^~ /app/ {
-        add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://js.stripe.com; connect-src 'self' http: https: ws: wss: https://api.stripe.com https://*.stripe.com; frame-src 'self' http: https: https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:;" always;
+        add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; connect-src 'self' http: https: ws: wss: https://api.stripe.com https://*.stripe.com; frame-src 'self' http: https: https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:;" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Permissions-Policy "camera=(self), microphone=(self), display-capture=(self), geolocation=()" always;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         try_files $uri $uri/ /app/index.html;
     }

--- a/apps/web/src/components/channel/channel-sidebar.tsx
+++ b/apps/web/src/components/channel/channel-sidebar.tsx
@@ -661,8 +661,19 @@ export function ChannelSidebar({
         </button>
 
         {isConnectedChannel && voiceErrorMessage && (
-          <div className="ml-8 rounded-lg border border-danger/20 bg-danger/10 px-2 py-1.5 text-xs font-bold text-danger">
-            {voiceErrorMessage}
+          <div className="ml-8 space-y-2 rounded-lg border border-danger/20 bg-danger/10 px-2 py-1.5 text-xs font-bold text-danger">
+            <div>{voiceErrorMessage}</div>
+            {voice.status === 'error' && (
+              <button
+                type="button"
+                onClick={() => void voice.join()}
+                className="h-7 rounded-md bg-danger/15 px-2 text-[11px] font-black text-danger transition hover:bg-danger/25"
+              >
+                {voice.errorKey === 'microphonePermission'
+                  ? t('voice.requestMicrophone')
+                  : t('voice.retryJoin')}
+              </button>
+            )}
           </div>
         )}
 
@@ -1122,6 +1133,18 @@ export function ChannelSidebar({
                   </div>
                 </div>
               </div>
+            )}
+
+            {voice.status === 'error' && (
+              <button
+                type="button"
+                onClick={() => void voice.join()}
+                className="mt-2 h-8 w-full rounded-lg bg-danger/15 text-xs font-black text-danger transition hover:bg-danger/25"
+              >
+                {voice.errorKey === 'microphonePermission'
+                  ? t('voice.requestMicrophone')
+                  : t('voice.retryJoin')}
+              </button>
             )}
           </div>
         </div>

--- a/apps/web/src/components/voice/voice-channel-panel.tsx
+++ b/apps/web/src/components/voice/voice-channel-panel.tsx
@@ -127,6 +127,72 @@ function ParticipantTile({
   )
 }
 
+function VoiceErrorRecovery({
+  errorKey,
+  errorMessage,
+  isRetrying,
+  onLeave,
+  onRetry,
+}: {
+  errorKey: string | null
+  errorMessage: string | null
+  isRetrying: boolean
+  onLeave: () => void
+  onRetry: () => void
+}) {
+  const { t } = useTranslation()
+  const title =
+    errorKey === 'microphonePolicy' || errorKey === 'screenPolicy'
+      ? t('voice.permissionPolicyTitle')
+      : errorKey === 'microphoneNotFound'
+        ? t('voice.microphoneMissingTitle')
+        : errorKey === 'microphonePermission'
+          ? t('voice.microphonePermissionTitle')
+          : t('voice.connectionError')
+  const hint =
+    errorKey === 'microphonePolicy'
+      ? t('voice.microphonePolicyHint')
+      : errorKey === 'screenPolicy'
+        ? t('voice.screenPolicyHint')
+        : errorKey === 'microphonePermission'
+          ? t('voice.microphonePermissionHint')
+          : null
+  const retryLabel =
+    errorKey === 'microphonePermission' ? t('voice.requestMicrophone') : t('voice.retryJoin')
+
+  return (
+    <div className="flex h-full min-h-[520px] items-center justify-center">
+      <div className="w-full max-w-lg rounded-2xl border border-danger/30 bg-[#151015]/95 p-6 text-center shadow-2xl">
+        <div className="mx-auto mb-4 grid h-16 w-16 place-items-center rounded-2xl bg-danger/15 text-danger">
+          <MicOff size={32} />
+        </div>
+        <h2 className="text-xl font-black">{title}</h2>
+        {errorMessage && <p className="mt-3 text-sm font-bold text-danger">{errorMessage}</p>}
+        {hint && <p className="mt-3 text-sm font-bold leading-relaxed text-white/55">{hint}</p>}
+        <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+          <button
+            type="button"
+            disabled={isRetrying}
+            onClick={onRetry}
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-xl bg-success px-4 text-sm font-black text-black transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <Phone size={17} />
+            {isRetrying ? t('voice.connecting') : retryLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onLeave}
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-xl bg-white/8 px-4 text-sm font-black text-white/75 transition hover:bg-white/14 hover:text-white"
+          >
+            <PhoneOff size={17} />
+            {t('voice.disconnect')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function ControlButton({
   active,
   danger,
@@ -230,7 +296,17 @@ export function VoiceChannelPanel({
           </div>
         )}
 
-        {connectedToThisChannel && (
+        {connectedToThisChannel && voice.status === 'error' && (
+          <VoiceErrorRecovery
+            errorKey={voice.errorKey}
+            errorMessage={errorMessage}
+            isRetrying={connecting}
+            onLeave={() => void leaveVoiceChannel()}
+            onRetry={() => void joinVoiceChannel({ id: channelId, name: channelName })}
+          />
+        )}
+
+        {connectedToThisChannel && voice.status !== 'error' && (
           <div className="mx-auto flex min-h-full max-w-5xl flex-col justify-center gap-4 pb-20">
             {localScreenTrack && (
               <div className="relative min-h-[420px] overflow-hidden rounded-lg bg-[#050607] ring-1 ring-primary/35">

--- a/apps/web/src/hooks/use-voice-channel.ts
+++ b/apps/web/src/hooks/use-voice-channel.ts
@@ -78,10 +78,26 @@ export interface RemoteScreen {
 }
 
 type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'error'
-type VoiceErrorKey = 'rtcNotConfigured' | 'microphonePermission' | 'screenPermission' | null
+type VoiceErrorKey =
+  | 'rtcNotConfigured'
+  | 'microphonePermission'
+  | 'microphonePolicy'
+  | 'microphoneNotFound'
+  | 'screenPermission'
+  | 'screenPolicy'
+  | null
 export type NetworkQuality = 'unknown' | 'excellent' | 'good' | 'fair' | 'poor'
 
 type VoiceCue = 'join' | 'leave'
+type CaptureFeature = 'microphone' | 'display-capture'
+
+const VOICE_MICROPHONE_POLICY_BLOCKED = 'VOICE_MICROPHONE_POLICY_BLOCKED'
+const VOICE_MICROPHONE_PERMISSION_DENIED = 'VOICE_MICROPHONE_PERMISSION_DENIED'
+const VOICE_SCREEN_POLICY_BLOCKED = 'VOICE_SCREEN_POLICY_BLOCKED'
+
+interface BrowserPermissionsPolicy {
+  allowsFeature?: (feature: string, origin?: string) => boolean
+}
 
 let voiceCueContext: AudioContext | null = null
 
@@ -142,9 +158,71 @@ function socketCall<T>(event: string, payload: unknown): Promise<T> {
   })
 }
 
+function createCodedError(message: string, code: string) {
+  return Object.assign(new Error(message), { code })
+}
+
+function getDocumentPermissionsPolicy() {
+  if (typeof document === 'undefined') return null
+  const policyDocument = document as Document & {
+    permissionsPolicy?: BrowserPermissionsPolicy
+    featurePolicy?: BrowserPermissionsPolicy
+  }
+  return policyDocument.permissionsPolicy ?? policyDocument.featurePolicy ?? null
+}
+
+function isCaptureBlockedByPolicy(feature: CaptureFeature) {
+  const policy = getDocumentPermissionsPolicy()
+  if (typeof policy?.allowsFeature !== 'function') return false
+
+  try {
+    return policy.allowsFeature(feature) === false
+  } catch {
+    return false
+  }
+}
+
+async function getBrowserPermissionState(name: 'microphone') {
+  if (typeof navigator === 'undefined' || !navigator.permissions?.query) return null
+
+  try {
+    const status = await navigator.permissions.query({ name: name as PermissionName })
+    return status.state
+  } catch {
+    return null
+  }
+}
+
+async function assertMicrophoneCaptureAllowed() {
+  if (isCaptureBlockedByPolicy('microphone')) {
+    throw createCodedError(
+      'Microphone capture is blocked by the page permissions policy.',
+      VOICE_MICROPHONE_POLICY_BLOCKED,
+    )
+  }
+
+  const permissionState = await getBrowserPermissionState('microphone')
+  if (permissionState === 'denied') {
+    throw createCodedError(
+      'Microphone permission has been denied by the browser.',
+      VOICE_MICROPHONE_PERMISSION_DENIED,
+    )
+  }
+}
+
+function assertScreenCaptureAllowed() {
+  if (isCaptureBlockedByPolicy('display-capture')) {
+    throw createCodedError(
+      'Screen capture is blocked by the page permissions policy.',
+      VOICE_SCREEN_POLICY_BLOCKED,
+    )
+  }
+}
+
 function voiceErrorKey(err: unknown): VoiceErrorKey {
-  const error = err as { code?: string; message?: string }
+  const error = err as { code?: string; message?: string; name?: string }
   const message = error?.message ?? ''
+  const normalized = `${error?.code ?? ''} ${error?.name ?? ''} ${message}`.toLowerCase()
   if (
     error?.code === 'VOICE_RTC_NOT_CONFIGURED' ||
     message.includes('Agora RTC is not configured')
@@ -152,21 +230,50 @@ function voiceErrorKey(err: unknown): VoiceErrorKey {
     return 'rtcNotConfigured'
   }
   if (
+    error?.code === VOICE_MICROPHONE_POLICY_BLOCKED ||
+    normalized.includes('permissions policy') ||
+    normalized.includes('permission policy') ||
+    normalized.includes('microphone is not allowed in this document')
+  ) {
+    return 'microphonePolicy'
+  }
+  if (
+    normalized.includes('notfounderror') ||
+    normalized.includes('devicesnotfounderror') ||
+    normalized.includes('requested device not found') ||
+    normalized.includes('no microphone')
+  ) {
+    return 'microphoneNotFound'
+  }
+  if (
+    error?.code === VOICE_MICROPHONE_PERMISSION_DENIED ||
     error?.code === 'PERMISSION_DENIED' ||
-    message.includes('PERMISSION_DENIED') ||
-    message.includes('NotAllowedError')
+    normalized.includes('permission_denied') ||
+    normalized.includes('notallowederror') ||
+    normalized.includes('permission denied')
   ) {
     return 'microphonePermission'
-  }
-  if (message.includes('NotAllowedError') || message.includes('Permission denied')) {
-    return 'screenPermission'
   }
   return null
 }
 
 function screenShareErrorKey(err: unknown): VoiceErrorKey {
-  const message = (err as { message?: string })?.message ?? ''
-  if (message.includes('NotAllowedError') || message.includes('Permission denied')) {
+  const error = err as { code?: string; message?: string; name?: string }
+  const normalized =
+    `${error?.code ?? ''} ${error?.name ?? ''} ${error?.message ?? ''}`.toLowerCase()
+  if (
+    error?.code === VOICE_SCREEN_POLICY_BLOCKED ||
+    normalized.includes('permissions policy') ||
+    normalized.includes('permission policy') ||
+    normalized.includes('display-capture')
+  ) {
+    return 'screenPolicy'
+  }
+  if (
+    normalized.includes('permission_denied') ||
+    normalized.includes('notallowederror') ||
+    normalized.includes('permission denied')
+  ) {
     return 'screenPermission'
   }
   return voiceErrorKey(err)
@@ -252,14 +359,25 @@ export function useVoiceChannel(channelId: string | null) {
 
   const startMicTest = useCallback(async () => {
     stopMicTest()
-    const track = await AgoraRTC.createMicrophoneAudioTrack({
-      microphoneId: selectedMicrophoneId || undefined,
-    })
-    micTestTrackRef.current = track
-    setIsTestingMic(true)
-    micTestTimerRef.current = setInterval(() => {
-      setMicTestLevel(Math.round((track.getVolumeLevel?.() ?? 0) * 100))
-    }, 120)
+    setError(null)
+    setErrorKey(null)
+    try {
+      await assertMicrophoneCaptureAllowed()
+      const track = await AgoraRTC.createMicrophoneAudioTrack({
+        microphoneId: selectedMicrophoneId || undefined,
+      })
+      micTestTrackRef.current = track
+      setIsTestingMic(true)
+      micTestTimerRef.current = setInterval(() => {
+        setMicTestLevel(Math.round((track.getVolumeLevel?.() ?? 0) * 100))
+      }, 120)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to test microphone'
+      setError(message)
+      setErrorKey(voiceErrorKey(err))
+      setIsTestingMic(false)
+      setMicTestLevel(0)
+    }
   }, [selectedMicrophoneId, stopMicTest])
 
   const clearTokenRenewal = useCallback(() => {
@@ -406,7 +524,17 @@ export function useVoiceChannel(channelId: string | null) {
     setStatus('connecting')
     setError(null)
     setErrorKey(null)
+    let localAudioTrack: Awaited<ReturnType<typeof AgoraRTC.createMicrophoneAudioTrack>> | null =
+      null
     try {
+      await assertMicrophoneCaptureAllowed()
+      localAudioTrack = await AgoraRTC.createMicrophoneAudioTrack({
+        microphoneId: selectedMicrophoneId || undefined,
+        encoderConfig: 'music_standard',
+      })
+      localAudioTrackRef.current = localAudioTrack
+      await localAudioTrack.setEnabled(!isMuted)
+
       const result = await socketCall<VoiceJoinResult>('voice:join', {
         channelId,
         clientId,
@@ -462,12 +590,6 @@ export function useVoiceChannel(channelId: string | null) {
         result.credentials.token,
         result.credentials.uid,
       )
-      const localAudioTrack = await AgoraRTC.createMicrophoneAudioTrack({
-        microphoneId: selectedMicrophoneId || undefined,
-        encoderConfig: 'music_standard',
-      })
-      localAudioTrackRef.current = localAudioTrack
-      await localAudioTrack.setEnabled(!isMuted)
       await client.publish([localAudioTrack])
       setStatus('connected')
       playVoiceCue('join')
@@ -478,6 +600,11 @@ export function useVoiceChannel(channelId: string | null) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to join voice channel'
       await leave({ silent: true })
+      if (localAudioTrackRef.current === localAudioTrack) {
+        localAudioTrackRef.current = null
+      }
+      localAudioTrack?.stop?.()
+      localAudioTrack?.close?.()
       setError(message)
       setErrorKey(voiceErrorKey(err))
       setStatus('error')
@@ -556,7 +683,17 @@ export function useVoiceChannel(channelId: string | null) {
     if (!credentials || isScreenSharing) return
     setError(null)
     setErrorKey(null)
+    let screenTrack: any = null
     try {
+      assertScreenCaptureAllowed()
+      const trackResult = await AgoraRTC.createScreenVideoTrack(
+        { encoderConfig: '1080p_1' },
+        'disable',
+      )
+      screenTrack = Array.isArray(trackResult) ? trackResult[0] : trackResult
+      localScreenTrackRef.current = screenTrack
+      screenTrack.on?.('track-ended', () => void stopScreenShare())
+
       const screenClient = AgoraRTC.createClient({ mode: 'rtc', codec: 'vp8' })
       screenClientRef.current = screenClient
       screenClient.on('token-privilege-will-expire', () => {
@@ -571,13 +708,6 @@ export function useVoiceChannel(channelId: string | null) {
         credentials.screenToken,
         credentials.screenUid,
       )
-      const trackResult = await AgoraRTC.createScreenVideoTrack(
-        { encoderConfig: '1080p_1' },
-        'disable',
-      )
-      const screenTrack = Array.isArray(trackResult) ? trackResult[0] : trackResult
-      localScreenTrackRef.current = screenTrack
-      screenTrack.on?.('track-ended', () => void stopScreenShare())
       await screenClient.publish([screenTrack])
       setLocalScreenTrack(screenTrack)
       setRemoteScreens((prev) =>
@@ -597,6 +727,8 @@ export function useVoiceChannel(channelId: string | null) {
       setError(message)
       setErrorKey(screenShareErrorKey(err))
       emitVoiceState({ screenSharing: false })
+      screenTrack?.stop?.()
+      screenTrack?.close?.()
     }
   }, [emitVoiceState, isScreenSharing, stopScreenShare])
 

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -2737,6 +2737,14 @@
     "speaker": "Speaker",
     "earpiece": "Earpiece",
     "joinFailed": "Failed to join voice channel",
+    "permissionPolicyTitle": "Page policy blocks voice",
+    "microphoneMissingTitle": "No microphone found",
+    "microphonePermissionTitle": "Microphone permission required",
+    "microphonePolicyHint": "The current deployment Permissions-Policy or embedding container blocks microphone capture, so the browser will not show a permission prompt. Update the deployment config, then refresh.",
+    "screenPolicyHint": "The current page policy blocks screen sharing, so the browser will not show the sharing picker. Update the deployment config, then retry.",
+    "microphonePermissionHint": "If no browser prompt appears, open site permissions from the address bar, allow microphone access, then request it again.",
+    "requestMicrophone": "Request microphone again",
+    "retryJoin": "Join again",
     "network": {
       "unknown": "Network unknown",
       "excellent": "Excellent network",
@@ -2747,7 +2755,10 @@
     "errors": {
       "rtcNotConfigured": "Voice service is not configured on the server.",
       "microphonePermission": "Allow microphone access in your browser, then join again.",
-      "screenPermission": "Allow screen sharing in your browser, then try again."
+      "microphonePolicy": "This page blocks microphone access, so the browser cannot show a permission prompt.",
+      "microphoneNotFound": "No available microphone was detected.",
+      "screenPermission": "Allow screen sharing in your browser, then try again.",
+      "screenPolicy": "This page blocks screen sharing, so the browser cannot show the sharing picker."
     }
   }
 }

--- a/apps/web/src/lib/locales/ja.json
+++ b/apps/web/src/lib/locales/ja.json
@@ -2737,6 +2737,14 @@
     "speaker": "スピーカー",
     "earpiece": "受話口",
     "joinFailed": "ボイスチャンネルに参加できませんでした",
+    "permissionPolicyTitle": "ページの権限ポリシーがボイスをブロックしています",
+    "microphoneMissingTitle": "利用可能なマイクが見つかりません",
+    "microphonePermissionTitle": "マイク権限が必要です",
+    "microphonePolicyHint": "現在のデプロイの Permissions-Policy または埋め込みコンテナがマイク取得を禁止しているため、ブラウザーは権限ダイアログを表示できません。デプロイ設定を更新してからページを再読み込みしてください。",
+    "screenPolicyHint": "現在のページポリシーが画面共有を禁止しているため、ブラウザーは共有ピッカーを表示できません。デプロイ設定を更新してから再試行してください。",
+    "microphonePermissionHint": "ブラウザーの確認が表示されない場合は、アドレスバー横のサイト権限でマイクを許可し、もう一度リクエストしてください。",
+    "requestMicrophone": "マイク権限を再リクエスト",
+    "retryJoin": "再参加",
     "network": {
       "unknown": "ネットワーク不明",
       "excellent": "ネットワーク良好",
@@ -2747,7 +2755,10 @@
     "errors": {
       "rtcNotConfigured": "サーバー側のボイスサービスが未設定です。",
       "microphonePermission": "ブラウザーでマイク権限を許可してから再参加してください。",
-      "screenPermission": "ブラウザーで画面共有を許可してから再試行してください。"
+      "microphonePolicy": "このページはマイクアクセスをブロックしているため、権限ダイアログを表示できません。",
+      "microphoneNotFound": "利用可能なマイクが検出されませんでした。",
+      "screenPermission": "ブラウザーで画面共有を許可してから再試行してください。",
+      "screenPolicy": "このページは画面共有をブロックしているため、共有ピッカーを表示できません。"
     }
   }
 }

--- a/apps/web/src/lib/locales/ko.json
+++ b/apps/web/src/lib/locales/ko.json
@@ -2737,6 +2737,14 @@
     "speaker": "스피커",
     "earpiece": "수화기",
     "joinFailed": "음성 채널 참여 실패",
+    "permissionPolicyTitle": "페이지 권한 정책이 음성을 차단했습니다",
+    "microphoneMissingTitle": "사용 가능한 마이크가 없습니다",
+    "microphonePermissionTitle": "마이크 권한이 필요합니다",
+    "microphonePolicyHint": "현재 배포의 Permissions-Policy 또는 임베드 컨테이너가 마이크 캡처를 차단해 브라우저 권한 창이 표시되지 않습니다. 배포 설정을 업데이트한 뒤 새로고침하세요.",
+    "screenPolicyHint": "현재 페이지 정책이 화면 공유를 차단해 브라우저 공유 선택 창이 표시되지 않습니다. 배포 설정을 업데이트한 뒤 다시 시도하세요.",
+    "microphonePermissionHint": "브라우저 권한 창이 표시되지 않으면 주소창 옆 사이트 권한에서 마이크를 허용한 뒤 다시 요청하세요.",
+    "requestMicrophone": "마이크 권한 다시 요청",
+    "retryJoin": "다시 참여",
     "network": {
       "unknown": "네트워크 상태 알 수 없음",
       "excellent": "네트워크 매우 좋음",
@@ -2747,7 +2755,10 @@
     "errors": {
       "rtcNotConfigured": "서버에 음성 서비스가 설정되지 않았습니다.",
       "microphonePermission": "브라우저에서 마이크 권한을 허용한 뒤 다시 참여하세요.",
-      "screenPermission": "브라우저에서 화면 공유를 허용한 뒤 다시 시도하세요."
+      "microphonePolicy": "이 페이지가 마이크 접근을 차단해 권한 창을 표시할 수 없습니다.",
+      "microphoneNotFound": "사용 가능한 마이크를 감지하지 못했습니다.",
+      "screenPermission": "브라우저에서 화면 공유를 허용한 뒤 다시 시도하세요.",
+      "screenPolicy": "이 페이지가 화면 공유를 차단해 공유 선택 창을 표시할 수 없습니다."
     }
   }
 }

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -2737,6 +2737,14 @@
     "speaker": "扬声器",
     "earpiece": "听筒",
     "joinFailed": "加入语音频道失败",
+    "permissionPolicyTitle": "页面权限策略阻止了语音",
+    "microphoneMissingTitle": "未找到可用麦克风",
+    "microphonePermissionTitle": "需要麦克风权限",
+    "microphonePolicyHint": "当前部署的 Permissions-Policy 或嵌入容器禁止了麦克风，浏览器不会弹出授权窗口。请更新部署配置后刷新页面。",
+    "screenPolicyHint": "当前页面策略禁止屏幕共享，浏览器不会弹出共享窗口。请更新部署配置后重试。",
+    "microphonePermissionHint": "如果浏览器没有弹窗，请点击地址栏旁的站点权限，将麦克风改为允许，然后再重新请求。",
+    "requestMicrophone": "重新请求麦克风权限",
+    "retryJoin": "重新加入",
     "network": {
       "unknown": "网络状态未知",
       "excellent": "网络极佳",
@@ -2747,7 +2755,10 @@
     "errors": {
       "rtcNotConfigured": "服务端尚未配置语音服务。",
       "microphonePermission": "请在浏览器中允许麦克风权限，然后重新加入。",
-      "screenPermission": "请在浏览器中允许屏幕共享，然后重试。"
+      "microphonePolicy": "当前页面禁止使用麦克风，无法弹出授权窗口。",
+      "microphoneNotFound": "未检测到可用麦克风。",
+      "screenPermission": "请在浏览器中允许屏幕共享，然后重试。",
+      "screenPolicy": "当前页面禁止屏幕共享，无法弹出共享窗口。"
     }
   }
 }

--- a/apps/web/src/lib/locales/zh-TW.json
+++ b/apps/web/src/lib/locales/zh-TW.json
@@ -2737,6 +2737,14 @@
     "speaker": "揚聲器",
     "earpiece": "聽筒",
     "joinFailed": "加入語音頻道失敗",
+    "permissionPolicyTitle": "頁面權限策略阻止了語音",
+    "microphoneMissingTitle": "找不到可用麥克風",
+    "microphonePermissionTitle": "需要麥克風權限",
+    "microphonePolicyHint": "目前部署的 Permissions-Policy 或嵌入容器禁止了麥克風，瀏覽器不會顯示授權視窗。請更新部署設定後重新整理頁面。",
+    "screenPolicyHint": "目前頁面策略禁止螢幕分享，瀏覽器不會顯示分享視窗。請更新部署設定後重試。",
+    "microphonePermissionHint": "如果瀏覽器沒有彈出視窗，請點擊網址列旁的網站權限，將麥克風改為允許，然後重新請求。",
+    "requestMicrophone": "重新請求麥克風權限",
+    "retryJoin": "重新加入",
     "network": {
       "unknown": "網路狀態未知",
       "excellent": "網路極佳",
@@ -2747,7 +2755,10 @@
     "errors": {
       "rtcNotConfigured": "服務端尚未設定語音服務。",
       "microphonePermission": "請在瀏覽器中允許麥克風權限，然後重新加入。",
-      "screenPermission": "請在瀏覽器中允許螢幕共享，然後重試。"
+      "microphonePolicy": "目前頁面禁止使用麥克風，無法顯示授權視窗。",
+      "microphoneNotFound": "未偵測到可用麥克風。",
+      "screenPermission": "請在瀏覽器中允許螢幕共享，然後重試。",
+      "screenPolicy": "目前頁面禁止螢幕分享，無法顯示分享視窗。"
     }
   }
 }

--- a/docs/api/voice-channels.md
+++ b/docs/api/voice-channels.md
@@ -11,6 +11,16 @@ Set these on the server process:
 
 Do not set or depend on `VITE_AGORA_*` in web or mobile clients. Clients call the authenticated Shadow `join` API and receive only scoped RTC data: `appId`, `agoraChannelName`, `uid`, `screenUid`, `token`, `screenToken`, and `expiresAt`.
 
+### Web deployment headers
+
+The browser must be allowed to request capture permissions on the Shadow app document. In production, the `/app` HTML response needs a `Permissions-Policy` that allows same-origin microphone capture and screen capture:
+
+```nginx
+add_header Permissions-Policy "camera=(self), microphone=(self), display-capture=(self), geolocation=()" always;
+```
+
+If `microphone=()` is sent for `/app`, Chrome rejects `getUserMedia` with `Permissions policy violation: microphone is not allowed in this document`. In that state the browser will not show a permission prompt, and the user cannot recover from UI retry alone until the deployment header or embedding `allow` policy is fixed and the page is refreshed.
+
 ## Authorization
 
 All voice routes require `PolicyService.requireChannelRead(actor, channelId)`. The target channel must be a server channel with `type: "voice"`.


### PR DESCRIPTION
## Summary\n- allow microphone and display capture on /app production responses while keeping non-app pages locked down\n- detect browser Permissions-Policy and denied microphone states before joining Agora, avoiding stuck half-connected voice sessions\n- add voice permission recovery UI, i18n copy, and deployment docs\n\n## Verification\n- pnpm build:packages\n- pnpm -C apps/web typecheck\n- pnpm check:security-pr\n- pnpm biome check apps/web/src/hooks/use-voice-channel.ts apps/web/src/components/voice/voice-channel-panel.tsx apps/web/src/components/channel/channel-sidebar.tsx apps/web/src/lib/locales/en.json apps/web/src/lib/locales/ja.json apps/web/src/lib/locales/ko.json apps/web/src/lib/locales/zh-CN.json apps/web/src/lib/locales/zh-TW.json docs/api/voice-channels.md --diagnostic-level=error\n- pnpm check:i18n\n- pnpm -C apps/web build\n- docker run --rm -v "/Users/maopeng/Projects/shadow-voice-permissions/apps/web/nginx.conf:/etc/nginx/conf.d/default.conf:ro" nginx:alpine nginx -t