### PR TITLE
fix(mobile): declare Apple sign-in capability

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -18,6 +18,7 @@ const config: ExpoConfig = {
   ios: {
     supportsTablet: true,
     bundleIdentifier: 'com.shadowob.mobile',
+    usesAppleSignIn: true,
     associatedDomains: ['applinks:shadowob.shadowob.com'],
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,


### PR DESCRIPTION
Hotfix for TestFlight signing after enabling Sign in with Apple in the Apple Developer portal.\n\n- Set ios.usesAppleSignIn so EAS capability sync knows the App Store profile needs the com.apple.developer.applesignin entitlement.\n\nSmoke tests:\n- pnpm --dir apps/mobile exec expo config --type introspect --json\n- pnpm --dir apps/mobile exec expo prebuild --no-install --platform ios