### PR TITLE
[codex] Harden code trainer integration access

### DIFF
--- a/apps/server/__tests__/app-integration-handler.test.ts
+++ b/apps/server/__tests__/app-integration-handler.test.ts
@@ -202,4 +202,28 @@ describe('app integration handler', () => {
       }),
     )
   })
+
+  it('accepts null optional command context from launch frames', async () => {
+    const service = {
+      callCommand: vi.fn().mockResolvedValue({ ok: true, result: { tickets: [] } }),
+    }
+    const app = createTestApp(service)
+
+    const response = await app.request('/api/servers/srv-1/apps/demo-desk/commands/tickets.list', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ input: { limit: 5 }, channelId: null, task: null }),
+    })
+
+    expect(response.status).toBe(200)
+    const call = service.callCommand.mock.calls[0]?.[0] as {
+      body: { input?: unknown; channelId?: string; task?: unknown }
+    }
+    expect(call.body.input).toEqual({ limit: 5 })
+    expect(call.body.channelId).toBeUndefined()
+    expect(call.body.task).toBeUndefined()
+  })
 })

--- a/apps/server/src/validators/app-integration.schema.ts
+++ b/apps/server/src/validators/app-integration.schema.ts
@@ -240,10 +240,14 @@ const serverAppTaskContextSchema = z.object({
   claimId: z.string().uuid().optional(),
 })
 
+function optionalNullable<T extends z.ZodTypeAny>(schema: T) {
+  return z.preprocess((value) => (value === null ? undefined : value), schema.optional())
+}
+
 export const callServerAppCommandSchema = z.object({
   input: z.unknown().optional(),
-  channelId: z.string().uuid().optional(),
-  task: serverAppTaskContextSchema.optional(),
+  channelId: optionalNullable(z.string().uuid()),
+  task: optionalNullable(serverAppTaskContextSchema),
 })
 
 export type ServerAppManifestInput = z.infer<typeof serverAppManifestSchema>

--- a/integrations/trainer/README.md
+++ b/integrations/trainer/README.md
@@ -9,6 +9,25 @@ pnpm -C integrations/trainer dev
 
 Open `http://localhost:4213/shadow/server`.
 
+## Architecture
+
+- `src/server.ts` defines Shadow Server App commands, OAuth command context handling, Buddy task outbox creation, and local-dev command fallback.
+- `src/data.ts` owns normalization, JSON persistence, seed data, owner scoping, and submission access policy.
+- `src/sources.ts` imports public LeetCode and Codeforces problems into the current owner scope.
+- `src/client/` contains the embedded React practice workspace.
+- `shadow-app.local.json` is the source manifest; `src/shadow-app.generated.ts` is generated with `pnpm -C integrations/trainer typegen`.
+
+## Data Isolation
+
+The app treats authentication and authorization separately. Shadow's OAuth command context identifies the current actor and provides `serverId`, `userId`, `buddyAgentId`, and `ownerId`.
+
+- Built-in seed challenges are global read-only practice material.
+- Imported or published challenges are stored under `serverId:userId`.
+- Submissions are always stored under the learner owner's `serverId:userId`.
+- Buddy actors resolve to their owner's scope through `ownerId`.
+- A Buddy can read or analyze a submission only when the submission belongs to the same owner scope and the submission was assigned to that Buddy's `buddyAgentId`.
+- Buddy actors cannot import or publish challenges.
+
 Commands:
 
 - `challenges.list`
@@ -22,4 +41,4 @@ Commands:
 - `submissions.pending`
 - `submissions.analyze`
 
-Challenges, imported source metadata, submissions, and Buddy review requests persist through `TRAINER_DATA_FILE`.
+Challenges, imported source metadata, submissions, owner scope metadata, and Buddy review requests persist through `TRAINER_DATA_FILE`.

--- a/integrations/trainer/shadow-app.local.json
+++ b/integrations/trainer/shadow-app.local.json
@@ -37,6 +37,11 @@
           },
           "difficulty": {
             "enum": ["easy", "medium", "hard"]
+          },
+          "tag": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 40
           }
         },
         "additionalProperties": false
@@ -153,7 +158,7 @@
         "type": "object",
         "properties": {
           "provider": {
-            "enum": ["exercism", "leetcode", "codeforces"]
+            "enum": ["leetcode", "codeforces"]
           },
           "query": {
             "type": "string",
@@ -186,7 +191,7 @@
         "required": ["sourceId"],
         "properties": {
           "provider": {
-            "enum": ["exercism", "leetcode", "codeforces"]
+            "enum": ["leetcode", "codeforces"]
           },
           "sourceId": {
             "type": "string",
@@ -243,6 +248,24 @@
               },
               "reviewFocus": {
                 "enum": ["standard", "interview", "debug", "complexity"]
+              },
+              "coachingFocuses": {
+                "type": "array",
+                "maxItems": 8,
+                "items": {
+                  "enum": [
+                    "reasoning",
+                    "edge_cases",
+                    "complexity",
+                    "communication",
+                    "follow_ups",
+                    "debugging"
+                  ]
+                }
+              },
+              "locale": {
+                "type": "string",
+                "maxLength": 32
               }
             },
             "additionalProperties": false

--- a/integrations/trainer/src/client/api.ts
+++ b/integrations/trainer/src/client/api.ts
@@ -10,6 +10,7 @@ import {
 import type {
   Challenge,
   CodeSubmission,
+  SubmissionCoachingFocus,
   SubmissionOutcome,
   SubmissionReviewFocus,
 } from '../types.js'
@@ -36,7 +37,7 @@ export type InboxDelivery = ShadowServerAppInboxDelivery
 export type InboxDeliveryError = ShadowServerAppInboxDeliveryError
 
 export interface ProblemSource {
-  provider: 'exercism' | 'leetcode' | 'codeforces'
+  provider: 'leetcode' | 'codeforces'
   id: string
   title: string
   difficulty?: Challenge['difficulty']
@@ -89,7 +90,11 @@ export async function listBuddyInboxes() {
   return bridge.inboxes() as Promise<{ inboxes: BuddyInboxOption[] }>
 }
 
-export function listChallenges(input: { query?: string; difficulty?: Challenge['difficulty'] }) {
+export function listChallenges(input: {
+  query?: string
+  difficulty?: Challenge['difficulty']
+  tag?: string
+}) {
   return command<{ challenges: Challenge[] }>('challenges.list', input)
 }
 
@@ -140,6 +145,8 @@ export function createSubmission(input: {
     assigneeLabel?: string
     displayName?: string
     reviewFocus?: SubmissionReviewFocus
+    coachingFocuses?: SubmissionCoachingFocus[]
+    locale?: string
   }
 }) {
   return command<{

--- a/integrations/trainer/src/client/main.tsx
+++ b/integrations/trainer/src/client/main.tsx
@@ -18,13 +18,10 @@ import {
   useNavigate,
 } from '@tanstack/react-router'
 import clsx from 'clsx'
-import gsap from 'gsap'
-import { ScrollTrigger } from 'gsap/ScrollTrigger'
 import {
   ArrowRight,
   BookOpen,
   Bot,
-  Brain,
   CheckCircle2,
   ChevronDown,
   ChevronUp,
@@ -34,23 +31,25 @@ import {
   ExternalLink,
   FileText,
   History,
-  Layers3,
   Lightbulb,
-  ListChecks,
   Loader2,
   Plus,
   RotateCcw,
   Search,
   Send,
-  Sparkles,
-  Target,
   TerminalSquare,
 } from 'lucide-react'
-import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import type { Challenge, CodeSubmission, SubmissionReviewFocus, TrainerLanguage } from '../types.js'
+import type {
+  Challenge,
+  CodeSubmission,
+  SubmissionCoachingFocus,
+  SubmissionReviewFocus,
+  TrainerLanguage,
+} from '../types.js'
 import {
   type BuddyInboxOption,
   createSubmission,
@@ -82,18 +81,6 @@ type ReviewFocusOption = {
   hint: string
 }
 type ProblemSourceProvider = ProblemSource['provider']
-type StudyTrack = {
-  id: string
-  title: string
-  principle: string
-  theory: string
-  invariant: string
-  template: string[]
-  pitfalls: string[]
-  checkpoint: string
-  tags: string[]
-  buddyDrill: string
-}
 
 const queryClient = new QueryClient()
 const languageOptions: LanguageOption[] = [
@@ -103,6 +90,7 @@ const languageOptions: LanguageOption[] = [
 ]
 const reviewerStorageKey = 'shadow-trainer:preferred-reviewer'
 const reviewFocusStorageKey = 'shadow-trainer:review-focus'
+const coachingFocusStorageKey = 'shadow-trainer:coaching-focuses'
 const reviewFocusOptions: ReviewFocusOption[] = [
   {
     value: 'standard',
@@ -126,16 +114,53 @@ const reviewFocusOptions: ReviewFocusOption[] = [
   },
 ]
 const defaultReviewFocusOption = reviewFocusOptions[0] as ReviewFocusOption
+const defaultCoachingFocuses: SubmissionCoachingFocus[] = [
+  'reasoning',
+  'edge_cases',
+  'complexity',
+  'communication',
+]
+const coachingFocusOptions: Array<{
+  value: SubmissionCoachingFocus
+  label: string
+  hint: string
+}> = [
+  {
+    value: 'reasoning',
+    label: 'Reasoning',
+    hint: 'invariant and proof path',
+  },
+  {
+    value: 'edge_cases',
+    label: 'Edge cases',
+    hint: 'boundary inputs and counterexamples',
+  },
+  {
+    value: 'complexity',
+    label: 'Complexity',
+    hint: 'time, space, and tradeoffs',
+  },
+  {
+    value: 'communication',
+    label: 'Communication',
+    hint: 'clear spoken answer structure',
+  },
+  {
+    value: 'follow_ups',
+    label: 'Follow-ups',
+    hint: 'realistic interview extensions',
+  },
+  {
+    value: 'debugging',
+    label: 'Debugging',
+    hint: 'trace the first wrong state',
+  },
+]
 const problemSourceOptions: Array<{
   value: ProblemSourceProvider
   label: string
   hint: string
 }> = [
-  {
-    value: 'exercism',
-    label: 'Exercism',
-    hint: 'open statements and canonical JSON tests',
-  },
   {
     value: 'leetcode',
     label: 'LeetCode',
@@ -149,212 +174,6 @@ const problemSourceOptions: Array<{
 ]
 const defaultProblemSourceOption = problemSourceOptions[0] as (typeof problemSourceOptions)[number]
 const problemSourcePageSize = 24
-const studyTracks: StudyTrack[] = [
-  {
-    id: 'array-hash',
-    title: 'Array and Hashing',
-    principle: 'Turn repeated lookup into stored state, then prove what each map entry means.',
-    theory:
-      'Array problems usually become easier when you name the information you wish you already had. Hash maps make that information constant-time state.',
-    invariant:
-      'Before index i is processed, the map contains exactly the values from earlier indices and the answer has not appeared among them.',
-    template: [
-      'Define the value you need to find later.',
-      'Check the stored state before writing the current item.',
-      'Store enough information to reconstruct the answer.',
-    ],
-    pitfalls: [
-      'Storing values instead of indices',
-      'Using the same element twice',
-      'Updating state before checking the complement',
-    ],
-    checkpoint: 'Explain why the map contents are sufficient and why no earlier pair was skipped.',
-    tags: ['hash-map', 'hash-table', 'hashing'],
-    buddyDrill: 'Ask Buddy to make you state the invariant before debugging the code.',
-  },
-  {
-    id: 'stack-parsing',
-    title: 'Stack and Parsing',
-    principle:
-      'Model the most recent unresolved choice, then pop only when the matching fact appears.',
-    theory:
-      'A stack is a memory of unfinished obligations. It is useful when the next valid action depends on the most recent unmatched item.',
-    invariant:
-      'After each character or token, the stack contains unmatched openings in the exact order they still need to be closed.',
-    template: [
-      'Classify each token as opening, closing, or ignorable.',
-      'Push openings with the metadata needed for matching.',
-      'On closing, fail fast if the top item does not match.',
-    ],
-    pitfalls: [
-      'Counting symbols without order',
-      'Calling pop on an empty stack without intent',
-      'Forgetting the final empty-stack check',
-    ],
-    checkpoint: 'Trace one failing case and point to the first token where the invariant breaks.',
-    tags: ['stack', 'parsing', 'bracket', 'parentheses'],
-    buddyDrill: 'Ask Buddy for one smallest counterexample and one whiteboard trace.',
-  },
-  {
-    id: 'two-pointers',
-    title: 'Two Pointers and Windows',
-    principle: 'Move boundaries because a monotonic fact proves which candidates can be discarded.',
-    theory:
-      'Two pointers are not just two indices. They encode a shrinking or sliding search space where each movement discards impossible states.',
-    invariant:
-      'At every step, all discarded positions are provably unable to improve the current answer.',
-    template: [
-      'State the sorted, monotonic, or window condition.',
-      'Move the boundary that can no longer help.',
-      'Update the answer only when the window is valid.',
-    ],
-    pitfalls: [
-      'Moving both pointers without proof',
-      'Letting the window become invalid silently',
-      'Confusing inclusive and exclusive bounds',
-    ],
-    checkpoint: 'Justify one pointer movement using only the problem constraints, not intuition.',
-    tags: ['two-pointers', 'sliding-window', 'window'],
-    buddyDrill: 'Ask Buddy to challenge every pointer movement with why it is safe.',
-  },
-  {
-    id: 'search-order',
-    title: 'Binary Search and Ordered Decisions',
-    principle:
-      'Define the predicate first, then search the first or last position where it changes.',
-    theory:
-      'Binary search applies to ordered answers, not just arrays. The hard part is proving the predicate flips once.',
-    invariant:
-      'The answer is always inside the current interval, and each update removes a side that cannot contain the boundary.',
-    template: [
-      'Write the predicate in one sentence.',
-      'Choose first true or last true before coding.',
-      'Use one interval convention and preserve it every loop.',
-    ],
-    pitfalls: [
-      'Searching a predicate that is not monotonic',
-      'Mixing inclusive and exclusive bounds',
-      'Returning mid instead of the maintained answer',
-    ],
-    checkpoint: 'Draw the true/false boundary and say which side each branch removes.',
-    tags: ['binary-search', 'search'],
-    buddyDrill: 'Ask Buddy to review predicate design and off-by-one cases before code style.',
-  },
-  {
-    id: 'graphs-trees',
-    title: 'Trees and Graphs',
-    principle:
-      'Choose traversal state deliberately: visited set, parent relation, depth, or accumulated path.',
-    theory:
-      'Graph problems are state design problems. The traversal is only correct when the carried state matches the property being asked.',
-    invariant:
-      'Every queued or recursive node has a well-defined reason for being visited and the state attached to it is still valid.',
-    template: [
-      'Choose DFS, BFS, or topological order from the question.',
-      'Store visited state at the right granularity.',
-      'Separate graph construction from traversal logic.',
-    ],
-    pitfalls: [
-      'Marking visited too late',
-      'Forgetting disconnected components',
-      'Treating directed and undirected edges the same',
-    ],
-    checkpoint: 'Describe what a visited entry means and when it becomes true.',
-    tags: ['tree', 'graph', 'dfs', 'bfs'],
-    buddyDrill: 'Ask Buddy to generate one cycle case and one disconnected case.',
-  },
-  {
-    id: 'dynamic-programming',
-    title: 'Dynamic Programming',
-    principle: 'Name the subproblem, prove the transition, then choose memoization or table order.',
-    theory:
-      'Dynamic programming caches repeated decisions. The key is to make each state small enough to reuse and complete enough to decide.',
-    invariant:
-      'When a state is read, every dependency needed by its recurrence has already been solved or memoized.',
-    template: [
-      'Name the state with parameters and meaning.',
-      'List choices that transition into smaller states.',
-      'Pick memoization or table order from dependency direction.',
-    ],
-    pitfalls: [
-      'Adding dimensions without meaning',
-      'Returning the recurrence before defining the base cases',
-      'Using a table order that reads future values',
-    ],
-    checkpoint:
-      'Say the state definition and recurrence without code, then test it on a tiny input.',
-    tags: ['dynamic-programming', 'dp'],
-    buddyDrill: 'Ask Buddy to explain the recurrence without giving the final implementation.',
-  },
-  {
-    id: 'greedy-intervals',
-    title: 'Greedy and Intervals',
-    principle: 'Find the exchange argument: why the local choice cannot make the future worse.',
-    theory:
-      'Greedy works when a local decision can be exchanged into an optimal solution without harming the future.',
-    invariant:
-      'After each choice, there exists an optimal solution that agrees with all choices made so far.',
-    template: [
-      'Sort by the property that makes future choices easiest.',
-      'Choose the local item and name what it preserves.',
-      'Prove skipped alternatives cannot lead to a better result.',
-    ],
-    pitfalls: [
-      'Sorting by a plausible but unproved field',
-      'Confusing earliest start with earliest finish',
-      'Missing equal-value tie handling',
-    ],
-    checkpoint: 'Give Buddy a counterexample attempt and explain why the greedy rule survives it.',
-    tags: ['greedy', 'interval', 'sorting'],
-    buddyDrill: 'Ask Buddy for a failed greedy counterexample before accepting the rule.',
-  },
-  {
-    id: 'math-implementation',
-    title: 'Math and Implementation',
-    principle:
-      'Reduce the rule to constraints, parity, divisibility, bounds, or careful simulation.',
-    theory:
-      'Math implementation problems punish vague reasoning. Translate each constraint into a small rule before writing loops.',
-    invariant:
-      'Every transformation preserves the original answer, or every simulation step matches the statement exactly.',
-    template: [
-      'Extract constraints and derive the smallest reusable rule.',
-      'Decide whether proof, formula, or bounded simulation is enough.',
-      'Write edge cases before performance optimizations.',
-    ],
-    pitfalls: [
-      'Ignoring integer bounds',
-      'Overfitting sample tests',
-      'Mixing one-based statement math with zero-based code',
-    ],
-    checkpoint: 'Separate parsing, formula, and proof in your explanation before coding.',
-    tags: ['math', 'simulation', 'implementation', 'brute force'],
-    buddyDrill: 'Ask Buddy to separate formula reasoning from input parsing mistakes.',
-  },
-]
-
-const generalStudyTrack: StudyTrack = {
-  id: 'general',
-  title: 'Mixed Review',
-  principle: 'Use uncategorized problems to discover weak patterns and route them into a track.',
-  theory:
-    'A mixed set is useful only after you classify each miss. Treat every attempt as evidence for which principle needs more practice.',
-  invariant:
-    'Every reviewed problem should leave behind one named pattern, one failure mode, and one next drill.',
-  template: [
-    'Solve once without hints.',
-    'Ask Buddy to classify the underlying pattern.',
-    'Move the problem into the closest study path mentally before retrying.',
-  ],
-  pitfalls: [
-    'Random practice without notes',
-    'Only reading accepted solutions',
-    'Not retrying after feedback',
-  ],
-  checkpoint: 'Write the pattern name and the reason your first attempt failed.',
-  tags: [],
-  buddyDrill: 'Ask Buddy which pattern this problem belongs to before solving.',
-}
 
 const rootRoute = createRootRoute({
   component: RootLayout,
@@ -376,12 +195,6 @@ const submissionsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/submissions',
   component: SubmissionsPage,
-})
-
-const studyRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: '/study',
-  component: StudyPage,
 })
 
 const importRoute = createRoute({
@@ -417,7 +230,6 @@ const submissionWaitingRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   indexRoute,
   problemsRoute,
-  studyRoute,
   submissionsRoute,
   importRoute,
   problemRoute,
@@ -455,9 +267,6 @@ function RootLayout() {
         <nav className="nav">
           <Link activeProps={{ className: 'active' }} to="/problems">
             Problems
-          </Link>
-          <Link activeProps={{ className: 'active' }} to="/study">
-            Study
           </Link>
           <Link activeProps={{ className: 'active' }} to="/submissions">
             Submissions
@@ -497,15 +306,32 @@ function SubmissionWaitingRoutePage() {
 function ProblemsPage() {
   const [query, setQuery] = useState('')
   const [difficulty, setDifficulty] = useState<Challenge['difficulty'] | 'all'>('all')
+  const [tag, setTag] = useState('all')
+  const tagsQuery = useQuery({
+    queryKey: ['challenges', 'tag-options'],
+    queryFn: () => listChallenges({}),
+  })
   const challengesQuery = useQuery({
-    queryKey: ['challenges', query, difficulty],
+    queryKey: ['challenges', query, difficulty, tag],
     queryFn: () =>
       listChallenges({
         query: query.trim() || undefined,
         difficulty: difficulty === 'all' ? undefined : difficulty,
+        tag: tag === 'all' ? undefined : tag,
       }),
   })
   const challenges = challengesQuery.data?.challenges ?? []
+  const tagOptions = useMemo(
+    () =>
+      [
+        ...new Set(
+          (tagsQuery.data?.challenges ?? []).flatMap((challenge) =>
+            visibleChallengeTags(challenge),
+          ),
+        ),
+      ].sort((a, b) => a.localeCompare(b)),
+    [tagsQuery.data?.challenges],
+  )
 
   return (
     <main className="libraryPage">
@@ -537,6 +363,29 @@ function ProblemsPage() {
         ))}
       </div>
 
+      {tagOptions.length ? (
+        <div className="tagFilterBar" aria-label="Problem type">
+          <span>Type</span>
+          <button
+            className={clsx('segmentedButton', tag === 'all' && 'active')}
+            type="button"
+            onClick={() => setTag('all')}
+          >
+            All types
+          </button>
+          {tagOptions.map((item) => (
+            <button
+              className={clsx('segmentedButton', tag === item && 'active')}
+              key={item}
+              type="button"
+              onClick={() => setTag(item)}
+            >
+              {item}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
       {challengesQuery.isLoading ? (
         <EmptyState icon={<Loader2 className="spinIcon" />} title="Loading problems" />
       ) : challenges.length ? (
@@ -559,276 +408,13 @@ function ProblemsPage() {
   )
 }
 
-function StudyPage() {
-  const studyRef = useRef<HTMLElement>(null)
-  const [activeTrackId, setActiveTrackId] = useState(studyTracks[0]?.id ?? 'array-hash')
-  const challengesQuery = useQuery({
-    queryKey: ['challenges', 'study'],
-    queryFn: () => listChallenges({}),
-  })
-  const submissionsQuery = useQuery({
-    queryKey: ['submissions', 'study'],
-    queryFn: () => listSubmissions({ limit: 100 }),
-  })
-  const challenges = challengesQuery.data?.challenges ?? []
-  const acceptedChallengeIds = useMemo(
-    () =>
-      new Set(
-        (submissionsQuery.data?.submissions ?? [])
-          .filter((submission) => submission.analysis?.outcome === 'accepted')
-          .map((submission) => submission.challengeId),
-      ),
-    [submissionsQuery.data?.submissions],
-  )
-  const trackByChallengeId = useMemo(() => {
-    return new Map(
-      challenges.map((challenge) => [challenge.id, firstMatchingTrackId(challenge)] as const),
-    )
-  }, [challenges])
-  const uncategorized = useMemo(() => {
-    return challenges.filter((challenge) => !trackByChallengeId.get(challenge.id))
-  }, [challenges, trackByChallengeId])
-  const tracks = useMemo(
-    () => (uncategorized.length ? [...studyTracks, generalStudyTrack] : studyTracks),
-    [uncategorized.length],
-  )
-  const activeTrack = tracks.find((track) => track.id === activeTrackId) ?? tracks[0]
-  const activeTrackChallenges = useMemo(() => {
-    if (!activeTrack) return []
-    if (activeTrack.id === generalStudyTrack.id) return uncategorized
-    return challenges.filter((challenge) => trackByChallengeId.get(challenge.id) === activeTrack.id)
-  }, [activeTrack, challenges, trackByChallengeId, uncategorized])
-  const activeSolvedCount = activeTrackChallenges.filter((challenge) =>
-    acceptedChallengeIds.has(challenge.id),
-  ).length
-  const continueChallenge =
-    activeTrackChallenges.find((challenge) => !acceptedChallengeIds.has(challenge.id)) ??
-    activeTrackChallenges[0]
-
-  useStudyMotion(studyRef, activeTrack?.id)
-
-  return (
-    <main className="studyPage" ref={studyRef}>
-      <section className="studyHero motion-reveal">
-        <div className="studyHeroCopy">
-          <p className="eyebrow">Study studio</p>
-          <h1>Learn the principle before the next attempt.</h1>
-          <p>
-            Build the mental model first, solve one focused problem, then let Buddy test the
-            invariant, sandbox cases, and interview explanation.
-          </p>
-        </div>
-        <div className="studyHeroPanel">
-          <span>Progress</span>
-          <strong>
-            {acceptedChallengeIds.size}/{challenges.length || 0}
-          </strong>
-          <p>accepted across the local library</p>
-          <div className="studyPhaseStrip">
-            <span>Theory</span>
-            <span>Drill</span>
-            <span>Review</span>
-          </div>
-        </div>
-      </section>
-
-      {challengesQuery.isLoading ? (
-        <EmptyState icon={<Loader2 className="spinIcon" />} title="Loading study plan" />
-      ) : (
-        <>
-          <section className="studyStudioGrid" aria-label="Study paths">
-            <aside className="studyTrackRail motion-reveal">
-              <div className="railHeader">
-                <h2>Paths</h2>
-                <span>{tracks.length} tracks</span>
-              </div>
-              {tracks.map((track) => {
-                const trackChallenges =
-                  track.id === generalStudyTrack.id
-                    ? uncategorized
-                    : challenges.filter(
-                        (challenge) => trackByChallengeId.get(challenge.id) === track.id,
-                      )
-                const solvedCount = trackChallenges.filter((challenge) =>
-                  acceptedChallengeIds.has(challenge.id),
-                ).length
-                return (
-                  <button
-                    className={clsx('studyTrackButton', activeTrack?.id === track.id && 'active')}
-                    key={track.id}
-                    type="button"
-                    onClick={() => setActiveTrackId(track.id)}
-                  >
-                    <span>
-                      <strong>{track.title}</strong>
-                      <small>{track.principle}</small>
-                    </span>
-                    <em>
-                      {solvedCount}/{trackChallenges.length}
-                    </em>
-                  </button>
-                )
-              })}
-            </aside>
-
-            {activeTrack ? (
-              <section className="theoryStudio" aria-live="polite">
-                <div className="studioHeader motion-reveal">
-                  <div>
-                    <p className="eyebrow">Theory path</p>
-                    <h2>{activeTrack.title}</h2>
-                    <p>{activeTrack.principle}</p>
-                  </div>
-                  {continueChallenge ? (
-                    <Link
-                      className="primaryLink"
-                      params={{ challengeId: continueChallenge.id }}
-                      to="/problems/$challengeId"
-                    >
-                      <Sparkles size={16} />
-                      Start drill
-                    </Link>
-                  ) : (
-                    <Link className="primaryLink" to="/import">
-                      <Download size={16} />
-                      Import drills
-                    </Link>
-                  )}
-                </div>
-
-                <div className="theoryBento">
-                  <article className="theoryTile theoryTileLarge stackMotionCard">
-                    <Brain size={20} />
-                    <h3>Principle</h3>
-                    <p>{activeTrack.theory}</p>
-                  </article>
-                  <article className="theoryTile stackMotionCard">
-                    <Target size={20} />
-                    <h3>Invariant</h3>
-                    <p>{activeTrack.invariant}</p>
-                  </article>
-                  <article className="theoryTile stackMotionCard">
-                    <Layers3 size={20} />
-                    <h3>Template</h3>
-                    <ol>
-                      {activeTrack.template.map((step) => (
-                        <li key={step}>{step}</li>
-                      ))}
-                    </ol>
-                  </article>
-                  <article className="theoryTile stackMotionCard">
-                    <ListChecks size={20} />
-                    <h3>Pitfalls</h3>
-                    <ul>
-                      {activeTrack.pitfalls.map((item) => (
-                        <li key={item}>{item}</li>
-                      ))}
-                    </ul>
-                  </article>
-                  <article className="theoryTile buddyTheoryTile stackMotionCard">
-                    <Bot size={20} />
-                    <h3>Buddy coaching</h3>
-                    <p>{activeTrack.buddyDrill}</p>
-                    <p>{activeTrack.checkpoint}</p>
-                  </article>
-                </div>
-              </section>
-            ) : null}
-          </section>
-
-          <section className="studyQueue motion-reveal" aria-label="Track problem queue">
-            <div className="queueHeader">
-              <div>
-                <p className="eyebrow">Drill queue</p>
-                <h2>{activeTrack?.title ?? 'Study'} problems</h2>
-              </div>
-              <span>
-                {activeSolvedCount}/{activeTrackChallenges.length} accepted
-              </span>
-            </div>
-            {activeTrackChallenges.length ? (
-              <div className="queueList">
-                {activeTrackChallenges.slice(0, 8).map((challenge, index) => (
-                  <Link
-                    className="queueProblemRow"
-                    key={challenge.id}
-                    params={{ challengeId: challenge.id }}
-                    to="/problems/$challengeId"
-                  >
-                    <span className="problemNumber">{String(index + 1).padStart(2, '0')}</span>
-                    <span className="problemMeta">
-                      <strong>{challenge.title}</strong>
-                      <span>{challenge.tags.join(', ') || 'general'}</span>
-                    </span>
-                    <span
-                      className={clsx(
-                        'statusDot',
-                        acceptedChallengeIds.has(challenge.id) && 'done',
-                      )}
-                    />
-                    <span className={clsx('difficultyBadge', challenge.difficulty)}>
-                      {difficultyLabel(challenge.difficulty)}
-                    </span>
-                  </Link>
-                ))}
-              </div>
-            ) : (
-              <EmptyState icon={<Download size={24} />} title="No drills in this path yet" />
-            )}
-          </section>
-        </>
-      )}
-    </main>
-  )
-}
-
-function useStudyMotion(rootRef: RefObject<HTMLElement | null>, activeTrackId?: string) {
-  useEffect(() => {
-    const root = rootRef.current
-    if (!root || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
-    gsap.registerPlugin(ScrollTrigger)
-    const context = gsap.context(() => {
-      gsap.fromTo(
-        '.motion-reveal',
-        { autoAlpha: 0, y: 26 },
-        {
-          autoAlpha: 1,
-          y: 0,
-          duration: 0.7,
-          ease: 'power3.out',
-          stagger: 0.08,
-        },
-      )
-      gsap.utils.toArray<HTMLElement>('.stackMotionCard').forEach((card, index) => {
-        gsap.fromTo(
-          card,
-          { y: 24, scale: 0.985 },
-          {
-            y: 0,
-            scale: 1,
-            ease: 'none',
-            scrollTrigger: {
-              trigger: card,
-              start: 'top 92%',
-              end: 'bottom 68%',
-              scrub: true,
-            },
-            delay: index * 0.03,
-          },
-        )
-      })
-    }, root)
-    return () => context.revert()
-  }, [rootRef, activeTrackId])
-}
-
 function ProblemCard({ challenge, index }: { challenge: Challenge; index: number }) {
   return (
     <Link className="problemRow" params={{ challengeId: challenge.id }} to="/problems/$challengeId">
       <span className="problemNumber">{String(index + 1).padStart(3, '0')}</span>
       <span className="problemMeta">
         <strong>{challenge.title}</strong>
-        <span>{challenge.tags.join(', ') || 'general'}</span>
+        <span>{visibleChallengeTags(challenge).join(', ') || 'general'}</span>
       </span>
       <span className="sourceBadge">{sourceLabel(challenge)}</span>
       <span className="caseCount">{caseCountLabel(challenge)}</span>
@@ -842,7 +428,7 @@ function ProblemCard({ challenge, index }: { challenge: Challenge; index: number
 function ImportPage() {
   const client = useQueryClient()
   const navigate = useNavigate()
-  const [provider, setProvider] = useState<ProblemSourceProvider>('exercism')
+  const [provider, setProvider] = useState<ProblemSourceProvider>('leetcode')
   const [query, setQuery] = useState('')
   const [page, setPage] = useState(0)
   const selectedProvider =
@@ -913,9 +499,9 @@ function ImportPage() {
       <div className="sourceNote">
         <Download size={16} />
         <span>
-          Exercism imports canonical test data. LeetCode uses alfa-leetcode-api for public
-          statements and examples. Codeforces uses the official problemset API for discovery, then
-          imports statements and samples from the Codeforces mirror when available.
+          LeetCode uses alfa-leetcode-api for public statements and examples. Codeforces uses the
+          official problemset API for discovery, then imports statements and samples from the
+          Codeforces mirror when available.
         </span>
       </div>
       <div className="sourcePagingSummary">
@@ -1008,6 +594,10 @@ function ProblemWorkspace({
     queryKey: ['challenge', challengeId],
     queryFn: () => getChallenge(challengeId),
   })
+  const allChallengesQuery = useQuery({
+    queryKey: ['challenges', 'workspace-switcher'],
+    queryFn: () => listChallenges({}),
+  })
   const submissionQuery = useQuery({
     enabled: !!submissionId,
     queryKey: ['submission', submissionId],
@@ -1016,6 +606,7 @@ function ProblemWorkspace({
   })
   const challenge = challengeQuery.data?.challenge
   const submissions = challengeQuery.data?.submissions ?? []
+  const challengeOptions = allChallengesQuery.data?.challenges ?? []
   const [language, setLanguage] = useState<TrainerLanguage>('javascript')
   const starter = useMemo(
     () => (challenge ? starterForLanguage(challenge, language) : ''),
@@ -1025,6 +616,8 @@ function ProblemWorkspace({
   const [consoleView, setConsoleView] = useState<ConsoleView>('testcase')
   const [consoleOpen, setConsoleOpen] = useState(false)
   const [reviewFocus, setReviewFocus] = useState<SubmissionReviewFocus>(readStoredReviewFocus)
+  const [coachingFocuses, setCoachingFocuses] =
+    useState<SubmissionCoachingFocus[]>(readStoredCoachingFocuses)
   const lastSubmitted = submissions.find((item) => item.language === language) ?? submissions[0]
   const latestSubmission = submissions[0]
   const selectedSubmission =
@@ -1063,12 +656,17 @@ function ProblemWorkspace({
   const selectedReviewer = buddyInboxes.find((inbox) => inbox.agent.id === reviewerAgentId)
   const selectedReviewFocus =
     reviewFocusOptions.find((option) => option.value === reviewFocus) ?? defaultReviewFocusOption
+  const selectedCoachingLabels = coachingFocuses
+    .map((focus) => coachingFocusOptions.find((option) => option.value === focus)?.label)
+    .filter((label): label is string => !!label)
   const reviewerHint = inboxesQuery.isLoading
     ? 'Loading Buddies'
     : inboxesQuery.isError
       ? 'Buddy list unavailable'
       : selectedReviewer
-        ? `Buddy will ${selectedReviewFocus.hint}`
+        ? reviewFocus === 'interview'
+          ? `Buddy will coach ${selectedCoachingLabels.join(', ').toLowerCase()}`
+          : `Buddy will ${selectedReviewFocus.hint}`
         : buddyInboxes.length
           ? 'Choose a Buddy for sandbox review'
           : 'No Buddy Inbox available'
@@ -1102,6 +700,16 @@ function ProblemWorkspace({
     writeStoredReviewFocus(reviewFocus)
   }, [reviewFocus])
 
+  useEffect(() => {
+    if (reviewFocus === 'interview' && !coachingFocuses.length) {
+      setCoachingFocuses(defaultCoachingFocuses)
+    }
+  }, [coachingFocuses.length, reviewFocus])
+
+  useEffect(() => {
+    writeStoredCoachingFocuses(coachingFocuses)
+  }, [coachingFocuses])
+
   const submit = useMutation({
     mutationFn: () =>
       createSubmission({
@@ -1114,6 +722,8 @@ function ProblemWorkspace({
               assigneeLabel: selectedReviewer ? buddyInboxLabel(selectedReviewer) : undefined,
               displayName: selectedReviewer ? buddyInboxLabel(selectedReviewer) : undefined,
               reviewFocus,
+              coachingFocuses: reviewFocus === 'interview' ? coachingFocuses : undefined,
+              locale: currentLocale(),
             }
           : undefined,
       }),
@@ -1141,6 +751,26 @@ function ProblemWorkspace({
     },
   })
   const canSubmit = !!reviewerAgentId && !submit.isPending && !!(code || starter).trim()
+  const switchChallenge = (nextChallengeId: string) => {
+    if (!nextChallengeId || nextChallengeId === challengeId) return
+    void navigate({ to: '/problems/$challengeId', params: { challengeId: nextChallengeId } })
+  }
+  const restoreSubmission = (submissionIdToRestore: string) => {
+    const submission = submissions.find((item) => item.id === submissionIdToRestore)
+    if (!submission) return
+    const restoreLanguage = knownLanguage(submission.language, language)
+    setLanguage(restoreLanguage)
+    setCode(submission.code)
+    void navigate({ to: '/problems/$challengeId', params: { challengeId } })
+  }
+  const toggleCoachingFocus = (focus: SubmissionCoachingFocus) => {
+    setCoachingFocuses((current) => {
+      if (current.includes(focus)) {
+        return current.length > 1 ? current.filter((item) => item !== focus) : current
+      }
+      return [...current, focus]
+    })
+  }
   const retryFromSubmission = () => {
     if (!selectedSubmission) return
     const retryLanguage = knownLanguage(selectedSubmission.language, language)
@@ -1171,6 +801,33 @@ function ProblemWorkspace({
 
   return (
     <main className="workspacePage">
+      <div className="workspaceSwitchBar">
+        <label className="problemSwitcher">
+          <span>Problem</span>
+          <select
+            aria-label="Switch problem"
+            value={challenge.id}
+            onChange={(event) => switchChallenge(event.target.value)}
+          >
+            {(challengeOptions.length ? challengeOptions : [challenge]).map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.title}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="problemSwitcherMeta">
+          <span className={clsx('difficultyBadge', challenge.difficulty)}>
+            {difficultyLabel(challenge.difficulty)}
+          </span>
+          {visibleChallengeTags(challenge)
+            .slice(0, 4)
+            .map((item) => (
+              <span key={item}>{item}</span>
+            ))}
+        </div>
+      </div>
+
       <section className="problemPane">
         <ProblemTabs challengeId={challenge.id} count={submissions.length} view={view} />
         <div className="leftScrollArea">
@@ -1231,6 +888,22 @@ function ProblemWorkspace({
                 <History size={16} />
                 Last submit
               </button>
+              <label className="restoreSelect">
+                <History size={15} />
+                <select
+                  aria-label="Restore submitted version"
+                  disabled={!submissions.length}
+                  value=""
+                  onChange={(event) => restoreSubmission(event.target.value)}
+                >
+                  <option value="">Restore version</option>
+                  {submissions.map((submission) => (
+                    <option key={submission.id} value={submission.id}>
+                      {formatDate(submission.createdAt)} · {submission.language}
+                    </option>
+                  ))}
+                </select>
+              </label>
             </div>
           ) : null}
         </div>
@@ -1302,21 +975,38 @@ function ProblemWorkspace({
                     ))}
                   </select>
                 </div>
-                <div className="focusSelect">
-                  <Lightbulb size={15} />
-                  <select
-                    aria-label="Buddy review focus"
-                    value={reviewFocus}
-                    onChange={(event) =>
-                      setReviewFocus(event.target.value as SubmissionReviewFocus)
-                    }
-                  >
+                <div className="focusPanel">
+                  <div className="reviewModeGroup" aria-label="Buddy review focus">
                     {reviewFocusOptions.map((option) => (
-                      <option key={option.value} value={option.value}>
+                      <button
+                        className={clsx(
+                          'reviewModeButton',
+                          reviewFocus === option.value && 'active',
+                        )}
+                        key={option.value}
+                        title={option.hint}
+                        type="button"
+                        onClick={() => setReviewFocus(option.value)}
+                      >
+                        {option.value === 'interview' ? <Lightbulb size={14} /> : null}
                         {option.label}
-                      </option>
+                      </button>
                     ))}
-                  </select>
+                  </div>
+                  {reviewFocus === 'interview' ? (
+                    <div className="coachingChecklist" aria-label="Interview coaching concerns">
+                      {coachingFocusOptions.map((option) => (
+                        <label key={option.value} title={option.hint}>
+                          <input
+                            checked={coachingFocuses.includes(option.value)}
+                            type="checkbox"
+                            onChange={() => toggleCoachingFocus(option.value)}
+                          />
+                          <span>{option.label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
                 <label className="rememberToggle">
                   <input
@@ -1330,7 +1020,6 @@ function ProblemWorkspace({
                 <span className="reviewerHint">{reviewerHint}</span>
               </div>
               <div className="submitActions">
-                <span className="submitMeta">{codeLength(code || starter)} chars</span>
                 <button
                   className="primaryAction"
                   disabled={!canSubmit}
@@ -1513,7 +1202,7 @@ function ProblemStatement({ challenge }: { challenge: Challenge }) {
         ) : null}
       </header>
       <div className="tagRow">
-        {challenge.tags.map((tag) => (
+        {visibleChallengeTags(challenge).map((tag) => (
           <span key={tag}>{tag}</span>
         ))}
       </div>
@@ -1843,7 +1532,6 @@ function SubmissionReplayBar({
           </Link>
         ) : null}
       </div>
-      <span className="submitMeta">{codeLength(submission.code)} chars</span>
     </div>
   )
 }
@@ -1978,6 +1666,35 @@ function writeStoredReviewFocus(value: SubmissionReviewFocus) {
   }
 }
 
+function readStoredCoachingFocuses(): SubmissionCoachingFocus[] {
+  if (typeof window === 'undefined') return defaultCoachingFocuses
+  try {
+    const raw = window.localStorage.getItem(coachingFocusStorageKey)
+    if (!raw) return defaultCoachingFocuses
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return defaultCoachingFocuses
+    const allowed = new Set(coachingFocusOptions.map((option) => option.value))
+    const values = parsed.filter((item): item is SubmissionCoachingFocus => allowed.has(item))
+    return values.length ? values : defaultCoachingFocuses
+  } catch {
+    return defaultCoachingFocuses
+  }
+}
+
+function writeStoredCoachingFocuses(value: SubmissionCoachingFocus[]) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(coachingFocusStorageKey, JSON.stringify(value))
+  } catch {
+    /* local preference persistence is best-effort */
+  }
+}
+
+function currentLocale() {
+  if (typeof navigator === 'undefined') return 'en'
+  return navigator.language || navigator.languages?.[0] || 'en'
+}
+
 function readStoredReviewerPreference() {
   if (typeof window === 'undefined') return null
   try {
@@ -2076,30 +1793,24 @@ function difficultyLabel(value: Challenge['difficulty'] | 'all') {
 }
 
 function sourceLabel(challenge: Challenge) {
-  if (challenge.source?.provider === 'exercism') return 'Exercism'
+  if (challenge.source?.provider === 'exercism') return 'Imported'
   if (challenge.source?.provider === 'leetcode') return 'LeetCode'
   if (challenge.source?.provider === 'codeforces') return 'Codeforces'
   if (challenge.source?.provider === 'manual') return 'Manual'
   return 'Trainer'
 }
 
+function visibleChallengeTags(challenge: Challenge) {
+  return challenge.tags.filter((tag) => tag.toLowerCase() !== 'exercism')
+}
+
 function providerLabel(provider: ProblemSourceProvider) {
   if (provider === 'leetcode') return 'LeetCode'
-  if (provider === 'codeforces') return 'Codeforces'
-  return 'Exercism'
+  return 'Codeforces'
 }
 
 function sourceKey(source: ProblemSource) {
   return `${source.provider}:${source.id}`
-}
-
-function challengeMatchesTrack(challenge: Challenge, track: StudyTrack) {
-  const haystack = [challenge.title, ...challenge.tags, challenge.prompt].join(' ').toLowerCase()
-  return track.tags.some((tag) => haystack.includes(tag))
-}
-
-function firstMatchingTrackId(challenge: Challenge) {
-  return studyTracks.find((track) => challengeMatchesTrack(challenge, track))?.id ?? null
 }
 
 function caseCountLabel(challenge: Challenge) {
@@ -2126,10 +1837,6 @@ function formatDate(value: string) {
     hour: '2-digit',
     minute: '2-digit',
   }).format(new Date(value))
-}
-
-function codeLength(value: string) {
-  return new Intl.NumberFormat().format(value.length)
 }
 
 const rootElement = document.getElementById('root') as HTMLElement

--- a/integrations/trainer/src/client/styles.css
+++ b/integrations/trainer/src/client/styles.css
@@ -131,6 +131,8 @@ dd {
 .rememberToggle,
 .submitActions,
 .reviewRequestPill,
+.problemSwitcher,
+.restoreSelect,
 .sourceLink,
 .ghostLightButton,
 .primaryLink,
@@ -256,7 +258,9 @@ h3 {
 }
 
 .librarySearch input,
+.problemSwitcher select,
 .toolbarGroup select,
+.restoreSelect select,
 .reviewerSelect select,
 .focusSelect select {
   min-width: 0;
@@ -277,9 +281,24 @@ h3 {
   margin: 22px 0 14px;
 }
 
+.tagFilterBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 16px;
+}
+
+.tagFilterBar > span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
 .sourceProviderBar {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
   margin: 22px 0 14px;
 }
@@ -301,333 +320,6 @@ h3 {
   font-size: 12px;
   font-weight: 700;
   line-height: 1.35;
-}
-
-.studyPage {
-  width: min(1220px, calc(100vw - 32px));
-  margin: 0 auto;
-  padding: 30px 0 52px;
-}
-
-.studyHero {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
-  gap: 14px;
-  align-items: stretch;
-  margin-bottom: 14px;
-}
-
-.studyHeroCopy,
-.studyHeroPanel,
-.studyTrackRail,
-.theoryStudio,
-.studyQueue {
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  background: color-mix(in oklch, var(--surface) 92%, transparent);
-  box-shadow: 0 22px 70px oklch(22% 0.06 252 / 0.08);
-}
-
-.studyHeroCopy {
-  overflow: hidden;
-  position: relative;
-  min-height: 250px;
-  padding: 34px;
-}
-
-.studyHeroCopy::after {
-  position: absolute;
-  right: 28px;
-  bottom: 22px;
-  width: 190px;
-  height: 6px;
-  background: linear-gradient(90deg, var(--accent), var(--mint), var(--amber));
-  content: "";
-}
-
-.studyHeroCopy h1 {
-  max-width: 900px;
-  font-size: clamp(42px, 6vw, 82px);
-  line-height: 0.96;
-  margin-top: 10px;
-}
-
-.studyHeroCopy p {
-  max-width: 760px;
-  color: var(--muted);
-  font-size: 17px;
-  font-weight: 650;
-  line-height: 1.55;
-  margin-top: 22px;
-}
-
-.studyHeroPanel {
-  display: grid;
-  align-content: end;
-  gap: 10px;
-  padding: 24px;
-}
-
-.studyHeroPanel > span {
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 900;
-  text-transform: uppercase;
-}
-
-.studyHeroPanel strong {
-  color: var(--ink);
-  font-size: 52px;
-  line-height: 0.95;
-}
-
-.studyHeroPanel p {
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 750;
-}
-
-.studyPhaseStrip {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 6px;
-  margin-top: 18px;
-}
-
-.studyPhaseStrip span {
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--surface-2);
-  color: var(--ink);
-  font-size: 12px;
-  font-weight: 900;
-  padding: 7px 8px;
-  text-align: center;
-}
-
-.studyStudioGrid {
-  display: grid;
-  grid-template-columns: 330px minmax(0, 1fr);
-  gap: 14px;
-  align-items: start;
-}
-
-.studyTrackRail {
-  position: sticky;
-  top: 86px;
-  display: grid;
-  gap: 8px;
-  max-height: calc(100vh - 110px);
-  overflow: auto;
-  padding: 14px;
-}
-
-.railHeader,
-.studioHeader,
-.queueHeader {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 14px;
-}
-
-.railHeader {
-  align-items: center;
-  padding: 2px 2px 8px;
-}
-
-.railHeader span,
-.queueHeader > span {
-  border-radius: 999px;
-  background: var(--surface-2);
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 900;
-  padding: 7px 10px;
-  white-space: nowrap;
-}
-
-.studyTrackButton {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 12px;
-  align-items: start;
-  border-color: var(--line);
-  background: transparent;
-  color: var(--ink);
-  min-height: 84px;
-  padding: 13px;
-  text-align: left;
-}
-
-.studyTrackButton:hover,
-.studyTrackButton.active {
-  border-color: color-mix(in oklch, var(--accent) 35%, var(--line));
-  background: color-mix(in oklch, var(--accent-weak) 55%, var(--surface));
-}
-
-.studyTrackButton span {
-  display: grid;
-  gap: 6px;
-  min-width: 0;
-}
-
-.studyTrackButton strong,
-.studyTrackButton small {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.studyTrackButton strong {
-  font-size: 14px;
-  line-height: 1.25;
-}
-
-.studyTrackButton small {
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-  line-height: 1.35;
-}
-
-.studyTrackButton em {
-  border-radius: 999px;
-  background: var(--ink);
-  color: var(--surface);
-  font-size: 11px;
-  font-style: normal;
-  font-weight: 900;
-  padding: 5px 8px;
-}
-
-.theoryStudio {
-  display: grid;
-  gap: 16px;
-  padding: 18px;
-}
-
-.studioHeader {
-  align-items: center;
-}
-
-.studioHeader h2 {
-  font-size: 28px;
-  margin-top: 4px;
-}
-
-.studioHeader p {
-  max-width: 720px;
-  color: var(--muted);
-  line-height: 1.5;
-  margin-top: 8px;
-}
-
-.theoryBento {
-  display: grid;
-  grid-auto-flow: dense;
-  grid-auto-rows: minmax(118px, auto);
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.theoryTile {
-  display: grid;
-  align-content: start;
-  gap: 10px;
-  grid-column: span 4;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  background: var(--surface-2);
-  min-width: 0;
-  padding: 16px;
-}
-
-.theoryTileLarge {
-  grid-column: span 5;
-  grid-row: span 2;
-  background: linear-gradient(135deg, oklch(20% 0.04 252), oklch(31% 0.08 265));
-  color: oklch(96% 0.01 240);
-}
-
-.buddyTheoryTile {
-  grid-column: span 7;
-  background: color-mix(in oklch, var(--mint) 20%, var(--surface));
-}
-
-.theoryTile svg {
-  color: var(--accent);
-}
-
-.theoryTileLarge svg {
-  color: var(--mint);
-}
-
-.theoryTileLarge h3 {
-  color: oklch(96% 0.01 240);
-}
-
-.theoryTile h3 {
-  font-size: 15px;
-}
-
-.theoryTile p,
-.theoryTile li {
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 650;
-  line-height: 1.55;
-}
-
-.theoryTileLarge p {
-  color: oklch(88% 0.02 240);
-  font-size: 15px;
-}
-
-.theoryTile ol,
-.theoryTile ul {
-  display: grid;
-  gap: 7px;
-  margin: 0;
-  padding-left: 18px;
-}
-
-.studyQueue {
-  display: grid;
-  gap: 12px;
-  margin-top: 14px;
-  padding: 18px;
-}
-
-.queueHeader h2 {
-  font-size: 23px;
-  margin-top: 4px;
-}
-
-.queueList {
-  display: grid;
-  gap: 0;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-}
-
-.queueProblemRow {
-  display: grid;
-  grid-template-columns: 48px minmax(0, 1fr) auto auto;
-  align-items: center;
-  gap: 12px;
-  background: var(--surface);
-  min-height: 56px;
-  padding: 10px 14px;
-}
-
-.queueProblemRow + .queueProblemRow {
-  border-top: 1px solid var(--line);
-}
-
-.queueProblemRow:hover {
-  background: color-mix(in oklch, var(--accent-weak) 35%, var(--surface));
 }
 
 .segmentedButton {
@@ -821,10 +513,67 @@ h3 {
 .workspacePage {
   display: grid;
   grid-template-columns: minmax(390px, 44vw) minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 12px;
   height: calc(100vh - 70px);
   min-height: 650px;
   padding: 12px;
+}
+
+.workspaceSwitchBar {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: color-mix(in oklch, var(--surface) 92%, var(--surface-2));
+  min-height: 50px;
+  padding: 8px 10px;
+}
+
+.problemSwitcher {
+  flex: 1 1 360px;
+  gap: 9px;
+  min-width: 0;
+}
+
+.problemSwitcher > span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 900;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.problemSwitcher select {
+  width: min(520px, 100%);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--ink);
+  font-weight: 850;
+  min-height: 34px;
+  padding: 0 10px;
+}
+
+.problemSwitcherMeta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.problemSwitcherMeta > span:not(.difficultyBadge) {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  min-height: 26px;
+  padding: 5px 9px;
 }
 
 .problemPane,
@@ -1205,6 +954,27 @@ h3 {
   background: oklch(29% 0.035 252);
 }
 
+.restoreSelect {
+  gap: 7px;
+  border: 1px solid oklch(32% 0.03 252);
+  border-radius: var(--radius);
+  background: oklch(23% 0.028 252);
+  color: oklch(86% 0.02 252);
+  min-height: 36px;
+  padding: 0 10px;
+}
+
+.restoreSelect select {
+  color: oklch(89% 0.018 252);
+  font-size: 13px;
+  font-weight: 800;
+  max-width: 210px;
+}
+
+.restoreSelect option {
+  color: var(--ink);
+}
+
 .editorFrame {
   flex: 1;
   min-height: 300px;
@@ -1383,6 +1153,57 @@ h3 {
   align-items: center;
   gap: 8px;
   min-width: 0;
+}
+
+.focusPanel {
+  display: grid;
+  gap: 7px;
+  min-width: min(420px, 100%);
+}
+
+.reviewModeGroup,
+.coachingChecklist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.reviewModeButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-color: var(--line);
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 12px;
+  min-height: 32px;
+  padding: 0 10px;
+}
+
+.reviewModeButton:hover,
+.reviewModeButton.active {
+  border-color: color-mix(in oklch, var(--accent) 35%, var(--line));
+  background: var(--accent-weak);
+  color: var(--accent);
+}
+
+.coachingChecklist label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  min-height: 28px;
+  padding: 0 9px;
+}
+
+.coachingChecklist input {
+  accent-color: var(--accent);
+  margin: 0;
 }
 
 .reviewerSelect,
@@ -1905,6 +1726,7 @@ h3 {
 @media (max-width: 980px) {
   .workspacePage {
     grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
     height: auto;
     min-height: 0;
   }
@@ -1965,54 +1787,18 @@ h3 {
     grid-template-columns: 1fr;
   }
 
-  .studyPage {
-    width: min(100vw - 20px, 1180px);
-    padding-top: 18px;
-  }
-
-  .studyHero,
-  .studyStudioGrid {
-    grid-template-columns: 1fr;
-  }
-
-  .studyHeroCopy {
-    min-height: auto;
-    padding: 24px;
-  }
-
-  .studyHeroCopy h1 {
-    font-size: 42px;
-  }
-
-  .studyTrackRail {
-    position: static;
-    max-height: none;
-  }
-
-  .studioHeader,
-  .queueHeader {
+  .workspaceSwitchBar {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .theoryBento {
-    grid-template-columns: 1fr;
+  .problemSwitcher,
+  .problemSwitcherMeta {
+    width: 100%;
   }
 
-  .theoryTile,
-  .theoryTileLarge,
-  .buddyTheoryTile {
-    grid-column: auto;
-    grid-row: auto;
-  }
-
-  .queueProblemRow {
-    grid-template-columns: 34px minmax(0, 1fr) auto;
-  }
-
-  .queueProblemRow .difficultyBadge {
-    grid-column: 2 / -1;
-    justify-self: start;
+  .problemSwitcherMeta {
+    justify-content: flex-start;
   }
 
   .sourceRow .ghostLightButton {
@@ -2084,7 +1870,7 @@ h3 {
 
   .toolbarActions {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 
   .submitActions {
@@ -2099,11 +1885,13 @@ h3 {
 
   .submitActions .primaryAction,
   .reviewerSelect,
+  .focusPanel,
   .focusSelect {
     width: 100%;
   }
 
   .reviewerSelect select,
+  .restoreSelect select,
   .focusSelect select {
     max-width: none;
     width: 100%;

--- a/integrations/trainer/src/data.ts
+++ b/integrations/trainer/src/data.ts
@@ -6,11 +6,13 @@ import type {
   ChallengeDifficulty,
   CodeSubmission,
   SubmissionAnalysis,
+  SubmissionCoachingFocus,
   SubmissionOutcome,
   SubmissionReviewFocus,
   SubmissionReviewRequest,
   SubmissionStatus,
   TrainerLanguage,
+  TrainerOwnerScope,
   TrainerPerson,
   TrainerState,
 } from './types.js'
@@ -75,6 +77,22 @@ const seedChallenges: Challenge[] = [
   },
 ]
 
+const seedChallengeIds = new Set(seedChallenges.map((challenge) => challenge.id))
+const legacyOwner: TrainerOwnerScope = {
+  ownerKey: process.env.TRAINER_LEGACY_OWNER_KEY ?? 'local:local',
+  serverId: process.env.TRAINER_LEGACY_SERVER_ID ?? 'local',
+  userId: process.env.TRAINER_LEGACY_USER_ID ?? 'local',
+}
+
+export type TrainerAccess = {
+  serverId: string
+  ownerKey: string
+  ownerUserId: string
+  buddyAgentId: string | null
+  isBuddy: boolean
+  actor: TrainerPerson
+}
+
 type ChallengeInput = {
   id?: string
   title: string
@@ -93,6 +111,8 @@ type SubmissionReviewerInput = {
   assigneeLabel?: string
   displayName?: string
   reviewFocus?: SubmissionReviewFocus
+  coachingFocuses?: SubmissionCoachingFocus[]
+  locale?: string
 }
 
 type StoredPerson = Partial<TrainerPerson> & {
@@ -222,10 +242,17 @@ function starterWithoutSeedAnswer(challengeId: string, starterCode: string) {
     : starterCode
 }
 
-function uniqueChallengeId(base: string) {
+function challengeIdTaken(candidate: string, ownerKey: string) {
+  return state.challenges.some((challenge) => {
+    if (challenge.id !== candidate) return false
+    return isGlobalChallenge(challenge) || ownerKeyOf(challenge) === ownerKey
+  })
+}
+
+function uniqueChallengeId(base: string, ownerKey: string) {
   let candidate = slugify(base)
   let index = 2
-  while (state.challenges.some((challenge) => challenge.id === candidate)) {
+  while (challengeIdTaken(candidate, ownerKey)) {
     candidate = `${slugify(base)}_${index}`
     index += 1
   }
@@ -252,6 +279,61 @@ function person(actor: ShadowServerAppActorRef): TrainerPerson {
   return normalizePerson(actor, 'Local Coder')
 }
 
+export function accessFromActor(input: {
+  serverId: string
+  actor: ShadowServerAppActorRef
+}): TrainerAccess {
+  const actor = person(input.actor)
+  const serverId = text(input.serverId, 'local') || 'local'
+  const ownerUserId = actor.ownerId || actor.userId || actor.id || 'local'
+  const buddyAgentId = actor.buddyAgentId || null
+  const isBuddy = Boolean(buddyAgentId || actor.kind === 'agent')
+  return {
+    serverId,
+    ownerKey: `${serverId}:${ownerUserId}`,
+    ownerUserId,
+    buddyAgentId,
+    isBuddy,
+    actor,
+  }
+}
+
+function ownerFromAccess(access: TrainerAccess): TrainerOwnerScope {
+  return {
+    ownerKey: access.ownerKey,
+    serverId: access.serverId,
+    userId: access.ownerUserId,
+  }
+}
+
+function normalizeOwnerScope(value: unknown): TrainerOwnerScope | undefined {
+  if (!isRecord(value)) return undefined
+  const ownerKey = text(value.ownerKey)
+  const serverId = text(value.serverId)
+  const userId = text(value.userId)
+  if (!ownerKey || !serverId || !userId) return undefined
+  return { ownerKey, serverId, userId }
+}
+
+function ownerKeyOf(challenge: Challenge) {
+  return challenge.owner?.ownerKey ?? null
+}
+
+function isGlobalChallenge(challenge: Challenge) {
+  return !challenge.owner && seedChallengeIds.has(challenge.id)
+}
+
+function canReadChallenge(challenge: Challenge, access: TrainerAccess) {
+  return isGlobalChallenge(challenge) || ownerKeyOf(challenge) === access.ownerKey
+}
+
+function canReadSubmission(submission: CodeSubmission, access: TrainerAccess) {
+  if (submission.owner.ownerKey !== access.ownerKey) return false
+  if (!access.isBuddy) return true
+  const assignedBuddyId = submission.reviewRequest?.agentId
+  return Boolean(assignedBuddyId && assignedBuddyId === access.buddyAgentId)
+}
+
 function normalizeChallenge(value: unknown): Challenge | null {
   if (!isRecord(value)) return null
   const title = text(value.title)
@@ -261,18 +343,23 @@ function normalizeChallenge(value: unknown): Challenge | null {
   if (!title || !prompt || !starterCode || !judgeInstructions) return null
   const timestamp = text(value.updatedAt, now())
   const source = normalizeSource(value.source)
+  const challengeId = text(value.id, slugify(title))
+  const owner =
+    normalizeOwnerScope(value.owner) ??
+    (seedChallengeIds.has(challengeId) ? undefined : legacyOwner)
 
   return {
-    id: text(value.id, slugify(title)),
+    id: challengeId,
     title,
     difficulty: normalizeDifficulty(value.difficulty),
     tags: normalizeTags(value.tags),
     prompt,
-    starterCode: starterWithoutSeedAnswer(text(value.id, slugify(title)), starterCode),
+    starterCode: starterWithoutSeedAnswer(challengeId, starterCode),
     examples: normalizeExamples(value.examples),
     testCases: normalizeTestCases(value.testCases),
     judgeInstructions,
     ...(source ? { source } : {}),
+    ...(owner ? { owner } : {}),
     createdAt: text(value.createdAt, timestamp),
     updatedAt: timestamp,
   }
@@ -323,6 +410,8 @@ function normalizeReviewRequest(value: unknown): SubmissionReviewRequest | undef
     ...(assigneeLabel ? { assigneeLabel } : {}),
     ...(text(value.displayName) ? { displayName: text(value.displayName) } : {}),
     reviewFocus: normalizeReviewFocus(value.reviewFocus),
+    coachingFocuses: normalizeCoachingFocuses(value.coachingFocuses),
+    ...(normalizeLocale(value.locale) ? { locale: normalizeLocale(value.locale) } : {}),
     requestedAt: text(value.requestedAt, now()),
   }
 }
@@ -341,6 +430,8 @@ function reviewRequestFromInput(
     ...(assigneeLabel ? { assigneeLabel } : {}),
     ...(text(reviewer.displayName) ? { displayName: text(reviewer.displayName) } : {}),
     reviewFocus: normalizeReviewFocus(reviewer.reviewFocus),
+    coachingFocuses: normalizeCoachingFocuses(reviewer.coachingFocuses),
+    ...(normalizeLocale(reviewer.locale) ? { locale: normalizeLocale(reviewer.locale) } : {}),
     requestedAt,
   }
 }
@@ -348,6 +439,25 @@ function reviewRequestFromInput(
 function normalizeReviewFocus(value: unknown): SubmissionReviewFocus {
   if (value === 'interview' || value === 'debug' || value === 'complexity') return value
   return 'standard'
+}
+
+function normalizeCoachingFocuses(value: unknown): SubmissionCoachingFocus[] {
+  if (!Array.isArray(value)) return []
+  const allowed = new Set<SubmissionCoachingFocus>([
+    'reasoning',
+    'edge_cases',
+    'complexity',
+    'communication',
+    'follow_ups',
+    'debugging',
+  ])
+  return [
+    ...new Set(value.filter((item): item is SubmissionCoachingFocus => allowed.has(item))),
+  ].slice(0, 8)
+}
+
+function normalizeLocale(value: unknown) {
+  return text(value).slice(0, 32)
 }
 
 function normalizeOutcome(value: unknown): SubmissionOutcome {
@@ -392,6 +502,7 @@ function normalizeSubmission(value: unknown): CodeSubmission | null {
 
   const analysis = normalizeAnalysis(stored.analysis, stored)
   const reviewRequest = normalizeReviewRequest(stored.reviewRequest)
+  const owner = normalizeOwnerScope(stored.owner) ?? legacyOwner
   const status: SubmissionStatus =
     stored.status === 'analyzed' || stored.status === 'judged' || analysis
       ? 'analyzed'
@@ -400,6 +511,7 @@ function normalizeSubmission(value: unknown): CodeSubmission | null {
   return {
     id: submissionId,
     challengeId,
+    owner,
     author: normalizePerson(stored.author, 'Learner'),
     language: normalizeLanguage(stored.language),
     code,
@@ -446,38 +558,55 @@ function persist() {
   state = stateStore.write(state)
 }
 
-export function listChallenges(input: { query?: string; difficulty?: ChallengeDifficulty }) {
+export function listChallenges(
+  input: {
+    query?: string
+    difficulty?: ChallengeDifficulty
+    tag?: string
+  },
+  access: TrainerAccess,
+) {
   const query = input.query?.trim().toLowerCase()
+  const tag = input.tag?.trim().toLowerCase()
   return structuredClone(
-    state.challenges.filter((challenge) => {
-      const difficultyMatches = !input.difficulty || challenge.difficulty === input.difficulty
-      const haystack = [challenge.title, challenge.prompt, challenge.tags.join(' ')]
-        .join(' ')
-        .toLowerCase()
-      return difficultyMatches && (!query || haystack.includes(query))
-    }),
+    state.challenges
+      .filter((challenge) => canReadChallenge(challenge, access))
+      .filter((challenge) => {
+        const difficultyMatches = !input.difficulty || challenge.difficulty === input.difficulty
+        const tagMatches = !tag || challenge.tags.some((item) => item.toLowerCase() === tag)
+        const haystack = [challenge.title, challenge.prompt, challenge.tags.join(' ')]
+          .join(' ')
+          .toLowerCase()
+        return difficultyMatches && tagMatches && (!query || haystack.includes(query))
+      }),
   )
 }
 
-export function getChallenge(challengeId: string) {
-  const challenge = state.challenges.find((item) => item.id === challengeId)
+export function getChallenge(challengeId: string, access: TrainerAccess) {
+  const challenge =
+    state.challenges.find(
+      (item) => item.id === challengeId && ownerKeyOf(item) === access.ownerKey,
+    ) ?? state.challenges.find((item) => item.id === challengeId && isGlobalChallenge(item))
   if (!challenge) return null
   return structuredClone({
     challenge,
     submissions: state.submissions
       .filter((submission) => submission.challengeId === challengeId)
+      .filter((submission) => canReadSubmission(submission, access))
       .sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
   })
 }
 
-export function upsertChallenge(input: ChallengeInput) {
+export function upsertChallenge(input: ChallengeInput, access: TrainerAccess) {
   const existing = input.id
-    ? state.challenges.find((challenge) => challenge.id === input.id)
+    ? state.challenges.find(
+        (challenge) => challenge.id === input.id && ownerKeyOf(challenge) === access.ownerKey,
+      )
     : undefined
   const timestamp = now()
   const source = normalizeSource(input.source)
   const challenge: Challenge = {
-    id: existing?.id ?? uniqueChallengeId(input.id || input.title),
+    id: existing?.id ?? uniqueChallengeId(input.id || input.title, access.ownerKey),
     title: input.title.trim(),
     difficulty: normalizeDifficulty(input.difficulty),
     tags: normalizeTags(input.tags),
@@ -487,12 +616,15 @@ export function upsertChallenge(input: ChallengeInput) {
     testCases: normalizeTestCases(input.testCases),
     judgeInstructions: input.judgeInstructions.trim(),
     ...(source ? { source } : {}),
+    owner: existing?.owner ?? ownerFromAccess(access),
     createdAt: existing?.createdAt ?? timestamp,
     updatedAt: timestamp,
   }
 
   if (existing) {
-    state.challenges = state.challenges.map((item) => (item.id === existing.id ? challenge : item))
+    state.challenges = state.challenges.map((item) =>
+      item.id === existing.id && ownerKeyOf(item) === access.ownerKey ? challenge : item,
+    )
   } else {
     state.challenges.push(challenge)
   }
@@ -507,14 +639,19 @@ export function createSubmission(input: {
   code: string
   reviewer?: SubmissionReviewerInput
   author: ShadowServerAppActorRef
+  access: TrainerAccess
 }) {
-  const challenge = state.challenges.find((item) => item.id === input.challengeId)
+  const challenge =
+    state.challenges.find(
+      (item) => item.id === input.challengeId && ownerKeyOf(item) === input.access.ownerKey,
+    ) ?? state.challenges.find((item) => item.id === input.challengeId && isGlobalChallenge(item))
   if (!challenge) return null
   const createdAt = now()
   const reviewRequest = reviewRequestFromInput(input.reviewer, createdAt)
   const submission: CodeSubmission = {
     id: id('sub'),
     challengeId: challenge.id,
+    owner: ownerFromAccess(input.access),
     author: person(input.author),
     language: normalizeLanguage(input.language),
     code: input.code.trim(),
@@ -527,14 +664,18 @@ export function createSubmission(input: {
   return structuredClone(submission)
 }
 
-export function listSubmissions(input: {
-  challengeId?: string
-  status?: SubmissionStatus
-  limit?: number
-}) {
+export function listSubmissions(
+  input: {
+    challengeId?: string
+    status?: SubmissionStatus
+    limit?: number
+  },
+  access: TrainerAccess,
+) {
   const limit = Math.min(Math.max(input.limit ?? 50, 1), 100)
   return structuredClone(
     state.submissions
+      .filter((submission) => canReadSubmission(submission, access))
       .filter((submission) => !input.challengeId || submission.challengeId === input.challengeId)
       .filter((submission) => !input.status || submission.status === input.status)
       .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
@@ -542,18 +683,31 @@ export function listSubmissions(input: {
   )
 }
 
-export function getSubmission(submissionId: string) {
+export function getSubmission(submissionId: string, access: TrainerAccess) {
   const submission = state.submissions.find((item) => item.id === submissionId)
-  if (!submission) return null
-  const challenge = state.challenges.find((item) => item.id === submission.challengeId)
+  if (!submission || !canReadSubmission(submission, access)) return null
+  const challenge =
+    state.challenges.find(
+      (item) =>
+        item.id === submission.challengeId && ownerKeyOf(item) === submission.owner.ownerKey,
+    ) ??
+    state.challenges.find((item) => item.id === submission.challengeId && isGlobalChallenge(item))
   return structuredClone({ submission, challenge })
 }
 
-export function pendingSubmissions(input: { limit?: number }) {
-  return listSubmissions({ status: 'submitted', limit: input.limit })
+export function pendingSubmissions(input: { limit?: number }, access: TrainerAccess) {
+  return listSubmissions({ status: 'submitted', limit: input.limit }, access)
     .map((submission) => ({
       submission,
-      challenge: state.challenges.find((challenge) => challenge.id === submission.challengeId),
+      challenge:
+        state.challenges.find(
+          (challenge) =>
+            challenge.id === submission.challengeId &&
+            ownerKeyOf(challenge) === submission.owner.ownerKey,
+        ) ??
+        state.challenges.find(
+          (challenge) => challenge.id === submission.challengeId && isGlobalChallenge(challenge),
+        ),
     }))
     .filter(
       (item): item is { submission: CodeSubmission; challenge: Challenge } => !!item.challenge,
@@ -569,9 +723,10 @@ export function analyzeSubmission(input: {
   suggestions?: string[]
   complexity?: string
   analyzer: ShadowServerAppActorRef
+  access: TrainerAccess
 }) {
   const submission = state.submissions.find((item) => item.id === input.submissionId)
-  if (!submission) return null
+  if (!submission || !canReadSubmission(submission, input.access)) return null
   submission.status = 'analyzed'
   submission.analysis = {
     outcome: normalizeOutcome(input.outcome),

--- a/integrations/trainer/src/server.ts
+++ b/integrations/trainer/src/server.ts
@@ -3,11 +3,13 @@ import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import {
   type ShadowServerAppCommandContext,
+  type ShadowServerAppCommandHandlerContext,
   type ShadowServerAppCommandName,
   ShadowServerAppOutbox,
 } from '@shadowob/sdk'
 import { Hono } from 'hono'
 import {
+  accessFromActor,
   analyzeSubmission,
   createSubmission,
   getChallenge,
@@ -15,6 +17,7 @@ import {
   listChallenges,
   listSubmissions,
   pendingSubmissions,
+  type TrainerAccess,
   upsertChallenge,
 } from './data.js'
 import { manifest, shadowApp } from './manifest.js'
@@ -24,7 +27,12 @@ import {
   refreshImportedCodeforcesChallenge,
   searchExternalChallenges,
 } from './sources.js'
-import type { Challenge, CodeSubmission, SubmissionReviewFocus } from './types.js'
+import type {
+  Challenge,
+  CodeSubmission,
+  SubmissionCoachingFocus,
+  SubmissionReviewFocus,
+} from './types.js'
 import { shellPage } from './ui.js'
 
 type TrainerCommandName = ShadowServerAppCommandName<typeof shadowServerAppManifest>
@@ -41,47 +49,182 @@ function clipForTask(value: string, limit: number) {
   return `${trimmed.slice(0, Math.max(0, limit - 3)).trim()}...`
 }
 
-function reviewFocusLabel(value?: SubmissionReviewFocus) {
+type TaskLocale = 'en' | 'zh'
+
+const defaultCoachingFocuses: SubmissionCoachingFocus[] = [
+  'reasoning',
+  'edge_cases',
+  'complexity',
+  'communication',
+]
+
+const coachingFocusCopy: Record<
+  SubmissionCoachingFocus,
+  { en: string; zh: string; instructionEn: string; instructionZh: string }
+> = {
+  reasoning: {
+    en: 'reasoning clarity',
+    zh: '思路清晰度',
+    instructionEn: 'Check whether the learner can explain the invariant and proof path.',
+    instructionZh: '检查学习者能否讲清不变量、证明路径和关键判断。',
+  },
+  edge_cases: {
+    en: 'edge cases',
+    zh: '边界用例',
+    instructionEn: 'Probe boundary inputs and ask which case would break the solution first.',
+    instructionZh: '追问边界输入，并指出哪个用例最先击穿当前解法。',
+  },
+  complexity: {
+    en: 'complexity',
+    zh: '复杂度',
+    instructionEn: 'Make the learner state time and space cost, plus the reason for each term.',
+    instructionZh: '要求学习者说明时间和空间复杂度，并解释每一项成本来源。',
+  },
+  communication: {
+    en: 'communication',
+    zh: '表达结构',
+    instructionEn:
+      'Coach a concise spoken answer with problem restatement, idea, proof, and tests.',
+    instructionZh: '辅导一段清晰口述回答，包含题意复述、核心思路、正确性和测试。',
+  },
+  follow_ups: {
+    en: 'follow-up questions',
+    zh: '追问扩展',
+    instructionEn: 'Ask one realistic follow-up and describe what a strong answer should cover.',
+    instructionZh: '提出一个真实面试追问，并说明优秀回答应覆盖什么。',
+  },
+  debugging: {
+    en: 'debugging process',
+    zh: '调试过程',
+    instructionEn: 'Have the learner trace the first wrong state before discussing the fix.',
+    instructionZh: '先让学习者追踪第一个错误状态，再讨论修复方式。',
+  },
+}
+
+function taskLocale(submission: CodeSubmission): TaskLocale {
+  const locale = submission.reviewRequest?.locale?.toLowerCase() ?? ''
+  return locale.startsWith('zh') ? 'zh' : 'en'
+}
+
+function selectedCoachingFocuses(submission: CodeSubmission) {
+  const focuses = submission.reviewRequest?.coachingFocuses ?? []
+  return focuses.length ? focuses : defaultCoachingFocuses
+}
+
+function reviewFocusLabel(value?: SubmissionReviewFocus, locale: TaskLocale = 'en') {
+  if (locale === 'zh') {
+    if (value === 'interview') return '面试辅导'
+    if (value === 'debug') return '调试提示'
+    if (value === 'complexity') return '复杂度与取舍评审'
+    return '沙箱正确性评审'
+  }
   if (value === 'interview') return 'interview coaching'
   if (value === 'debug') return 'debugging hints'
   if (value === 'complexity') return 'complexity and tradeoff review'
   return 'sandbox correctness review'
 }
 
-function reviewFocusInstruction(submission: CodeSubmission) {
+function reviewFocusInstruction(submission: CodeSubmission, locale: TaskLocale) {
   const focus = submission.reviewRequest?.reviewFocus
   if (focus === 'interview') {
-    return 'Focus on interview readiness: point out the reasoning gap, ask one follow-up question, and include a short whiteboard explanation path.'
+    const details = selectedCoachingFocuses(submission)
+      .map((item) =>
+        locale === 'zh'
+          ? `- ${coachingFocusCopy[item].zh}: ${coachingFocusCopy[item].instructionZh}`
+          : `- ${coachingFocusCopy[item].en}: ${coachingFocusCopy[item].instructionEn}`,
+      )
+      .join('\n')
+    return locale === 'zh'
+      ? `重点做面试辅导：指出思路缺口，给一个追问，并提供一段可白板讲解的表达路径。\n${details}`
+      : `Focus on interview readiness: point out the reasoning gap, ask one follow-up question, and include a short whiteboard explanation path.\n${details}`
   }
   if (focus === 'debug') {
-    return 'Focus on debugging: identify the smallest failing case, explain the first wrong state, and give hints before any direct fix.'
+    return locale === 'zh'
+      ? '重点做调试辅导：找出最小失败用例，解释第一个错误状态，并先给提示再给直接修复建议。'
+      : 'Focus on debugging: identify the smallest failing case, explain the first wrong state, and give hints before any direct fix.'
   }
   if (focus === 'complexity') {
-    return 'Focus on complexity: verify asymptotic cost, explain tradeoffs, and mention when an alternative data structure would be justified.'
+    return locale === 'zh'
+      ? '重点做复杂度评审：验证渐进成本，解释取舍，并说明何时值得换数据结构或算法。'
+      : 'Focus on complexity: verify asymptotic cost, explain tradeoffs, and mention when an alternative data structure would be justified.'
   }
-  return 'Focus on sandbox correctness: run cases, identify correctness gaps, and explain the core invariant.'
+  return locale === 'zh'
+    ? '重点做沙箱正确性评审：运行用例，定位正确性缺口，并解释核心不变量。'
+    : 'Focus on sandbox correctness: run cases, identify correctness gaps, and explain the core invariant.'
 }
 
 function reviewTaskBody(submission: CodeSubmission, challenge: Challenge) {
+  const locale = taskLocale(submission)
   const examples = challenge.examples
     .slice(0, 5)
     .map((example, index) => {
-      const lines = [`Case ${index + 1}`, `Input: ${example.input}`, `Output: ${example.output}`]
-      if (example.explanation) lines.push(`Explanation: ${example.explanation}`)
+      const lines =
+        locale === 'zh'
+          ? [`示例 ${index + 1}`, `输入：${example.input}`, `输出：${example.output}`]
+          : [`Case ${index + 1}`, `Input: ${example.input}`, `Output: ${example.output}`]
+      if (example.explanation) {
+        lines.push(
+          locale === 'zh' ? `解释：${example.explanation}` : `Explanation: ${example.explanation}`,
+        )
+      }
       return lines.join('\n')
     })
     .join('\n\n')
   const testCases = (challenge.testCases ?? [])
     .slice(0, 40)
     .map((testCase, index) => {
-      const label = testCase.visibility === 'hidden' ? 'Hidden' : 'Visible'
-      return [
-        `${label} case ${index + 1}${testCase.description ? `: ${testCase.description}` : ''}`,
-        `Input: ${testCase.input}`,
-        `Expected: ${testCase.expected}`,
-      ].join('\n')
+      const label =
+        locale === 'zh'
+          ? testCase.visibility === 'hidden'
+            ? '隐藏'
+            : '可见'
+          : testCase.visibility === 'hidden'
+            ? 'Hidden'
+            : 'Visible'
+      const suffix = testCase.description ? `: ${testCase.description}` : ''
+      return locale === 'zh'
+        ? [
+            `${label}用例 ${index + 1}${suffix}`,
+            `输入：${testCase.input}`,
+            `期望：${testCase.expected}`,
+          ].join('\n')
+        : [
+            `${label} case ${index + 1}${suffix}`,
+            `Input: ${testCase.input}`,
+            `Expected: ${testCase.expected}`,
+          ].join('\n')
     })
     .join('\n\n')
+
+  if (locale === 'zh') {
+    return [
+      `请评审提交 ${submission.id}，题目是「${challenge.title}」。`,
+      '',
+      '工作流：',
+      `1. 使用 shadow-trainer submissions.get 和 {"submissionId":"${submission.id}"} 获取提交。`,
+      '2. 在你的沙箱里运行可见示例、隐藏用例和必要边界用例。不要把判题委托给在线评测平台。',
+      '3. 使用 shadow-trainer submissions.analyze 写回评审结果。',
+      '',
+      '反馈要求：',
+      '- 给出结论、分数和简洁的问题诊断。',
+      '- 解释核心算法思路以及为什么它成立。',
+      '- 说明时间复杂度和空间复杂度。',
+      '- 给出有针对性的修复建议和面试准备提醒。',
+      '- 不要直接粘贴完整最终答案。保留练习价值，只给诊断、提示和下一步。',
+      '',
+      `评审模式：${reviewFocusLabel(submission.reviewRequest?.reviewFocus, locale)}。`,
+      reviewFocusInstruction(submission, locale),
+      '',
+      `提交语言：${submission.language}`,
+      challenge.source?.url ? `来源链接：${challenge.source.url}` : '',
+      `题目描述：${clipForTask(challenge.prompt, 1400)}`,
+      examples ? `可见示例：\n${clipForTask(examples, 1800)}` : '',
+      testCases ? `沙箱用例：\n${clipForTask(testCases, 5000)}` : '',
+      `判题备注：${clipForTask(challenge.judgeInstructions, 1400)}`,
+    ]
+      .filter(Boolean)
+      .join('\n')
+  }
 
   return [
     `Review submission ${submission.id} for "${challenge.title}".`,
@@ -98,8 +241,8 @@ function reviewTaskBody(submission: CodeSubmission, challenge: Challenge) {
     '- Include targeted fixes and interview preparation notes for the learner.',
     '- Do not paste a complete final solution. Preserve the exercise by giving diagnosis, hints, and focused next steps.',
     '',
-    `Review focus: ${reviewFocusLabel(submission.reviewRequest?.reviewFocus)}.`,
-    reviewFocusInstruction(submission),
+    `Review focus: ${reviewFocusLabel(submission.reviewRequest?.reviewFocus, locale)}.`,
+    reviewFocusInstruction(submission, locale),
     '',
     `Language: ${submission.language}`,
     challenge.source?.url ? `Source URL: ${challenge.source.url}` : '',
@@ -117,9 +260,11 @@ function reviewInboxTask(submission: CodeSubmission, challenge: Challenge) {
   if (!reviewRequest) return null
   const assignee = reviewRequest.agentId || reviewRequest.assigneeLabel
   if (!assignee) return null
+  const locale = taskLocale(submission)
 
   return {
-    title: `Review ${challenge.title} submission`,
+    title:
+      locale === 'zh' ? `评审「${challenge.title}」提交` : `Review ${challenge.title} submission`,
     body: reviewTaskBody(submission, challenge),
     priority: 'normal' as const,
     agentId: reviewRequest.agentId,
@@ -141,49 +286,88 @@ function reviewInboxTask(submission: CodeSubmission, challenge: Challenge) {
         writeAnalysis: 'submissions.analyze',
       },
       learningGoals: [
-        'sandbox test execution',
-        'algorithm correctness feedback',
-        'complexity explanation',
-        'interview preparation guidance',
-        reviewFocusLabel(reviewRequest.reviewFocus),
+        ...(locale === 'zh'
+          ? ['沙箱用例执行', '算法正确性反馈', '复杂度解释', '面试准备指导']
+          : [
+              'sandbox test execution',
+              'algorithm correctness feedback',
+              'complexity explanation',
+              'interview preparation guidance',
+            ]),
+        reviewFocusLabel(reviewRequest.reviewFocus, locale),
       ],
     },
     required: false,
   }
 }
 
+function commandAccess(handlerContext: ShadowServerAppCommandHandlerContext): TrainerAccess {
+  return accessFromActor({
+    serverId: handlerContext.context.serverId,
+    actor: handlerContext.actor,
+  })
+}
+
+function requireOwnerAccess(access: TrainerAccess) {
+  if (access.isBuddy) throw shadowApp.error(403, 'owner_actor_required')
+}
+
 const commands = shadowApp.defineCommands({
-  'challenges.list': (input) => ({ challenges: listChallenges(input) }),
-  'challenges.get': async (input) => {
-    const result = getChallenge(input.challengeId)
+  'challenges.list': (input, context) => ({
+    challenges: listChallenges(input, commandAccess(context)),
+  }),
+  'challenges.get': async (input, context) => {
+    const access = commandAccess(context)
+    const result = getChallenge(input.challengeId, access)
     if (!result) throw shadowApp.error(404, 'challenge_not_found')
-    const refreshed = await refreshImportedCodeforcesChallenge(result.challenge)
-    return refreshed ? (getChallenge(refreshed.id) ?? result) : result
+    const refreshed = await refreshImportedCodeforcesChallenge(result.challenge, access)
+    return refreshed ? (getChallenge(refreshed.id, access) ?? result) : result
   },
-  'challenges.upsert': (input) => ({ challenge: upsertChallenge(input) }),
+  'challenges.upsert': (input, context) => {
+    const access = commandAccess(context)
+    requireOwnerAccess(access)
+    return { challenge: upsertChallenge(input, access) }
+  },
   'sources.search': (input) => searchExternalChallenges(input),
-  'sources.import': (input) => importExternalChallenge(input),
+  'sources.import': (input, context) => {
+    const access = commandAccess(context)
+    requireOwnerAccess(access)
+    return importExternalChallenge(input, access)
+  },
   'submissions.create': (input, context) => {
     if (!input.reviewer?.agentId && !input.reviewer?.assigneeLabel) {
       throw shadowApp.error(422, 'reviewer_required')
     }
-    const submission = createSubmission({ ...input, author: context.actor })
+    const access = commandAccess(context)
+    const submission = createSubmission({
+      ...input,
+      access,
+      author: context.actor,
+    })
     if (!submission) throw shadowApp.error(404, 'challenge_not_found')
-    const challenge = getSubmission(submission.id)?.challenge
+    const challenge = getSubmission(submission.id, access)?.challenge
     const task = challenge ? reviewInboxTask(submission, challenge) : null
     return task
       ? new ShadowServerAppOutbox().enqueueInboxTask(task).attachTo({ submission })
       : { submission }
   },
-  'submissions.list': (input) => ({ submissions: listSubmissions(input) }),
-  'submissions.get': (input) => {
-    const result = getSubmission(input.submissionId)
+  'submissions.list': (input, context) => ({
+    submissions: listSubmissions(input, commandAccess(context)),
+  }),
+  'submissions.get': (input, context) => {
+    const result = getSubmission(input.submissionId, commandAccess(context))
     if (!result) throw shadowApp.error(404, 'submission_not_found')
     return result
   },
-  'submissions.pending': (input) => ({ submissions: pendingSubmissions(input) }),
+  'submissions.pending': (input, context) => ({
+    submissions: pendingSubmissions(input, commandAccess(context)),
+  }),
   'submissions.analyze': (input, context) => {
-    const submission = analyzeSubmission({ ...input, analyzer: context.actor })
+    const submission = analyzeSubmission({
+      ...input,
+      access: commandAccess(context),
+      analyzer: context.actor,
+    })
     if (!submission) throw shadowApp.error(404, 'submission_not_found')
     return { submission }
   },

--- a/integrations/trainer/src/shadow-app.generated.ts
+++ b/integrations/trainer/src/shadow-app.generated.ts
@@ -43,6 +43,11 @@ export const shadowServerAppManifest = {
           difficulty: {
             enum: ['easy', 'medium', 'hard'],
           },
+          tag: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 40,
+          },
         },
         additionalProperties: false,
       },
@@ -159,7 +164,7 @@ export const shadowServerAppManifest = {
         type: 'object',
         properties: {
           provider: {
-            enum: ['exercism', 'leetcode', 'codeforces'],
+            enum: ['leetcode', 'codeforces'],
           },
           query: {
             type: 'string',
@@ -193,7 +198,7 @@ export const shadowServerAppManifest = {
         required: ['sourceId'],
         properties: {
           provider: {
-            enum: ['exercism', 'leetcode', 'codeforces'],
+            enum: ['leetcode', 'codeforces'],
           },
           sourceId: {
             type: 'string',
@@ -250,6 +255,24 @@ export const shadowServerAppManifest = {
               },
               reviewFocus: {
                 enum: ['standard', 'interview', 'debug', 'complexity'],
+              },
+              coachingFocuses: {
+                type: 'array',
+                maxItems: 8,
+                items: {
+                  enum: [
+                    'reasoning',
+                    'edge_cases',
+                    'complexity',
+                    'communication',
+                    'follow_ups',
+                    'debugging',
+                  ],
+                },
+              },
+              locale: {
+                type: 'string',
+                maxLength: 32,
               },
             },
             additionalProperties: false,

--- a/integrations/trainer/src/sources.ts
+++ b/integrations/trainer/src/sources.ts
@@ -1,28 +1,8 @@
 import * as cheerio from 'cheerio'
-import { upsertChallenge } from './data.js'
-import type { Challenge, ChallengeDifficulty, ChallengeTestCase } from './types.js'
+import { type TrainerAccess, upsertChallenge } from './data.js'
+import type { Challenge, ChallengeDifficulty } from './types.js'
 
-type SourceProvider = 'exercism' | 'leetcode' | 'codeforces'
-
-interface GitHubContentEntry {
-  name: string
-  type: string
-  html_url?: string
-}
-
-interface ExercismCanonicalCase {
-  uuid?: string
-  description?: string
-  property?: string
-  input?: unknown
-  expected?: unknown
-  cases?: ExercismCanonicalCase[]
-}
-
-interface ExercismCanonicalData {
-  exercise?: string
-  cases?: ExercismCanonicalCase[]
-}
+type SourceProvider = 'leetcode' | 'codeforces'
 
 interface LeetCodeListProblem {
   acRate?: number
@@ -79,10 +59,6 @@ interface CodeforcesProblemsetResponse {
   }
 }
 
-const exercismRawBase =
-  'https://raw.githubusercontent.com/exercism/problem-specifications/main/exercises'
-const exercismContentsUrl =
-  'https://api.github.com/repos/exercism/problem-specifications/contents/exercises'
 const leetcodeApiBase = (
   process.env.LEETCODE_API_BASE_URL ?? 'https://alfa-leetcode-api.onrender.com'
 ).replace(/\/+$/, '')
@@ -118,10 +94,6 @@ function identifierFromSlug(value: string) {
     )
     .join('')
   return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(candidate) ? candidate : 'solve'
-}
-
-function compactJson(value: unknown) {
-  return JSON.stringify(value, null, 2)
 }
 
 function difficultyFromText(value: string | undefined): ChallengeDifficulty {
@@ -197,29 +169,6 @@ function parseLeetCodeExamples(questionHtml: string): Challenge['examples'] {
 
 function problemFunctionStarter(sourceId: string) {
   return `function ${identifierFromSlug(sourceId)}(...args) {\n  // Write your solution here.\n}`
-}
-
-function flattenCanonicalCases(cases: ExercismCanonicalCase[] | undefined) {
-  const output: ExercismCanonicalCase[] = []
-  const visit = (items: ExercismCanonicalCase[] | undefined) => {
-    for (const item of items ?? []) {
-      if (Array.isArray(item.cases)) visit(item.cases)
-      else if ('input' in item && 'expected' in item) output.push(item)
-    }
-  }
-  visit(cases)
-  return output
-}
-
-async function fetchText(url: string) {
-  const response = await fetch(url, {
-    headers: {
-      Accept: 'text/plain, application/json',
-      'User-Agent': 'shadow-trainer',
-    },
-  })
-  if (!response.ok) throw new Error(`source_fetch_failed:${response.status}`)
-  return response.text()
 }
 
 async function fetchOptionalText(url: string) {
@@ -372,29 +321,13 @@ async function fetchCodeforcesStatement(problem: CodeforcesProblem) {
   return null
 }
 
-function canonicalCasesToChallengeCases(cases: ExercismCanonicalCase[]): ChallengeTestCase[] {
-  return cases.slice(0, 80).map((testCase, index) => ({
-    id: testCase.uuid || `case_${index + 1}`,
-    ...(testCase.description ? { description: testCase.description } : {}),
-    input: compactJson(testCase.input),
-    expected: compactJson(testCase.expected),
-    visibility: index < 2 ? 'visible' : 'hidden',
-  }))
-}
-
-function starterForSource(sourceId: string, canonicalCases: ExercismCanonicalCase[]) {
-  const property = canonicalCases.find((testCase) => testCase.property)?.property
-  const functionName = identifierFromSlug(property || sourceId)
-  return `function ${functionName}(input) {\n  // Write your solution here.\n}`
-}
-
 export async function searchExternalChallenges(input: {
   provider?: SourceProvider
   query?: string
   limit?: number
   offset?: number
 }) {
-  const provider = input.provider ?? 'exercism'
+  const provider = input.provider ?? 'leetcode'
   const query = input.query?.trim().toLowerCase()
   const limit = Math.min(Math.max(input.limit ?? 24, 1), 50)
   const offset = Math.max(input.offset ?? 0, 0)
@@ -479,23 +412,7 @@ export async function searchExternalChallenges(input: {
     return { sources, pageInfo: pageInfo(offset, limit, filtered.length, sources.length) }
   }
 
-  const entries = await fetchJson<GitHubContentEntry[]>(exercismContentsUrl)
-  const filtered = entries
-    .filter((entry) => entry.type === 'dir')
-    .filter(
-      (entry) =>
-        !query ||
-        entry.name.includes(query) ||
-        titleFromSlug(entry.name).toLowerCase().includes(query),
-    )
-  const sources = filtered.slice(offset, offset + limit).map((entry) => ({
-    provider,
-    id: entry.name,
-    title: titleFromSlug(entry.name),
-    description: 'Exercism exercise with open problem statement and canonical test data.',
-    url: entry.html_url ?? `${exercismRawBase}/${entry.name}`,
-  }))
-  return { sources, pageInfo: pageInfo(offset, limit, filtered.length, sources.length) }
+  throw new Error('unsupported_source_provider')
 }
 
 function pageInfo(offset: number, limit: number, total: number, pageSize: number) {
@@ -507,11 +424,14 @@ function pageInfo(offset: number, limit: number, total: number, pageSize: number
   }
 }
 
-export async function importExternalChallenge(input: {
-  provider?: SourceProvider
-  sourceId: string
-}) {
-  const provider = input.provider ?? 'exercism'
+export async function importExternalChallenge(
+  input: {
+    provider?: SourceProvider
+    sourceId: string
+  },
+  access: TrainerAccess,
+) {
+  const provider = input.provider ?? 'leetcode'
   const sourceId = input.sourceId.trim()
 
   if (provider === 'leetcode') {
@@ -528,44 +448,47 @@ export async function importExternalChallenge(input: {
       expected: example.output,
       visibility: 'visible' as const,
     }))
-    const challenge = upsertChallenge({
-      id: `leetcode_${sourceId}`,
-      title: detail.questionTitle,
-      difficulty: difficultyFromText(detail.difficulty),
-      tags: [
-        'leetcode',
-        'imported',
-        ...(detail.topicTags ?? []).map((tag) => tag.slug || tag.name || '').filter(Boolean),
-      ].slice(0, 12),
-      prompt: htmlToPlainText(detail.question),
-      starterCode: problemFunctionStarter(sourceId),
-      examples: examples.length
-        ? examples
-        : [
-            {
-              input: detail.exampleTestcases || 'See source problem statement',
-              output: 'Buddy should derive expected output from the source statement.',
-            },
-          ],
-      testCases,
-      judgeInstructions: [
-        'Imported from alfa-leetcode-api selected problem endpoint.',
-        'Use visible examples from the statement for initial sandbox checks.',
-        'Do not expose official solutions in learner feedback.',
-        'If additional edge cases are needed, derive them from the constraints and explain them.',
-        detail.hints?.length
-          ? `Source hints available for Buddy coaching: ${detail.hints.map(htmlFragmentToPlainText).join(' ')}`
-          : '',
-      ]
-        .filter(Boolean)
-        .join('\n'),
-      source: {
-        provider,
-        id: sourceId,
-        url: detail.link || `https://leetcode.com/problems/${sourceId}`,
-        importedAt: new Date().toISOString(),
+    const challenge = upsertChallenge(
+      {
+        id: `leetcode_${sourceId}`,
+        title: detail.questionTitle,
+        difficulty: difficultyFromText(detail.difficulty),
+        tags: [
+          'leetcode',
+          'imported',
+          ...(detail.topicTags ?? []).map((tag) => tag.slug || tag.name || '').filter(Boolean),
+        ].slice(0, 12),
+        prompt: htmlToPlainText(detail.question),
+        starterCode: problemFunctionStarter(sourceId),
+        examples: examples.length
+          ? examples
+          : [
+              {
+                input: detail.exampleTestcases || 'See source problem statement',
+                output: 'Buddy should derive expected output from the source statement.',
+              },
+            ],
+        testCases,
+        judgeInstructions: [
+          'Imported from alfa-leetcode-api selected problem endpoint.',
+          'Use visible examples from the statement for initial sandbox checks.',
+          'Do not expose official solutions in learner feedback.',
+          'If additional edge cases are needed, derive them from the constraints and explain them.',
+          detail.hints?.length
+            ? `Source hints available for Buddy coaching: ${detail.hints.map(htmlFragmentToPlainText).join(' ')}`
+            : '',
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        source: {
+          provider,
+          id: sourceId,
+          url: detail.link || `https://leetcode.com/problems/${sourceId}`,
+          importedAt: new Date().toISOString(),
+        },
       },
-    })
+      access,
+    )
     return { challenge }
   }
 
@@ -583,93 +506,57 @@ export async function importExternalChallenge(input: {
       expected: example.output,
       visibility: 'visible' as const,
     }))
-    const challenge = upsertChallenge({
-      id: `codeforces_${sourceId.toLowerCase().replace(/[^a-z0-9]+/g, '_')}`,
-      title: `${problem.contestId ?? 'Problemset'}${problem.index}. ${problem.name}`,
-      difficulty: difficultyFromCodeforces(problem),
-      tags: ['codeforces', 'imported', ...(problem.tags ?? [])].slice(0, 12),
-      prompt:
-        importedStatement?.prompt ??
-        [
-          `${problem.name} was imported from Codeforces metadata, but the statement page could not be reached from this server.`,
-          '',
-          'The official Codeforces API exposes metadata, tags, rating, and solve counts. It does not include the problem statement or sample tests.',
-          `Open the source problem for the full statement: ${codeforcesProblemUrl(problem)}`,
-        ].join('\n'),
-      starterCode:
-        'function solve(input) {\n  // Parse Codeforces stdin and write your solution here.\n}',
-      examples,
-      testCases,
-      judgeInstructions: [
-        importedStatement
-          ? 'Imported from Codeforces problemset metadata and mirror statement HTML.'
-          : 'Imported from Codeforces problemset metadata only; statement fetch failed.',
-        examples.length
-          ? 'Use imported sample tests for visible sandbox checks.'
-          : 'No sample tests were imported. Ask the learner to paste samples before sandbox validation.',
-        'Buddy should generate additional hidden edge cases from the constraints and explain why each case matters.',
-        'Do not expose official solutions in learner feedback.',
-        problem.rating ? `Problem rating: ${problem.rating}.` : '',
-        problem.tags?.length ? `Tags: ${problem.tags.join(', ')}.` : '',
-      ]
-        .filter(Boolean)
-        .join('\n'),
-      source: {
-        provider,
-        id: sourceId,
-        url: importedStatement?.statementUrl ?? codeforcesProblemUrl(problem),
-        importedAt: new Date().toISOString(),
+    const challenge = upsertChallenge(
+      {
+        id: `codeforces_${sourceId.toLowerCase().replace(/[^a-z0-9]+/g, '_')}`,
+        title: `${problem.contestId ?? 'Problemset'}${problem.index}. ${problem.name}`,
+        difficulty: difficultyFromCodeforces(problem),
+        tags: ['codeforces', 'imported', ...(problem.tags ?? [])].slice(0, 12),
+        prompt:
+          importedStatement?.prompt ??
+          [
+            `${problem.name} was imported from Codeforces metadata, but the statement page could not be reached from this server.`,
+            '',
+            'The official Codeforces API exposes metadata, tags, rating, and solve counts. It does not include the problem statement or sample tests.',
+            `Open the source problem for the full statement: ${codeforcesProblemUrl(problem)}`,
+          ].join('\n'),
+        starterCode:
+          'function solve(input) {\n  // Parse Codeforces stdin and write your solution here.\n}',
+        examples,
+        testCases,
+        judgeInstructions: [
+          importedStatement
+            ? 'Imported from Codeforces problemset metadata and mirror statement HTML.'
+            : 'Imported from Codeforces problemset metadata only; statement fetch failed.',
+          examples.length
+            ? 'Use imported sample tests for visible sandbox checks.'
+            : 'No sample tests were imported. Ask the learner to paste samples before sandbox validation.',
+          'Buddy should generate additional hidden edge cases from the constraints and explain why each case matters.',
+          'Do not expose official solutions in learner feedback.',
+          problem.rating ? `Problem rating: ${problem.rating}.` : '',
+          problem.tags?.length ? `Tags: ${problem.tags.join(', ')}.` : '',
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        source: {
+          provider,
+          id: sourceId,
+          url: importedStatement?.statementUrl ?? codeforcesProblemUrl(problem),
+          importedAt: new Date().toISOString(),
+        },
       },
-    })
+      access,
+    )
     return { challenge }
   }
 
-  if (provider !== 'exercism') throw new Error('unsupported_source_provider')
-  if (!/^[a-z0-9][a-z0-9-]*$/i.test(sourceId)) throw new Error('invalid_source_id')
-
-  const [introduction, instructions, canonicalText] = await Promise.all([
-    fetchOptionalText(`${exercismRawBase}/${sourceId}/introduction.md`),
-    fetchText(`${exercismRawBase}/${sourceId}/instructions.md`),
-    fetchText(`${exercismRawBase}/${sourceId}/canonical-data.json`),
-  ])
-  const canonical = JSON.parse(canonicalText) as ExercismCanonicalData
-  const canonicalCases = flattenCanonicalCases(canonical.cases)
-  if (canonicalCases.length === 0) throw new Error('source_has_no_canonical_tests')
-
-  const testCases = canonicalCasesToChallengeCases(canonicalCases)
-  const title = titleFromSlug(canonical.exercise || sourceId)
-  const challenge = upsertChallenge({
-    id: `exercism_${sourceId}`,
-    title,
-    difficulty: canonicalCases.length > 20 ? 'medium' : 'easy',
-    tags: ['exercism', 'imported'],
-    prompt: [introduction.trim(), instructions.trim()].filter(Boolean).join('\n\n'),
-    starterCode: starterForSource(sourceId, canonicalCases),
-    examples: testCases
-      .filter((testCase) => testCase.visibility === 'visible')
-      .map((testCase) => ({
-        input: testCase.input,
-        output: testCase.expected,
-        ...(testCase.description ? { explanation: testCase.description } : {}),
-      })),
-    testCases,
-    judgeInstructions: [
-      'Use the imported Exercism canonical cases as the primary sandbox test suite.',
-      'Visible examples may be shown to the learner. Hidden cases are for Buddy review and edge-case feedback.',
-      `Canonical test count: ${testCases.length}.`,
-    ].join('\n'),
-    source: {
-      provider,
-      id: sourceId,
-      url: `https://github.com/exercism/problem-specifications/tree/main/exercises/${sourceId}`,
-      importedAt: new Date().toISOString(),
-    },
-  })
-
-  return { challenge }
+  throw new Error('unsupported_source_provider')
 }
 
-export async function refreshImportedCodeforcesChallenge(challenge: Challenge) {
+export async function refreshImportedCodeforcesChallenge(
+  challenge: Challenge,
+  access: TrainerAccess,
+) {
   if (challenge.source?.provider !== 'codeforces') return null
   const metadataOnly =
     challenge.prompt.includes('Codeforces API exposes problem metadata') ||
@@ -678,10 +565,13 @@ export async function refreshImportedCodeforcesChallenge(challenge: Challenge) {
   if (!metadataOnly) return null
 
   try {
-    const result = await importExternalChallenge({
-      provider: 'codeforces',
-      sourceId: challenge.source.id,
-    })
+    const result = await importExternalChallenge(
+      {
+        provider: 'codeforces',
+        sourceId: challenge.source.id,
+      },
+      access,
+    )
     return result.challenge
   } catch {
     return null

--- a/integrations/trainer/src/types.ts
+++ b/integrations/trainer/src/types.ts
@@ -29,6 +29,12 @@ export interface ChallengeSource {
   importedAt?: string
 }
 
+export interface TrainerOwnerScope {
+  ownerKey: string
+  serverId: string
+  userId: string
+}
+
 export type ChallengeDifficulty = 'easy' | 'medium' | 'hard'
 export type TrainerLanguage = 'javascript' | 'typescript' | 'python'
 
@@ -43,6 +49,7 @@ export interface Challenge {
   testCases?: ChallengeTestCase[]
   judgeInstructions: string
   source?: ChallengeSource
+  owner?: TrainerOwnerScope
   createdAt?: string
   updatedAt?: string
 }
@@ -50,6 +57,13 @@ export interface Challenge {
 export type SubmissionStatus = 'submitted' | 'analyzed'
 export type SubmissionOutcome = 'accepted' | 'needs_work' | 'runtime_error' | 'incomplete'
 export type SubmissionReviewFocus = 'standard' | 'interview' | 'debug' | 'complexity'
+export type SubmissionCoachingFocus =
+  | 'reasoning'
+  | 'edge_cases'
+  | 'complexity'
+  | 'communication'
+  | 'follow_ups'
+  | 'debugging'
 
 export interface SubmissionAnalysis {
   outcome: SubmissionOutcome
@@ -67,12 +81,15 @@ export interface SubmissionReviewRequest {
   assigneeLabel?: string
   displayName?: string
   reviewFocus?: SubmissionReviewFocus
+  coachingFocuses?: SubmissionCoachingFocus[]
+  locale?: string
   requestedAt: string
 }
 
 export interface CodeSubmission {
   id: string
   challengeId: string
+  owner: TrainerOwnerScope
   author: TrainerPerson
   language: TrainerLanguage | string
   code: string


### PR DESCRIPTION
## Summary
- fix nullable app integration payload validation that caused integration POST requests to return 500
- simplify Code Trainer around the core practice flow and remove Exercism/Study surface
- add owner-scoped trainer persistence, problem switching, tag filtering, submission restore, and configurable interview coaching focus areas
- localize published Buddy tasks from the user language context

## Validation
- pnpm lint
- pnpm typecheck
- pnpm -C apps/server typecheck
- pnpm -C integrations/trainer typecheck
- pnpm -C integrations/trainer build
- browser smoke test for the admin Code Trainer app
- restart persistence smoke test for imported challenge and submission data