### PR TITLE
fix(ci): enable apple sign in before mobile profile reset

### DIFF
--- a/.github/workflows/release-mobile-testflight.yml
+++ b/.github/workflows/release-mobile-testflight.yml
@@ -177,11 +177,6 @@ jobs:
           fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`)
           NODE
 
-      - name: Reset EAS iOS App Store provisioning profile
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.reset_ios_profile == true }}
-        working-directory: apps/mobile
-        run: node scripts/reset-eas-ios-profile.mjs
-
       - name: Configure ASC API key for EAS credential repair
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.reset_ios_profile == true }}
         shell: bash
@@ -226,6 +221,16 @@ jobs:
           fi
 
           echo "EXPO_ASC_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
+      - name: Ensure Sign in with Apple capability
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.reset_ios_profile == true }}
+        working-directory: apps/mobile
+        run: node scripts/ensure-apple-signin-capability.mjs
+
+      - name: Reset EAS iOS App Store provisioning profile
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.reset_ios_profile == true }}
+        working-directory: apps/mobile
+        run: node scripts/reset-eas-ios-profile.mjs
 
       - name: Build and auto-submit to TestFlight
         working-directory: apps/mobile

--- a/apps/mobile/scripts/ensure-apple-signin-capability.mjs
+++ b/apps/mobile/scripts/ensure-apple-signin-capability.mjs
@@ -1,0 +1,107 @@
+import { createSign } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+
+const ASC_API_URL = 'https://api.appstoreconnect.apple.com/v1'
+const BUNDLE_IDENTIFIER = 'com.shadowob.mobile'
+const APPLE_SIGN_IN_CAPABILITY = 'APPLE_ID_AUTH'
+
+function requireEnv(name) {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} is required`)
+  }
+  return value
+}
+
+function base64Url(input) {
+  return Buffer.from(input)
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '')
+}
+
+function createJwt() {
+  const keyId = requireEnv('EXPO_ASC_KEY_ID')
+  const issuerId = requireEnv('EXPO_ASC_ISSUER_ID')
+  const privateKey = readFileSync(requireEnv('EXPO_ASC_API_KEY_PATH'), 'utf8')
+  const now = Math.floor(Date.now() / 1000)
+
+  const header = base64Url(JSON.stringify({ alg: 'ES256', kid: keyId, typ: 'JWT' }))
+  const payload = base64Url(
+    JSON.stringify({
+      aud: 'appstoreconnect-v1',
+      exp: now + 10 * 60,
+      iat: now,
+      iss: issuerId,
+    }),
+  )
+  const unsignedToken = `${header}.${payload}`
+  const signature = createSign('SHA256').update(unsignedToken).sign(privateKey)
+  return `${unsignedToken}.${base64Url(signature)}`
+}
+
+async function appStoreConnect(path, init = {}) {
+  const response = await fetch(`${ASC_API_URL}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${createJwt()}`,
+      'content-type': 'application/json',
+      ...init.headers,
+    },
+  })
+
+  const text = await response.text()
+  const body = text ? JSON.parse(text) : null
+  if (!response.ok) {
+    const message =
+      body?.errors
+        ?.map((error) => `${error.status ?? response.status}: ${error.detail ?? error.title}`)
+        .join('; ') ?? response.statusText
+    throw new Error(`App Store Connect API request failed for ${path}: ${message}`)
+  }
+  return body
+}
+
+const bundleIds = await appStoreConnect(
+  `/bundleIds?filter[identifier]=${encodeURIComponent(BUNDLE_IDENTIFIER)}&fields[bundleIds]=identifier`,
+)
+const bundleId = bundleIds.data?.find((item) => item.attributes?.identifier === BUNDLE_IDENTIFIER)
+
+if (!bundleId) {
+  throw new Error(`Bundle ID ${BUNDLE_IDENTIFIER} was not found in App Store Connect`)
+}
+
+const capabilities = await appStoreConnect(
+  `/bundleIds/${bundleId.id}/bundleIdCapabilities?fields[bundleIdCapabilities]=capabilityType`,
+)
+const hasAppleSignIn = capabilities.data?.some(
+  (capability) => capability.attributes?.capabilityType === APPLE_SIGN_IN_CAPABILITY,
+)
+
+if (hasAppleSignIn) {
+  console.log(`Bundle ID ${BUNDLE_IDENTIFIER} already has Sign in with Apple enabled.`)
+  process.exit(0)
+}
+
+await appStoreConnect('/bundleIdCapabilities', {
+  method: 'POST',
+  body: JSON.stringify({
+    data: {
+      type: 'bundleIdCapabilities',
+      attributes: {
+        capabilityType: APPLE_SIGN_IN_CAPABILITY,
+      },
+      relationships: {
+        bundleId: {
+          data: {
+            id: bundleId.id,
+            type: 'bundleIds',
+          },
+        },
+      },
+    },
+  }),
+})
+
+console.log(`Enabled Sign in with Apple for Bundle ID ${BUNDLE_IDENTIFIER}.`)


### PR DESCRIPTION
Adds an App Store Connect API step to ensure com.shadowob.mobile has the Sign in with Apple Bundle ID capability before EAS deletes and regenerates the App Store provisioning profile. This targets the current Xcode failure where the newly-created profile still lacks com.apple.developer.applesignin.\n\nVerification:\n- node --check apps/mobile/scripts/ensure-apple-signin-capability.mjs\n- pnpm biome format --write apps/mobile/scripts/ensure-apple-signin-capability.mjs .github/workflows/release-mobile-testflight.yml\n- git diff --check -- .github/workflows/release-mobile-testflight.yml apps/mobile/scripts/ensure-apple-signin-capability.mjs