### PR TITLE
fix(ci): normalize mobile ASC private key

### DIFF
--- a/.github/workflows/release-mobile-testflight.yml
+++ b/.github/workflows/release-mobile-testflight.yml
@@ -208,9 +208,23 @@ jobs:
           if [[ -n "${EXPO_ASC_API_KEY_BASE64:-}" ]]; then
             printf '%s' "$EXPO_ASC_API_KEY_BASE64" | base64 --decode > "$key_path"
           else
-            printf '%s\n' "$EXPO_ASC_API_KEY_P8" > "$key_path"
+            python3 - <<'PY' > "$key_path"
+          import os
+
+          value = os.environ["EXPO_ASC_API_KEY_P8"]
+          if "\\n" in value:
+              value = value.replace("\\n", "\n")
+
+          print(value, end="" if value.endswith("\n") else "\n")
+          PY
           fi
           chmod 600 "$key_path"
+
+          if ! grep -q "BEGIN PRIVATE KEY" "$key_path" || ! openssl pkey -in "$key_path" -noout >/dev/null 2>&1; then
+            echo "::error::EXPO_ASC_API_KEY_P8/EXPO_ASC_API_KEY_BASE64 is not a valid App Store Connect .p8 private key."
+            exit 1
+          fi
+
           echo "EXPO_ASC_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
       - name: Build and auto-submit to TestFlight


### PR DESCRIPTION
Normalizes App Store Connect .p8 key secrets before handing them to EAS and validates the generated private key with openssl so invalid key contents fail before the EAS build step.\n\nVerification:\n- git diff --check -- .github/workflows/release-mobile-testflight.yml\n- openssl pkey -in /Users/maopeng/Downloads/AuthKey_TUT9HUCGZ6.p8 -noout\n\nAlso refreshed ShadowOB Expo secrets from /Users/maopeng/Downloads/AuthKey_TUT9HUCGZ6.p8.