### PR TITLE
fix(ci): repair post-merge release builds

### DIFF
--- a/apps/cloud/images/openclaw-runner/Dockerfile
+++ b/apps/cloud/images/openclaw-runner/Dockerfile
@@ -61,6 +61,7 @@ RUN find node_modules -type d \( -name ".github" -o -name "test" -o -name "tests
 # TypeScript source changes.
 WORKDIR /workspace
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json .npmrc ./
+COPY patches patches
 COPY packages/shared/package.json packages/shared/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/cli/package.json packages/cli/package.json

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -36,7 +36,16 @@ if (isMac) {
 }
 
 function resolveDependencyDir(packageName: string) {
-  return dirname(requireFromDesktop.resolve(`${packageName}/package.json`))
+  try {
+    return dirname(requireFromDesktop.resolve(`${packageName}/package.json`))
+  } catch (error) {
+    if (!packageName.startsWith('sherpa-onnx-') || packageName === 'sherpa-onnx-node') {
+      throw error
+    }
+
+    const sherpaRequire = createRequire(requireFromDesktop.resolve('sherpa-onnx-node/package.json'))
+    return dirname(sherpaRequire.resolve(`${packageName}/package.json`))
+  }
 }
 
 function sherpaNativePackageName(platform: string, arch: string) {

--- a/apps/web/rsbuild.config.ts
+++ b/apps/web/rsbuild.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@rsbuild/core'
 import { pluginReact } from '@rsbuild/plugin-react'
 
 // Absolute path to @shadowob/cloud-ui source
+const cloudUiRoot = path.resolve(__dirname, '../cloud/packages/ui')
 const cloudUiSrc = path.resolve(__dirname, '../cloud/packages/ui/src')
 const devApiTarget = process.env.SHADOW_DEV_API_BASE ?? 'http://127.0.0.1:3002'
 
@@ -34,6 +35,7 @@ export default defineConfig({
       '@shadowob/cloud-ui/stores': path.join(cloudUiSrc, 'stores'),
       '@shadowob/cloud-ui/styles': path.join(cloudUiSrc, 'styles'),
       '@shadowob/cloud-ui/i18n': path.join(cloudUiSrc, 'i18n/index.ts'),
+      '@shadowob/cloud-ui/web-saas': path.join(cloudUiRoot, 'web-saas/index.tsx'),
     },
     conditionNames: ['development', 'import', 'module', 'default'],
   },
@@ -70,9 +72,13 @@ export default defineConfig({
       config.plugins ??= []
       config.plugins.push(
         new rspack.NormalModuleReplacementPlugin(/^@\//, (resource) => {
-          const issuer: string = resource.contextInfo?.issuer ?? resource.context ?? ''
+          const issuer = (resource.contextInfo?.issuer ?? resource.context ?? '').replaceAll(
+            '\\',
+            '/',
+          )
           const isCloudFile =
             issuer.includes('/cloud/packages/ui/src/') ||
+            issuer.includes('/cloud/packages/ui/web-saas/') ||
             issuer.includes('/cloud/src/interfaces/web-saas/')
           if (isCloudFile) {
             resource.request = path.join(cloudUiSrc, resource.request.replace(/^@\//, ''))

--- a/package.json
+++ b/package.json
@@ -8,6 +8,20 @@
   },
   "packageManager": "pnpm@10.19.0",
   "pnpm": {
+    "supportedArchitectures": {
+      "os": [
+        "current",
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "cpu": [
+        "current",
+        "x64",
+        "arm64",
+        "ia32"
+      ]
+    },
     "onlyBuiltDependencies": [
       "electron",
       "electron-winstaller",


### PR DESCRIPTION
## Summary
- install native sherpa optional packages for desktop cross-target release builds and resolve nested sherpa native packages
- fix web cloud-ui web-saas aliasing on Windows paths
- include root patches in the openclaw runner Docker build context before pnpm install

## Validation
- pnpm install --frozen-lockfile
- pnpm -C apps/desktop typecheck
- pnpm --filter @shadowob/web build
- pnpm check:sdk-versions
- pnpm exec biome check apps/cloud/images/openclaw-runner/Dockerfile apps/desktop/forge.config.ts apps/web/rsbuild.config.ts package.json --diagnostic-level=error
- git diff --check

Note: package and TestFlight workflows still require real repository credentials/secrets for main-branch publishing; no dry-run fallback is introduced.