### PR TITLE
fix(ci): auto bump mobile release version

### DIFF
--- a/.github/workflows/release-mobile-testflight.yml
+++ b/.github/workflows/release-mobile-testflight.yml
@@ -32,7 +32,11 @@ jobs:
   gate:
     name: Detect releasable mobile changes
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    if: |
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      !startsWith(github.event.workflow_run.head_commit.message || '', 'chore(release): mobile v'))
     outputs:
       should_release: ${{ steps.gate.outputs.should_release }}
       tag: ${{ steps.gate.outputs.tag }}
@@ -150,6 +154,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Prepare mobile release version
+        id: mobile_version
+        working-directory: apps/mobile
+        run: node scripts/prepare-release-version.mjs
+
       - name: Validate mobile app
         run: pnpm mobile:verify:ios
 
@@ -240,14 +249,26 @@ jobs:
             --profile production \
             --auto-submit \
             --non-interactive \
-            --message "Mobile TestFlight ${{ needs.gate.outputs.tag }} ${{ needs.gate.outputs.head_sha }}"
+            --message "Mobile TestFlight ${{ steps.mobile_version.outputs.version }} ${{ needs.gate.outputs.tag }} ${{ needs.gate.outputs.head_sha }}"
 
       - name: Mark daily mobile TestFlight release
         shell: bash
+        env:
+          RELEASE_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
         run: |
           set -euo pipefail
           git fetch --force --tags
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add apps/mobile/app.config.ts
+          if git diff --cached --quiet; then
+            echo "No mobile release version change to commit."
+          else
+            git commit -m "chore(release): mobile v${{ steps.mobile_version.outputs.version }}"
+          fi
+
           git tag -a "${{ needs.gate.outputs.tag }}" -m "Mobile TestFlight ${{ needs.gate.outputs.tag }}"
-          git push origin "${{ needs.gate.outputs.tag }}"
+          git tag -a "${{ steps.mobile_version.outputs.version_tag }}" -m "Mobile app ${{ steps.mobile_version.outputs.version }}"
+          git push origin "HEAD:${RELEASE_BRANCH}"
+          git push origin "${{ needs.gate.outputs.tag }}" "${{ steps.mobile_version.outputs.version_tag }}"

--- a/apps/mobile/scripts/prepare-release-version.mjs
+++ b/apps/mobile/scripts/prepare-release-version.mjs
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process'
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs'
+
+const APP_CONFIG_PATH = 'app.config.ts'
+const VERSION_TAG_PREFIX = 'mobile-version-v'
+
+function parseSemver(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+  if (!match) {
+    throw new Error(`Unsupported mobile app version: ${version}`)
+  }
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+  }
+}
+
+function compareSemver(left, right) {
+  const a = parseSemver(left)
+  const b = parseSemver(right)
+  if (a.major !== b.major) return a.major - b.major
+  if (a.minor !== b.minor) return a.minor - b.minor
+  return a.patch - b.patch
+}
+
+function bumpPatch(version) {
+  const parsed = parseSemver(version)
+  return `${parsed.major}.${parsed.minor}.${parsed.patch + 1}`
+}
+
+function currentConfigVersion(content) {
+  const match = content.match(/(^\s*version:\s*['"])(\d+\.\d+\.\d+)(['"]\s*,)/m)
+  if (!match) {
+    throw new Error(`Cannot find a static semver version in ${APP_CONFIG_PATH}`)
+  }
+  return {
+    match,
+    version: match[2],
+  }
+}
+
+function mobileVersionTags() {
+  const output = execFileSync('git', ['tag', '--list', `${VERSION_TAG_PREFIX}*`], {
+    encoding: 'utf8',
+  })
+
+  return output
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .map((tag) => tag.slice(VERSION_TAG_PREFIX.length))
+    .filter((version) => /^\d+\.\d+\.\d+$/.test(version))
+}
+
+const content = readFileSync(APP_CONFIG_PATH, 'utf8')
+const configVersion = currentConfigVersion(content)
+const versions = [configVersion.version, ...mobileVersionTags()].sort(compareSemver)
+const baseVersion = versions.at(-1)
+const releaseVersion = bumpPatch(baseVersion)
+const patched = content.replace(
+  configVersion.match[0],
+  `${configVersion.match[1]}${releaseVersion}${configVersion.match[3]}`,
+)
+
+writeFileSync(APP_CONFIG_PATH, patched)
+
+console.log(`Mobile app version: ${baseVersion} -> ${releaseVersion}`)
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `base_version=${baseVersion}\n`)
+  appendFileSync(process.env.GITHUB_OUTPUT, `version=${releaseVersion}\n`)
+  appendFileSync(process.env.GITHUB_OUTPUT, `version_tag=${VERSION_TAG_PREFIX}${releaseVersion}\n`)
+}


### PR DESCRIPTION
Adds a mobile release version ledger and automatic patch bump for TestFlight releases. The release workflow now prepares a new Expo app version from the highest of app.config.ts and mobile-version-v* tags, builds with that version, commits the app.config.ts bump after a successful submission, and tags both the daily release and the mobile app version. It also ignores mobile release commits to avoid release loops.\n\nVerification:\n- node --check apps/mobile/scripts/prepare-release-version.mjs\n- pnpm biome format --write apps/mobile/scripts/prepare-release-version.mjs .github/workflows/release-mobile-testflight.yml\n- git diff --check -- .github/workflows/release-mobile-testflight.yml apps/mobile/scripts/prepare-release-version.mjs\n- temp-dir smoke: 1.3.3 -> 1.3.4