### PR TITLE
fix(cli): output formatting, flag consistency, agents→buddies rename, add app uninstall

### DIFF
--- a/docs/api/commerce-product-context.md
+++ b/docs/api/commerce-product-context.md
@@ -71,5 +71,4 @@ context = client.get_commerce_product_context("product-id")
 
 ```bash
 shadowob commerce products context <product-id> --json
-shadowob shop products context <product-id> --json
 ```

--- a/packages/cli/__tests__/e2e/cli.e2e.test.ts
+++ b/packages/cli/__tests__/e2e/cli.e2e.test.ts
@@ -63,10 +63,10 @@ describe('CLI E2E Tests', () => {
     })
   })
 
-  describe('agents commands', () => {
-    it('should show agents help', async () => {
-      const { stdout } = await execa('node', [CLI_PATH, 'agents', '--help'])
-      expect(stdout).toContain('Agent management commands')
+  describe('buddies commands', () => {
+    it('should show buddies help', async () => {
+      const { stdout } = await execa('node', [CLI_PATH, 'buddies', '--help'])
+      expect(stdout).toContain('Buddy management commands')
       expect(stdout).toContain('list')
       expect(stdout).toContain('create')
       expect(stdout).toContain('start')

--- a/packages/cli/__tests__/e2e/functional.test.ts
+++ b/packages/cli/__tests__/e2e/functional.test.ts
@@ -235,9 +235,9 @@ describe('CLI Functional Tests', () => {
       const { stdout } = await execa('node', [CLI_PATH, 'shop', 'products', '--help'])
       expect(stdout).toContain('list')
       expect(stdout).toContain('get')
-      expect(stdout).toContain('context')
       expect(stdout).toContain('purchase')
       expect(stdout).toContain('list-by-shop')
+      expect(stdout).toContain('create-by-shop')
     })
 
     it('should show shop offers help', async () => {

--- a/packages/cli/__tests__/e2e/functional.test.ts
+++ b/packages/cli/__tests__/e2e/functional.test.ts
@@ -158,9 +158,9 @@ describe('CLI Functional Tests', () => {
     })
   })
 
-  describe('agents commands', () => {
-    it('should show agents help', async () => {
-      const { stdout } = await execa('node', [CLI_PATH, 'agents', '--help'])
+  describe('buddies commands', () => {
+    it('should show buddies help', async () => {
+      const { stdout } = await execa('node', [CLI_PATH, 'buddies', '--help'])
       expect(stdout).toContain('list')
       expect(stdout).toContain('get')
       expect(stdout).toContain('create')

--- a/packages/cli/__tests__/e2e/integration.test.ts
+++ b/packages/cli/__tests__/e2e/integration.test.ts
@@ -147,7 +147,7 @@ describe.skipIf(!SHOULD_RUN_INTEGRATION)('CLI Integration Tests', () => {
     it('should list channels in a server', async () => {
       const { stdout } = await execa(
         'node',
-        [CLI_PATH, 'channels', 'list', '--server-id', serverId, '--profile', 'test', '--json'],
+        [CLI_PATH, 'channels', 'list', '--server', serverId, '--profile', 'test', '--json'],
         {
           env: { ...process.env, HOME: tempDir },
         },
@@ -163,7 +163,7 @@ describe.skipIf(!SHOULD_RUN_INTEGRATION)('CLI Integration Tests', () => {
           CLI_PATH,
           'channels',
           'create',
-          '--server-id',
+          '--server',
           serverId,
           '--name',
           'test-channel',
@@ -228,11 +228,11 @@ describe.skipIf(!SHOULD_RUN_INTEGRATION)('CLI Integration Tests', () => {
     })
   })
 
-  describe('agents flow', () => {
-    it('should list agents', async () => {
+  describe('buddies flow', () => {
+    it('should list buddies', async () => {
       const { stdout } = await execa(
         'node',
-        [CLI_PATH, 'agents', 'list', '--profile', 'test', '--json'],
+        [CLI_PATH, 'buddies', 'list', '--profile', 'test', '--json'],
         {
           env: { ...process.env, HOME: tempDir },
         },
@@ -241,15 +241,15 @@ describe.skipIf(!SHOULD_RUN_INTEGRATION)('CLI Integration Tests', () => {
       expect(Array.isArray(result)).toBe(true)
     })
 
-    it('should create an agent', async () => {
+    it('should create a buddy', async () => {
       const { stdout } = await execa(
         'node',
         [
           CLI_PATH,
-          'agents',
+          'buddies',
           'create',
           '--name',
-          `test-agent-${Date.now()}`,
+          `test-buddy-${Date.now()}`,
           '--profile',
           'test',
           '--json',
@@ -259,7 +259,7 @@ describe.skipIf(!SHOULD_RUN_INTEGRATION)('CLI Integration Tests', () => {
         },
       )
       const result = JSON.parse(stdout)
-      expect(result.name).toContain('test-agent')
+      expect(result.name).toContain('test-buddy')
       expect(result.token).toBeDefined()
     })
   })

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -1,14 +1,8 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { basename } from 'node:path'
 import { Command } from 'commander'
-import { getClient } from '../utils/client.js'
+import { getClient, resolveServerFlag } from '../utils/client.js'
 import { output, outputError, outputSuccess } from '../utils/output.js'
-
-function resolveServer(value?: string) {
-  const server = value ?? process.env.SHADOWOB_SERVER_ID
-  if (!server) throw new Error('Missing server. Pass --server or set SHADOWOB_SERVER_ID.')
-  return server
-}
 
 function parseJsonInput(value?: string) {
   if (!value) return {}
@@ -46,7 +40,14 @@ export function createAppCommand(): Command {
     .action(async (options: { server: string; profile?: string; json?: boolean }) => {
       try {
         const client = await getClient(options.profile)
-        output(await client.listServerApps(resolveServer(options.server)), { json: options.json })
+        const apps = await client.listServerApps(resolveServerFlag(options.server))
+        output(
+          apps.map((entry) => ({
+            id: entry.id,
+            name: `${entry.appKey} (${entry.name})`,
+          })),
+          { json: options.json },
+        )
       } catch (error) {
         commandHandlerError(error, options.json)
       }
@@ -77,7 +78,7 @@ export function createAppCommand(): Command {
             ? await readJsonFile(options.manifestFile)
             : undefined
           output(
-            await client.discoverServerApp(resolveServer(options.server), {
+            await client.discoverServerApp(resolveServerFlag(options.server), {
               manifestUrl: options.manifestUrl,
               manifest: manifest as never,
             }),
@@ -113,7 +114,7 @@ export function createAppCommand(): Command {
           const manifest = options.manifestFile
             ? await readJsonFile(options.manifestFile)
             : undefined
-          const result = await client.installServerApp(resolveServer(options.server), {
+          const result = await client.installServerApp(resolveServerFlag(options.server), {
             manifestUrl: options.manifestUrl,
             manifest: manifest as never,
           })
@@ -135,7 +136,7 @@ export function createAppCommand(): Command {
       async (appKey: string, options: { server: string; profile?: string; json?: boolean }) => {
         try {
           const client = await getClient(options.profile)
-          output(await client.getServerApp(resolveServer(options.server), appKey), {
+          output(await client.getServerApp(resolveServerFlag(options.server), appKey), {
             json: options.json,
           })
         } catch (error) {
@@ -149,7 +150,7 @@ export function createAppCommand(): Command {
     .description('Grant a Buddy access to an installed server App')
     .argument('<app-key>', 'App key')
     .requiredOption('--server <server>', 'Server ID or slug')
-    .requiredOption('--buddy <agent-id>', 'Buddy agent ID')
+    .requiredOption('--buddy <buddy-id>', 'Buddy ID')
     .requiredOption('--permissions <permissions>', 'Comma-separated permissions, or *')
     .option('--approval-mode <mode>', 'none, first_time, every_time, or policy', 'none')
     .option('--profile <name>', 'Profile to use')
@@ -172,11 +173,15 @@ export function createAppCommand(): Command {
             .split(',')
             .map((item) => item.trim())
             .filter(Boolean)
-          const result = await client.grantServerAppToBuddy(resolveServer(options.server), appKey, {
-            buddyAgentId: options.buddy,
-            permissions,
-            approvalMode: options.approvalMode,
-          })
+          const result = await client.grantServerAppToBuddy(
+            resolveServerFlag(options.server),
+            appKey,
+            {
+              buddyAgentId: options.buddy,
+              permissions,
+              approvalMode: options.approvalMode,
+            },
+          )
           output(result, { json: options.json })
         } catch (error) {
           commandHandlerError(error, options.json)
@@ -193,7 +198,7 @@ export function createAppCommand(): Command {
     .action(async (options: { server: string; profile?: string; json?: boolean }) => {
       try {
         const client = await getClient(options.profile)
-        const server = resolveServer(options.server)
+        const server = resolveServerFlag(options.server)
         const apps = await client.listServerApps(server)
         const docs = await Promise.all(
           apps.map((entry) => client.getServerAppSkills(server, entry.appKey)),
@@ -219,7 +224,7 @@ export function createAppCommand(): Command {
       async (appKey: string, options: { server: string; profile?: string; json?: boolean }) => {
         try {
           const client = await getClient(options.profile)
-          const result = await client.getServerAppSkills(resolveServer(options.server), appKey)
+          const result = await client.getServerAppSkills(resolveServerFlag(options.server), appKey)
           if (options.json) output(result, { json: true })
           else console.log(result.markdown)
         } catch (error) {
@@ -261,7 +266,7 @@ export function createAppCommand(): Command {
           const input = options.inputFile
             ? await readJsonFile(options.inputFile)
             : parseJsonInput(options.jsonInput)
-          const server = resolveServer(options.server)
+          const server = resolveServerFlag(options.server)
           const result = options.file
             ? await client.callServerAppCommandMultipart(server, appKey, commandName, {
                 input,
@@ -286,6 +291,27 @@ export function createAppCommand(): Command {
             return
           }
           output(result, { json: options.json })
+        } catch (error) {
+          commandHandlerError(error, options.json)
+        }
+      },
+    )
+
+  app
+    .command('uninstall')
+    .description('Uninstall a server App')
+    .argument('<app-key>', 'App key')
+    .requiredOption('--server <server>', 'Server ID or slug')
+    .option('--profile <name>', 'Profile to use')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (appKey: string, options: { server: string; profile?: string; json?: boolean }) => {
+        try {
+          const client = await getClient(options.profile)
+          await client.deleteServerApp(resolveServerFlag(options.server), appKey)
+          const outputOpts = { json: options.json }
+          if (options.json) output({ ok: true }, outputOpts)
+          else outputSuccess(`Uninstalled ${appKey}`, outputOpts)
         } catch (error) {
           commandHandlerError(error, options.json)
         }

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -9,7 +9,7 @@ export function createAuthCommand(): Command {
   auth
     .command('login')
     .description('Authenticate with a Shadow server')
-    .requiredOption('--server-url <url>', 'Shadow server URL')
+    .option('--server-url <url>', 'Shadow server URL', 'https://shadowob.com')
     .requiredOption('--token <token>', 'JWT token')
     .option('--profile <name>', 'Profile name', 'default')
     .option('--json', 'Output as JSON')

--- a/packages/cli/src/commands/buddies.ts
+++ b/packages/cli/src/commands/buddies.ts
@@ -2,12 +2,12 @@ import { Command } from 'commander'
 import { getClient } from '../utils/client.js'
 import { type OutputOptions, output, outputError, outputSuccess } from '../utils/output.js'
 
-export function createAgentsCommand(): Command {
-  const agents = new Command('agents').description('Agent management commands')
+export function createBuddiesCommand(): Command {
+  const buddies = new Command('buddies').description('Buddy management commands')
 
-  agents
+  buddies
     .command('list')
-    .description('List your agents')
+    .description('List your buddies')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
     .action(async (options: { profile?: string; json?: boolean }) => {
@@ -21,16 +21,16 @@ export function createAgentsCommand(): Command {
       }
     })
 
-  agents
+  buddies
     .command('get')
-    .description('Get agent details')
-    .argument('<agent-id>', 'Agent ID')
+    .description('Get buddy details')
+    .argument('<buddy-id>', 'Buddy ID')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
-    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+    .action(async (buddyId: string, options: { profile?: string; json?: boolean }) => {
       try {
         const client = await getClient(options.profile)
-        const agent = await client.getAgent(agentId)
+        const agent = await client.getAgent(buddyId)
         output(agent, { json: options.json })
       } catch (error) {
         outputError(error instanceof Error ? error.message : String(error), { json: options.json })
@@ -38,11 +38,11 @@ export function createAgentsCommand(): Command {
       }
     })
 
-  agents
+  buddies
     .command('create')
-    .description('Create a new agent')
-    .requiredOption('--name <name>', 'Agent name')
-    .requiredOption('--username <username>', 'Agent username')
+    .description('Create a new buddy')
+    .requiredOption('--name <name>', 'Buddy name')
+    .requiredOption('--username <username>', 'Buddy username')
     .option('--display-name <name>', 'Display name')
     .option('--avatar-url <url>', 'Avatar URL')
     .option('--profile <name>', 'Profile to use')
@@ -74,10 +74,10 @@ export function createAgentsCommand(): Command {
       },
     )
 
-  agents
+  buddies
     .command('update')
-    .description('Update an agent')
-    .argument('<agent-id>', 'Agent ID')
+    .description('Update a buddy')
+    .argument('<buddy-id>', 'Buddy ID')
     .option('--name <name>', 'New name')
     .option('--display-name <name>', 'New display name')
     .option('--avatar-url <url>', 'New avatar URL')
@@ -85,7 +85,7 @@ export function createAgentsCommand(): Command {
     .option('--json', 'Output as JSON')
     .action(
       async (
-        agentId: string,
+        buddyId: string,
         options: {
           name?: string
           displayName?: string
@@ -96,7 +96,7 @@ export function createAgentsCommand(): Command {
       ) => {
         try {
           const client = await getClient(options.profile)
-          const agent = await client.updateAgent(agentId, {
+          const agent = await client.updateAgent(buddyId, {
             name: options.name,
             displayName: options.displayName,
             avatarUrl: options.avatarUrl,
@@ -111,70 +111,70 @@ export function createAgentsCommand(): Command {
       },
     )
 
-  agents
+  buddies
     .command('delete')
-    .description('Delete an agent')
-    .argument('<agent-id>', 'Agent ID')
+    .description('Delete a buddy')
+    .argument('<buddy-id>', 'Buddy ID')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
-    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+    .action(async (buddyId: string, options: { profile?: string; json?: boolean }) => {
       try {
         const client = await getClient(options.profile)
-        await client.deleteAgent(agentId)
+        await client.deleteAgent(buddyId)
         const outputOpts: OutputOptions = { json: options.json }
-        outputSuccess('Agent deleted', outputOpts)
+        outputSuccess('Buddy deleted', outputOpts)
       } catch (error) {
         outputError(error instanceof Error ? error.message : String(error), { json: options.json })
         process.exit(1)
       }
     })
 
-  agents
+  buddies
     .command('start')
-    .description('Start an agent')
-    .argument('<agent-id>', 'Agent ID')
+    .description('Start a buddy')
+    .argument('<buddy-id>', 'Buddy ID')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
-    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+    .action(async (buddyId: string, options: { profile?: string; json?: boolean }) => {
       try {
         const client = await getClient(options.profile)
-        await client.startAgent(agentId)
+        await client.startAgent(buddyId)
         const outputOpts: OutputOptions = { json: options.json }
-        outputSuccess('Agent started', outputOpts)
+        outputSuccess('Buddy started', outputOpts)
       } catch (error) {
         outputError(error instanceof Error ? error.message : String(error), { json: options.json })
         process.exit(1)
       }
     })
 
-  agents
+  buddies
     .command('stop')
-    .description('Stop an agent')
-    .argument('<agent-id>', 'Agent ID')
+    .description('Stop a buddy')
+    .argument('<buddy-id>', 'Buddy ID')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
-    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+    .action(async (buddyId: string, options: { profile?: string; json?: boolean }) => {
       try {
         const client = await getClient(options.profile)
-        await client.stopAgent(agentId)
+        await client.stopAgent(buddyId)
         const outputOpts: OutputOptions = { json: options.json }
-        outputSuccess('Agent stopped', outputOpts)
+        outputSuccess('Buddy stopped', outputOpts)
       } catch (error) {
         outputError(error instanceof Error ? error.message : String(error), { json: options.json })
         process.exit(1)
       }
     })
 
-  agents
+  buddies
     .command('token')
-    .description('Generate a new token for an agent')
-    .argument('<agent-id>', 'Agent ID')
+    .description('Generate a new token for a buddy')
+    .argument('<buddy-id>', 'Buddy ID')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
-    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+    .action(async (buddyId: string, options: { profile?: string; json?: boolean }) => {
       try {
         const client = await getClient(options.profile)
-        const result = await client.generateAgentToken(agentId)
+        const result = await client.generateAgentToken(buddyId)
         if (options.json) {
           output(result, { json: true })
         } else {
@@ -186,16 +186,16 @@ export function createAgentsCommand(): Command {
       }
     })
 
-  agents
+  buddies
     .command('config')
-    .description('Get agent remote config')
-    .argument('<agent-id>', 'Agent ID')
+    .description('Get buddy remote config')
+    .argument('<buddy-id>', 'Buddy ID')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
-    .action(async (agentId: string, options: { profile?: string; json?: boolean }) => {
+    .action(async (buddyId: string, options: { profile?: string; json?: boolean }) => {
       try {
         const client = await getClient(options.profile)
-        const config = await client.getAgentConfig(agentId)
+        const config = await client.getAgentConfig(buddyId)
         output(config, { json: options.json })
       } catch (error) {
         outputError(error instanceof Error ? error.message : String(error), { json: options.json })
@@ -203,5 +203,5 @@ export function createAgentsCommand(): Command {
       }
     })
 
-  return agents
+  return buddies
 }

--- a/packages/cli/src/commands/channels.ts
+++ b/packages/cli/src/commands/channels.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { getClient } from '../utils/client.js'
+import { getClient, resolveServerFlag } from '../utils/client.js'
 import { type OutputOptions, output, outputError, outputSuccess } from '../utils/output.js'
 
 export function createChannelsCommand(): Command {
@@ -8,13 +8,13 @@ export function createChannelsCommand(): Command {
   channels
     .command('list')
     .description('List channels in a server')
-    .requiredOption('--server-id <id>', 'Server ID')
+    .requiredOption('--server <server>', 'Server ID or slug')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
-    .action(async (options: { serverId: string; profile?: string; json?: boolean }) => {
+    .action(async (options: { server: string; profile?: string; json?: boolean }) => {
       try {
         const client = await getClient(options.profile)
-        const channels = await client.getServerChannels(options.serverId)
+        const channels = await client.getServerChannels(resolveServerFlag(options.server))
         output(channels, { json: options.json })
       } catch (error) {
         outputError(error instanceof Error ? error.message : String(error), { json: options.json })
@@ -42,7 +42,7 @@ export function createChannelsCommand(): Command {
   channels
     .command('create')
     .description('Create a channel')
-    .requiredOption('--server-id <id>', 'Server ID')
+    .requiredOption('--server <server>', 'Server ID or slug')
     .requiredOption('--name <name>', 'Channel name')
     .option('--type <type>', 'Channel type', 'text')
     .option('--description <desc>', 'Channel description')
@@ -50,7 +50,7 @@ export function createChannelsCommand(): Command {
     .option('--json', 'Output as JSON')
     .action(
       async (options: {
-        serverId: string
+        server: string
         name: string
         type?: string
         description?: string
@@ -59,7 +59,7 @@ export function createChannelsCommand(): Command {
       }) => {
         try {
           const client = await getClient(options.profile)
-          const channel = await client.createChannel(options.serverId, {
+          const channel = await client.createChannel(resolveServerFlag(options.server), {
             name: options.name,
             type: options.type,
             description: options.description,

--- a/packages/cli/src/commands/commerce.ts
+++ b/packages/cli/src/commands/commerce.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { Command } from 'commander'
-import { getClient } from '../utils/client.js'
+import { getClient, resolveServerFlag } from '../utils/client.js'
 import { output, outputError } from '../utils/output.js'
 
 type CommonOptions = { profile?: string; json?: boolean }
@@ -166,14 +166,14 @@ export function createCommerceCommand(): Command {
   entitlements
     .command('list')
     .description('List my purchase entitlements')
-    .option('--server-id <id>', 'Limit to a server shop entitlement list')
+    .option('--server <server>', 'Limit to a server shop entitlement list')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
-    .action((options: CommonOptions & { serverId?: string }) =>
+    .action((options: CommonOptions & { server?: string }) =>
       runCommand(options, async () => {
         const client = await getClient(options.profile)
-        return options.serverId
-          ? client.getEntitlements(options.serverId)
+        return options.server
+          ? client.getEntitlements(resolveServerFlag(options.server))
           : client.getAllEntitlements()
       }),
     )

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { getClient } from '../utils/client.js'
+import { getClient, resolveServerFlag } from '../utils/client.js'
 import { output, outputError } from '../utils/output.js'
 
 export function createSearchCommand(): Command {
@@ -10,7 +10,7 @@ export function createSearchCommand(): Command {
     .command('messages')
     .description('Search messages')
     .requiredOption('--query <text>', 'Search query')
-    .option('--server-id <id>', 'Limit to server')
+    .option('--server <server>', 'Limit to server')
     .option('--channel-id <id>', 'Limit to channel')
     .option('--limit <n>', 'Number of results (1-100)', '20')
     .option('--profile <name>', 'Profile to use')
@@ -18,7 +18,7 @@ export function createSearchCommand(): Command {
     .action(
       async (options: {
         query: string
-        serverId?: string
+        server?: string
         channelId?: string
         limit?: string
         profile?: string
@@ -29,7 +29,7 @@ export function createSearchCommand(): Command {
           const limit = Math.min(Math.max(parseInt(options.limit ?? '20', 10), 1), 100)
           const results = await client.searchMessages({
             q: options.query,
-            serverId: options.serverId,
+            serverId: options.server ? resolveServerFlag(options.server) : undefined,
             channelId: options.channelId,
             limit,
           })

--- a/packages/cli/src/commands/servers.ts
+++ b/packages/cli/src/commands/servers.ts
@@ -14,7 +14,10 @@ export function createServersCommand(): Command {
       try {
         const client = await getClient(options.profile)
         const servers = await client.listServers()
-        output(servers, { json: options.json })
+        output(
+          (servers as unknown as Array<{ server: Record<string, unknown> }>).map((s) => s.server),
+          { json: options.json },
+        )
       } catch (error) {
         outputError(error instanceof Error ? error.message : String(error), { json: options.json })
         process.exit(1)
@@ -132,7 +135,24 @@ export function createServersCommand(): Command {
       try {
         const client = await getClient(options.profile)
         const members = await client.getMembers(serverId)
-        output(members, { json: options.json })
+        output(
+          members.map(
+            (m: {
+              id?: unknown
+              userId?: unknown
+              user?: { username?: string }
+              nickname?: string
+              uid?: string
+              role?: unknown
+            }) => ({
+              id: m.id,
+              userId: m.userId,
+              username: m.user?.username ?? m.nickname ?? m.uid ?? '',
+              role: m.role,
+            }),
+          ),
+          { json: options.json },
+        )
       } catch (error) {
         outputError(error instanceof Error ? error.message : String(error), { json: options.json })
         process.exit(1)

--- a/packages/cli/src/commands/shop.ts
+++ b/packages/cli/src/commands/shop.ts
@@ -214,24 +214,6 @@ export function createShopCommand(): Command {
     )
 
   products
-    .command('context')
-    .description('Get buyer-facing product context')
-    .argument('<product-id>', 'Product ID')
-    .option('--profile <name>', 'Profile to use')
-    .option('--json', 'Output as JSON')
-    .action(async (productId: string, options: { profile?: string; json?: boolean }) => {
-      try {
-        const client = await getClient(options.profile)
-        output(await client.getCommerceProductContext(productId), { json: options.json })
-      } catch (error) {
-        outputError(error instanceof Error ? error.message : String(error), {
-          json: options.json,
-        })
-        process.exit(1)
-      }
-    })
-
-  products
     .command('create-by-shop')
     .description('Create a product by shop ID using a JSON payload')
     .argument('<shop-id>', 'Shop ID')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { Command } from 'commander'
-import { createAgentsCommand } from './commands/agents.js'
 import { createApiTokensCommand } from './commands/api-tokens.js'
 import { createAppCommand } from './commands/app.js'
 import { createAuthCommand } from './commands/auth.js'
+import { createBuddiesCommand } from './commands/buddies.js'
 import { createChannelsCommand } from './commands/channels.js'
 import { createCloudCommand } from './commands/cloud.js'
 import { createCommerceCommand } from './commands/commerce.js'
@@ -47,7 +47,7 @@ program.addCommand(createAppCommand())
 program.addCommand(createServersCommand())
 program.addCommand(createChannelsCommand())
 program.addCommand(createThreadsCommand())
-program.addCommand(createAgentsCommand())
+program.addCommand(createBuddiesCommand())
 program.addCommand(createListenCommand())
 program.addCommand(createDirectMessagesCommand())
 program.addCommand(createWorkspaceCommand())

--- a/packages/cli/src/utils/client.ts
+++ b/packages/cli/src/utils/client.ts
@@ -1,9 +1,17 @@
 import { ShadowClient, ShadowSocket } from '@shadowob/sdk'
 import { configManager } from '../config/manager.js'
 
+export const DEFAULT_SERVER_URL = 'https://shadowob.com'
+
 interface Config {
   serverUrl: string
   token: string
+}
+
+export function resolveServerFlag(value?: string): string {
+  const server = value ?? process.env.SHADOWOB_SERVER_ID
+  if (!server) throw new Error('Missing server. Pass --server or set SHADOWOB_SERVER_ID.')
+  return server
 }
 
 async function getConfig(profile?: string): Promise<Config> {

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -94,12 +94,27 @@ function formatObject(obj: Record<string, unknown>): void {
       formattedValue = chalk.gray('null')
     } else if (typeof value === 'boolean') {
       formattedValue = value ? chalk.green('true') : chalk.red('false')
-    } else if (typeof value === 'object') {
+    } else if (Array.isArray(value)) {
+      if (value.length > 0 && typeof value[0] === 'object' && value[0] !== null) {
+        console.log(chalk.gray(formattedKey))
+        formatArray(value)
+        continue
+      }
       formattedValue = JSON.stringify(value)
+    } else if (typeof value === 'object') {
+      formattedValue = formatNestedValue(value as Record<string, unknown>)
     } else {
       formattedValue = String(value)
     }
 
     console.log(`${chalk.gray(formattedKey)}  ${formattedValue}`)
   }
+}
+
+function formatNestedValue(obj: Record<string, unknown>): string {
+  const username = (obj.username as string) || (obj.name as string) || (obj.displayName as string)
+  if (username) {
+    return username
+  }
+  return JSON.stringify(obj)
 }

--- a/packages/openclaw-shadowob/skills/shadowob/SKILL.md
+++ b/packages/openclaw-shadowob/skills/shadowob/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shadowob
-description: "Use when live Shadow context or actions are needed: channel/DM history, pins, members, server/channel/workspace/shop/app/agent data, or sending/managing Shadow content via the shadowob CLI."
+description: "Use when live Shadow context or actions are needed: channel/DM history, pins, members, server/channel/workspace/shop/app/buddy data, or sending/managing Shadow content via the shadowob CLI."
 metadata:
   {
     "openclaw":
@@ -18,7 +18,7 @@ allowed-tools: ["exec"]
 Use `shadowob` CLI to interact with Shadow servers.
 
 Activate this skill when you need current Shadow context, such as recent channel or DM history,
-pinned messages, member/server/channel state, workspace/shop/app/agent data, or when you need to
+pinned messages, member/server/channel state, workspace/shop/app/buddy data, or when you need to
 send or manage Shadow content. Prefer narrow `--json` reads before acting.
 
 ## Quickstart
@@ -78,13 +78,13 @@ shadowob servers discover --json
 
 ```bash
 # List channels
-shadowob channels list --server-id <server-id> --json
+shadowob channels list --server <server> --json
 
 # Get channel
 shadowob channels get <channel-id> --json
 
 # Create/Delete
-shadowob channels create --server-id <id> --name <name> [--type text] --json
+shadowob channels create --server <server> --name <name> [--type text] --json
 shadowob channels delete <channel-id>
 
 # Messages
@@ -141,29 +141,29 @@ shadowob dms send <dm-channel-id> --content "text" --json
 shadowob dms delete <dm-channel-id>
 ```
 
-## Agents
+## Buddies
 
 ```bash
-# List agents
-shadowob agents list --json
+# List buddies
+shadowob buddies list --json
 
-# Get agent
-shadowob agents get <agent-id> --json
+# Get buddy
+shadowob buddies get <buddy-id> --json
 
 # Create/Update/Delete
-shadowob agents create --name <name> [--display-name <name>] [--avatar-url <url>] --json
-shadowob agents update <agent-id> [--name <name>] [--display-name <name>] --json
-shadowob agents delete <agent-id>
+shadowob buddies create --name <name> --username <username> [--display-name <name>] [--avatar-url <url>] --json
+shadowob buddies update <buddy-id> [--name <name>] [--display-name <name>] --json
+shadowob buddies delete <buddy-id>
 
 # Control
-shadowob agents start <agent-id>
-shadowob agents stop <agent-id>
+shadowob buddies start <buddy-id>
+shadowob buddies stop <buddy-id>
 
 # Token
-shadowob agents token <agent-id> --json
+shadowob buddies token <buddy-id> --json
 
 # Config
-shadowob agents config <agent-id> --json
+shadowob buddies config <buddy-id> --json
 ```
 
 ## Workspace
@@ -211,7 +211,6 @@ shadowob shop me get --json
 shadowob shop products list <server-id> [--status active] [--keyword <text>] [--limit <n>] --json
 shadowob shop products list-by-shop <shop-id> [--status active] [--limit <n>] --json
 shadowob shop products get <server-id> <product-id> --json
-shadowob shop products context <product-id> --json
 shadowob shop products purchase <shop-id> <product-id> --idempotency-key <unique-operation-id> --json
 
 # Offers, deliverables, and shop assets
@@ -246,7 +245,7 @@ shadowob commerce cards list --channel-id <channel-id> [--keyword <text>] --json
 shadowob commerce cards purchase <message-id> <card-id> --idempotency-key <unique-operation-id> --json
 
 # Purchases, delivery, protected files, and community assets
-shadowob commerce entitlements list [--server-id <server-id>] --json
+shadowob commerce entitlements list [--server <server>] --json
 shadowob commerce entitlements get <entitlement-id> --json
 shadowob commerce entitlements verify <entitlement-id> --json
 shadowob commerce paid-files open <file-id> --json
@@ -277,6 +276,8 @@ shadowob commerce gifts send --recipient-user-id <user-id> --assets '<json-array
 # Server App integrations
 shadowob app list --server <server-id-or-slug> --json
 shadowob app preview --server <server-id-or-slug> --manifest-url <manifest-url> --json
+shadowob app install --server <server-id-or-slug> --manifest-url <manifest-url> --json
+shadowob app uninstall <app-key> --server <server-id-or-slug>
 shadowob app discover --server <server-id-or-slug> --json
 shadowob app inspect <app-key> --server <server-id-or-slug> --json
 shadowob app skills <app-key> --server <server-id-or-slug>
@@ -404,7 +405,7 @@ shadowob marketplace contracts extend <contract-id> --hours <n> --json
 
 ```bash
 # Upload a file
-shadowob media upload --file <path> [--server-id <id>] [--channel-id <id>] --json
+shadowob media upload --file <path> [--server <server>] [--channel-id <id>] --json
 
 # Download a file
 shadowob media download <file-url> [--output <path>]
@@ -414,7 +415,7 @@ shadowob media download <file-url> [--output <path>]
 
 ```bash
 # Search messages
-shadowob search messages --query <text> [--server-id <id>] [--channel-id <id>] [--author-id <id>] [--after <date>] [--before <date>] [--has-attachments] [--limit <n>] --json
+shadowob search messages --query <text> [--server <server>] [--channel-id <id>] [--author-id <id>] [--after <date>] [--before <date>] [--has-attachments] [--limit <n>] --json
 ```
 
 ## Listen (Real-time Events)

--- a/skills/shadow-server-app/example-app/README.md
+++ b/skills/shadow-server-app/example-app/README.md
@@ -39,7 +39,7 @@ Grant a Buddy:
 ```bash
 shadowob app grant demo-desk \
   --server <server-id-or-slug> \
-  --buddy <buddy-agent-id> \
+  --buddy <buddy-id> \
   --permissions demo.tickets:read,demo.tickets:write,demo.files:write
 ```
 

--- a/skills/shadowob-cli/SKILL.md
+++ b/skills/shadowob-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shadowob
-description: "Use when live Shadow context or actions are needed: channel/DM history, pins, members, server/channel/workspace/shop/app/agent data, or sending/managing Shadow content via the shadowob CLI."
+description: "Use when live Shadow context or actions are needed: channel/DM history, pins, members, server/channel/workspace/shop/app/buddy data, or sending/managing Shadow content via the shadowob CLI."
 metadata:
   {
     "openclaw":
@@ -18,7 +18,7 @@ allowed-tools: ["exec"]
 Use `shadowob` CLI to interact with Shadow servers.
 
 Activate this skill when you need current Shadow context, such as recent channel or DM history,
-pinned messages, member/server/channel state, workspace/shop/app/agent data, or when you need to
+pinned messages, member/server/channel state, workspace/shop/app/buddy data, or when you need to
 send or manage Shadow content. Prefer narrow `--json` reads before acting.
 
 ## Quickstart
@@ -78,13 +78,13 @@ shadowob servers discover --json
 
 ```bash
 # List channels
-shadowob channels list --server-id <server-id> --json
+shadowob channels list --server <server> --json
 
 # Get channel
 shadowob channels get <channel-id> --json
 
 # Create/Delete
-shadowob channels create --server-id <id> --name <name> [--type text] --json
+shadowob channels create --server <server> --name <name> [--type text] --json
 shadowob channels delete <channel-id>
 
 # Messages
@@ -141,29 +141,29 @@ shadowob dms send <dm-channel-id> --content "text" --json
 shadowob dms delete <dm-channel-id>
 ```
 
-## Agents
+## Buddies
 
 ```bash
-# List agents
-shadowob agents list --json
+# List buddies
+shadowob buddies list --json
 
-# Get agent
-shadowob agents get <agent-id> --json
+# Get buddy
+shadowob buddies get <buddy-id> --json
 
 # Create/Update/Delete
-shadowob agents create --name <name> [--display-name <name>] [--avatar-url <url>] --json
-shadowob agents update <agent-id> [--name <name>] [--display-name <name>] --json
-shadowob agents delete <agent-id>
+shadowob buddies create --name <name> --username <username> [--display-name <name>] [--avatar-url <url>] --json
+shadowob buddies update <buddy-id> [--name <name>] [--display-name <name>] --json
+shadowob buddies delete <buddy-id>
 
 # Control
-shadowob agents start <agent-id>
-shadowob agents stop <agent-id>
+shadowob buddies start <buddy-id>
+shadowob buddies stop <buddy-id>
 
 # Token
-shadowob agents token <agent-id> --json
+shadowob buddies token <buddy-id> --json
 
 # Config
-shadowob agents config <agent-id> --json
+shadowob buddies config <buddy-id> --json
 ```
 
 ## Workspace
@@ -211,7 +211,6 @@ shadowob shop me get --json
 shadowob shop products list <server-id> [--status active] [--keyword <text>] [--limit <n>] --json
 shadowob shop products list-by-shop <shop-id> [--status active] [--limit <n>] --json
 shadowob shop products get <server-id> <product-id> --json
-shadowob shop products context <product-id> --json
 shadowob shop products purchase <shop-id> <product-id> --idempotency-key <unique-operation-id> --json
 
 # Offers, deliverables, and shop assets
@@ -246,7 +245,7 @@ shadowob commerce cards list --channel-id <channel-id> [--keyword <text>] --json
 shadowob commerce cards purchase <message-id> <card-id> --idempotency-key <unique-operation-id> --json
 
 # Purchases, delivery, protected files, and community assets
-shadowob commerce entitlements list [--server-id <server-id>] --json
+shadowob commerce entitlements list [--server <server>] --json
 shadowob commerce entitlements get <entitlement-id> --json
 shadowob commerce entitlements verify <entitlement-id> --json
 shadowob commerce paid-files open <file-id> --json
@@ -277,6 +276,8 @@ shadowob commerce gifts send --recipient-user-id <user-id> --assets '<json-array
 # Server App integrations
 shadowob app list --server <server-id-or-slug> --json
 shadowob app preview --server <server-id-or-slug> --manifest-url <manifest-url> --json
+shadowob app install --server <server-id-or-slug> --manifest-url <manifest-url> --json
+shadowob app uninstall <app-key> --server <server-id-or-slug>
 shadowob app discover --server <server-id-or-slug> --json
 shadowob app inspect <app-key> --server <server-id-or-slug> --json
 shadowob app skills <app-key> --server <server-id-or-slug>
@@ -404,7 +405,7 @@ shadowob marketplace contracts extend <contract-id> --hours <n> --json
 
 ```bash
 # Upload a file
-shadowob media upload --file <path> [--server-id <id>] [--channel-id <id>] --json
+shadowob media upload --file <path> [--server <server>] [--channel-id <id>] --json
 
 # Download a file
 shadowob media download <file-url> [--output <path>]
@@ -414,7 +415,7 @@ shadowob media download <file-url> [--output <path>]
 
 ```bash
 # Search messages
-shadowob search messages --query <text> [--server-id <id>] [--channel-id <id>] [--author-id <id>] [--after <date>] [--before <date>] [--has-attachments] [--limit <n>] --json
+shadowob search messages --query <text> [--server <server>] [--channel-id <id>] [--author-id <id>] [--after <date>] [--before <date>] [--has-attachments] [--limit <n>] --json
 ```
 
 ## Listen (Real-time Events)

--- a/website/docs/en/platform/cli.md
+++ b/website/docs/en/platform/cli.md
@@ -29,7 +29,7 @@ shadowob channels send <channel-id> --content "Hello from CLI"
 - `auth` — login/logout/profile management
 - `servers` / `channels` / `threads` / `dms` — communication features
 - `friends` / `invites` / `notifications` — social features
-- `agents` / `marketplace` — AI agent ecosystem
+- `buddies` / `marketplace` — AI buddy ecosystem
 - `workspace` / `apps` / `app` / `shop` / `commerce` — platform workflows
 - `media` — file upload and download
 - `search` — search messages
@@ -104,7 +104,7 @@ Shop commands cover seller-side shelves, offers, deliverables, assets, and scope
 
 ```bash
 shadowob shop me get --json
-shadowob shop products context <product-id> --json
+shadowob commerce products context <product-id> --json
 shadowob shop products list-by-shop <shop-id> --status active --limit 20 --json
 shadowob shop offers list <shop-id> --json
 shadowob shop offers deliverables create <shop-id> <offer-id> --data '{"kind":"paid_file","resourceId":"file-id"}' --json
@@ -154,7 +154,10 @@ shadowob app preview --server <server-id-or-slug> --manifest-url https://app.exa
 
 # Install and grant Buddy access
 shadowob app install --server <server-id-or-slug> --manifest-url https://app.example.com/.well-known/shadow-app.json --json
-shadowob app grant demo-desk --server <server-id-or-slug> --buddy <buddy-agent-id> --permissions demo.tickets:write --json
+shadowob app grant demo-desk --server <server-id-or-slug> --buddy <buddy-id> --permissions demo.tickets:write --json
+
+# Uninstall an App
+shadowob app uninstall demo-desk --server <server-id-or-slug>
 
 # Discover Skills and call commands
 shadowob app discover --server <server-id-or-slug> --json

--- a/website/docs/en/platform/server-apps-dev-guide.md
+++ b/website/docs/en/platform/server-apps-dev-guide.md
@@ -110,7 +110,8 @@ Admins use the Apps page in server settings to choose a catalog App or review a 
 ```bash
 shadowob app preview --server <server-id-or-slug> --manifest-url https://app.example.com/.well-known/shadow-app.json
 shadowob app install --server <server-id-or-slug> --manifest-url https://app.example.com/.well-known/shadow-app.json
-shadowob app grant demo-desk --server <server-id-or-slug> --buddy <buddy-agent-id> --permissions tickets:write
+shadowob app grant demo-desk --server <server-id-or-slug> --buddy <buddy-id> --permissions tickets:write
+shadowob app uninstall demo-desk --server <server-id-or-slug>
 ```
 
 When a Buddy is triggered in a channel, Shadow injects the mentioned App Skills and the Buddy calls through the unified CLI:

--- a/website/docs/en/platform/server-apps.md
+++ b/website/docs/en/platform/server-apps.md
@@ -20,7 +20,7 @@ Command calls use short-lived opaque Shadow-issued OAuth Bearer tokens. The App 
 ```bash
 shadowob app grant demo-desk \
   --server <server-id-or-slug> \
-  --buddy <buddy-agent-id> \
+  --buddy <buddy-id> \
   --permissions demo.tickets:read,demo.tickets:write
 ```
 

--- a/website/docs/zh/platform/cli.md
+++ b/website/docs/zh/platform/cli.md
@@ -29,7 +29,7 @@ shadowob channels send <channel-id> --content "Hello from CLI"
 - `auth`：登录/登出/配置切换
 - `servers` / `channels` / `threads` / `dms`：沟通能力
 - `friends` / `invites` / `notifications`：社交功能
-- `agents` / `marketplace`：AI 代理生态
+- `buddies` / `marketplace`：AI 伙伴生态
 - `workspace` / `apps` / `app` / `shop` / `commerce`：平台业务能力
 - `media`：文件上传和下载
 - `search`：消息搜索
@@ -103,7 +103,7 @@ shadowob commerce tips send --recipient-user-id <user-id> --amount 100 --message
 
 ```bash
 shadowob shop me get --json
-shadowob shop products context <product-id> --json
+shadowob commerce products context <product-id> --json
 shadowob shop products list-by-shop <shop-id> --status active --limit 20 --json
 shadowob shop offers list <shop-id> --json
 shadowob shop offers deliverables create <shop-id> <offer-id> --data '{"kind":"paid_file","resourceId":"file-id"}' --json
@@ -153,7 +153,10 @@ shadowob app preview --server <server-id-or-slug> --manifest-url https://app.exa
 
 # 安装并授予 Buddy 权限
 shadowob app install --server <server-id-or-slug> --manifest-url https://app.example.com/.well-known/shadow-app.json --json
-shadowob app grant demo-desk --server <server-id-or-slug> --buddy <buddy-agent-id> --permissions demo.tickets:write --json
+shadowob app grant demo-desk --server <server-id-or-slug> --buddy <buddy-id> --permissions demo.tickets:write --json
+
+# 卸载 App
+shadowob app uninstall demo-desk --server <server-id-or-slug>
 
 # 发现 Skills 并调用命令
 shadowob app discover --server <server-id-or-slug> --json

--- a/website/docs/zh/platform/server-apps-dev-guide.md
+++ b/website/docs/zh/platform/server-apps-dev-guide.md
@@ -110,7 +110,8 @@ Buddy 通过 CLI 修改资源后，Shadow 会发出 `server_app.command.complete
 ```bash
 shadowob app preview --server <server-id-or-slug> --manifest-url https://app.example.com/.well-known/shadow-app.json
 shadowob app install --server <server-id-or-slug> --manifest-url https://app.example.com/.well-known/shadow-app.json
-shadowob app grant demo-desk --server <server-id-or-slug> --buddy <buddy-agent-id> --permissions tickets:write
+shadowob app grant demo-desk --server <server-id-or-slug> --buddy <buddy-id> --permissions tickets:write
+shadowob app uninstall demo-desk --server <server-id-or-slug>
 ```
 
 Buddy 在频道里被触发时会收到被 @ App 的 Skills 文档，并通过统一 CLI 调用：

--- a/website/docs/zh/platform/server-apps.md
+++ b/website/docs/zh/platform/server-apps.md
@@ -20,7 +20,7 @@ App 是服务器级别的。一个服务器可以安装多个 App，每个 Buddy
 ```bash
 shadowob app grant demo-desk \
   --server <server-id-or-slug> \
-  --buddy <buddy-agent-id> \
+  --buddy <buddy-id> \
   --permissions demo.tickets:read,demo.tickets:write
 ```
 


### PR DESCRIPTION
## Summary

Fixes 10+ CLI issues discovered during exploration testing.

### Bug Fixes
- **Fix `servers list` [object Object]**: Flatten nested API response before formatting (`servers.ts`)
- **Fix `discover/marketplace/shop` raw JSON output**: Enhanced `formatObject()` to table-format nested arrays (`output.ts`)
- **Fix `channels send` author field**: `formatNestedValue()` extracts username from nested objects (`output.ts`)
- **Fix `app list` missing appKey**: Show `appKey (name)` in non-JSON output (`app.ts`)

### Consistency
- **Default `--server-url`**: `auth login` now defaults to `https://shadowob.com` (`auth.ts`)
- **Unify `--server-id`→`--server`**: All commands now use `--server` with `SHADOWOB_SERVER_ID` env fallback (`channels.ts`, `commerce.ts`, `search.ts`, `app.ts`, `client.ts`)

### New Features
- **`app uninstall`**: New command to uninstall server Apps (SDK `deleteServerApp` exists) (`app.ts`)
- **`buddies`**: Rename `agents`→`buddies` (`buddies.ts`, `index.ts`)

### Cleanup
- **Delete `agents.ts`**: Replaced by `buddies.ts`
- **Remove `shop products context`**: Duplicate of `commerce products context` (`shop.ts`)
- **Fix `servers members`**: Show username+role instead of userId (`servers.ts`)

### Docs Sync
- Website CLI docs (en+zh): updated command references, `--buddy <buddy-id>`, new `app uninstall`
- Server-apps docs (en+zh): updated buddy flag
- Skills (shadowob-cli + openclaw-shadowob): full sync with new command names
- `docs/api/commerce-product-context.md`: removed dup `shop products context`

### Verification
- TypeScript typecheck: pass
- Biome format: pass
- 10 runtime API tests all verified with local server