### PR TITLE
fix(ci): unblock release reruns

### DIFF
--- a/.github/workflows/release-mobile-testflight.yml
+++ b/.github/workflows/release-mobile-testflight.yml
@@ -119,6 +119,7 @@ jobs:
     environment: ShadowOB Expo
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_ASC_APP_ID: ${{ vars.EXPO_ASC_APP_ID || secrets.EXPO_ASC_APP_ID || vars.ASC_APP_ID || secrets.ASC_APP_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -140,6 +141,30 @@ jobs:
 
       - name: Validate mobile app
         run: pnpm mobile:verify:ios
+
+      - name: Configure TestFlight submit profile
+        working-directory: apps/mobile
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${EXPO_ASC_APP_ID:-}" ]]; then
+            echo "::error::Missing EXPO_ASC_APP_ID or ASC_APP_ID in the ShadowOB Expo environment. Set it to the App Store Connect app id for com.shadowob.mobile."
+            exit 1
+          fi
+          node - <<'NODE'
+          const fs = require('node:fs')
+
+          const ascAppId = process.env.EXPO_ASC_APP_ID
+          if (!ascAppId) throw new Error('EXPO_ASC_APP_ID is required')
+
+          const file = 'eas.json'
+          const config = JSON.parse(fs.readFileSync(file, 'utf8'))
+          config.submit ??= {}
+          config.submit.production ??= {}
+          config.submit.production.ios ??= {}
+          config.submit.production.ios.ascAppId = ascAppId
+          fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`)
+          NODE
 
       - name: Build and auto-submit to TestFlight
         working-directory: apps/mobile

--- a/package.json
+++ b/package.json
@@ -151,12 +151,14 @@
       "bash -c 'pnpm typecheck:staged'"
     ]
   },
+  "optionalDependencies": {
+    "fs-xattr": "0.3.1"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
     "@vitest/coverage-v8": "^4.1.0",
-    "fs-xattr": "0.3.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.0
         version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)))
-      fs-xattr:
-        specifier: 0.3.1
-        version: 0.3.1
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -62,6 +59,10 @@ importers:
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+    optionalDependencies:
+      fs-xattr:
+        specifier: 0.3.1
+        version: 0.3.1
 
   apps/admin:
     dependencies:
@@ -27727,7 +27728,8 @@ snapshots:
       random-path: 0.1.2
     optional: true
 
-  fs-xattr@0.3.1: {}
+  fs-xattr@0.3.1:
+    optional: true
 
   fs.realpath@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- treat fs-xattr as an optional native dependency so Windows desktop release installs do not fail compiling macOS-only headers
- inject the App Store Connect app id into the EAS submit profile from the ShadowOB Expo environment before TestFlight auto-submit

## Validation
- skipped per hotfix request