### PR TITLE
[codex] Fix desktop community auth state synchronization

### DIFF
--- a/apps/desktop/src/main/connector-daemon.ts
+++ b/apps/desktop/src/main/connector-daemon.ts
@@ -4,6 +4,11 @@ import { hostname } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { app, BrowserWindow, ipcMain, net } from 'electron'
 import {
+  COMMUNITY_ACCESS_TOKEN_FROM_STORAGE_SCRIPT,
+  communityAccessTokenFromAuthorizationHeader,
+  normalizeCommunityAccessToken,
+} from '../shared/community-auth'
+import {
   connectorWorkDirMapFilePath,
   type DesktopRuntimeSettings,
   normalizeConnectorApiKey,
@@ -216,16 +221,10 @@ async function readAccessTokenFromWindow(win: BrowserWindow | null): Promise<str
   }
   try {
     const token = (await win.webContents.executeJavaScript(
-      `(() => {
-        try {
-          return localStorage.getItem('accessToken') || ''
-        } catch {
-          return ''
-        }
-      })()`,
+      COMMUNITY_ACCESS_TOKEN_FROM_STORAGE_SCRIPT,
       true,
     )) as unknown
-    const normalizedToken = typeof token === 'string' ? token.trim() : ''
+    const normalizedToken = normalizeCommunityAccessToken(token)
     if (normalizedToken) lastCommunityAccessToken = normalizedToken
     return normalizedToken
   } catch {
@@ -242,8 +241,19 @@ async function readAccessTokenFromOpenWindows(): Promise<string> {
 }
 
 export function rememberCommunityAccessToken(token: string | null | undefined): void {
-  const normalizedToken = typeof token === 'string' ? token.trim() : ''
+  const normalizedToken = normalizeCommunityAccessToken(token)
   if (normalizedToken) lastCommunityAccessToken = normalizedToken
+}
+
+export function rememberCommunityAuthorizationHeader(header: string | null | undefined): void {
+  rememberCommunityAccessToken(communityAccessTokenFromAuthorizationHeader(header))
+}
+
+export function forgetCommunityAccessToken(token?: string | null): void {
+  const normalizedToken = normalizeCommunityAccessToken(token)
+  if (!normalizedToken || normalizedToken === lastCommunityAccessToken) {
+    lastCommunityAccessToken = ''
+  }
 }
 
 export async function readCommunityAccessToken(): Promise<string> {
@@ -272,6 +282,7 @@ async function fetchCommunityJson<T>(path: string, options: RequestInit = {}): P
   })
   if (!response.ok) {
     const body = await response.text().catch(() => '')
+    if (response.status === 401 || response.status === 403) forgetCommunityAccessToken(token)
     throw new Error(`Community API ${path} failed (${response.status})${body ? `: ${body}` : ''}`)
   }
   return (await response.json()) as T

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,7 +13,10 @@ import {
   session,
   shell,
 } from 'electron'
-import { DESKTOP_COMMUNITY_AUTH_REQUIRED } from '../shared/community-auth'
+import {
+  DESKTOP_COMMUNITY_AUTH_REQUIRED,
+  normalizeCommunityAccessToken,
+} from '../shared/community-auth'
 
 // Suppress EPIPE errors that occur when a child process dies while the main
 // process writes to its stdio pipe (e.g. gateway process exit).
@@ -24,8 +27,10 @@ process.on('uncaughtException', (err) => {
 
 import { setupAutoUpdater } from './auto-updater'
 import {
+  forgetCommunityAccessToken,
   readCommunityAccessToken,
   rememberCommunityAccessToken,
+  rememberCommunityAuthorizationHeader,
   setupConnectorDaemonHandlers,
   startConnectorDaemonIfEnabled,
   stopConnectorDaemon,
@@ -252,6 +257,18 @@ function getReaderState(): { activeId: string | null; tabs: ReaderResourceSnapsh
   return { activeId, tabs }
 }
 
+function isCommunityAuthSnapshotSource(sourceUrl: string): boolean {
+  try {
+    const url = new URL(sourceUrl)
+    if (url.protocol === 'app:' && url.hostname === 'shadow') return true
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
+    const serverOrigin = new URL(getDesktopServerBaseUrl()).origin
+    return url.origin === serverOrigin
+  } catch {
+    return false
+  }
+}
+
 function publishReaderState(): void {
   const win = getReaderWindow()
   if (!win || win.isDestroyed()) return
@@ -279,8 +296,10 @@ async function fetchReaderResource(rawUrl: string, title: string): Promise<Reade
     const token = await readCommunityAccessToken()
     if (token && isTrustedCommunityUrl(url)) headers.set('Authorization', `Bearer ${token}`)
     const response = await net.fetch(url.toString(), { headers })
-    if (response.status === 401 || response.status === 403)
+    if (response.status === 401 || response.status === 403) {
+      forgetCommunityAccessToken(token)
       throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
+    }
     if (!response.ok) throw new Error(`READER_FETCH_FAILED_${response.status}`)
     buffer = Buffer.from(await response.arrayBuffer())
     contentType = inferContentType(url, response.headers.get('content-type') ?? '')
@@ -324,8 +343,10 @@ async function resolveReaderAttachmentUrl(attachmentId: string): Promise<string>
     },
   )
   const text = await response.text()
-  if (response.status === 401 || response.status === 403)
+  if (response.status === 401 || response.status === 403) {
+    forgetCommunityAccessToken(token)
     throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
+  }
   if (!response.ok) throw new Error(text || `READER_ATTACHMENT_URL_FAILED_${response.status}`)
   const payload = text ? (JSON.parse(text) as { url?: unknown }) : {}
   if (typeof payload.url !== 'string' || !payload.url)
@@ -438,6 +459,7 @@ app.on('ready', async () => {
         request.method === 'GET' || request.method === 'HEAD'
           ? undefined
           : await request.arrayBuffer()
+      rememberCommunityAuthorizationHeader(request.headers.get('authorization'))
       return net.fetch(`${getDesktopServerBaseUrl()}${filePath}${url.search}`, {
         method: request.method,
         headers: request.headers,
@@ -590,11 +612,25 @@ app.on('ready', async () => {
   )
 
   ipcMain.handle('desktop:quit', () => app.quit())
-  ipcMain.on('desktop:communityAuthSnapshot', (_event, payload: { accessToken?: unknown }) => {
-    rememberCommunityAccessToken(
-      typeof payload?.accessToken === 'string' ? payload.accessToken : '',
-    )
-  })
+  ipcMain.on(
+    'desktop:communityAuthSnapshot',
+    (
+      event,
+      payload: {
+        accessToken?: unknown
+        sourceUrl?: unknown
+      },
+    ) => {
+      const token = normalizeCommunityAccessToken(payload?.accessToken)
+      const sourceUrl =
+        typeof payload?.sourceUrl === 'string' ? payload.sourceUrl : event.sender.getURL()
+      if (token) {
+        rememberCommunityAccessToken(token)
+      } else if (isCommunityAuthSnapshotSource(sourceUrl)) {
+        forgetCommunityAccessToken()
+      }
+    },
+  )
   ipcMain.handle('desktop:getCommunityAuthToken', () => readCommunityAccessToken())
   ipcMain.handle(
     'desktop:community:fetchJson',
@@ -620,8 +656,10 @@ app.on('ready', async () => {
         body: input.body === undefined ? undefined : JSON.stringify(input.body),
       })
       const text = await response.text()
-      if (response.status === 401 || response.status === 403)
+      if (response.status === 401 || response.status === 403) {
+        forgetCommunityAccessToken(token)
         throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
+      }
       if (!response.ok) throw new Error(text || `REQUEST_FAILED_${response.status}`)
       return text ? (JSON.parse(text) as unknown) : null
     },
@@ -647,8 +685,10 @@ app.on('ready', async () => {
         body: JSON.stringify({ ...input.body, stream: true }),
       })
       if (!response.ok) {
-        if (response.status === 401 || response.status === 403)
+        if (response.status === 401 || response.status === 403) {
+          forgetCommunityAccessToken(token)
           throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
+        }
         const text = await response.text().catch(() => '')
         throw new Error(text || `REQUEST_FAILED_${response.status}`)
       }

--- a/apps/desktop/src/main/pet-assets.ts
+++ b/apps/desktop/src/main/pet-assets.ts
@@ -14,7 +14,7 @@ import { basename, dirname, join, normalize, relative, sep } from 'node:path'
 import { app, dialog, ipcMain, nativeImage, net } from 'electron'
 import JSZip from 'jszip'
 import { DESKTOP_COMMUNITY_AUTH_REQUIRED } from '../shared/community-auth'
-import { readCommunityAccessToken } from './connector-daemon'
+import { forgetCommunityAccessToken, readCommunityAccessToken } from './connector-daemon'
 import {
   broadcastDesktopSettings,
   type DesktopPetAssetPack,
@@ -464,8 +464,10 @@ async function fetchMarketplaceJson<T>(path: string, init?: RequestInit): Promis
     },
   })
   const text = await response.text()
-  if (response.status === 401 || response.status === 403)
+  if (response.status === 401 || response.status === 403) {
+    forgetCommunityAccessToken(token)
     throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
+  }
   if (!response.ok) throw new Error(text || `REQUEST_FAILED_${response.status}`)
   return (text ? JSON.parse(text) : null) as T
 }
@@ -484,8 +486,10 @@ async function downloadMarketplacePaidFile(fileId: string): Promise<Buffer> {
     headers['x-paid-file-grant-token'] = opened.grantToken
   }
   const response = await net.fetch(url.toString(), { headers })
-  if (response.status === 401 || response.status === 403)
+  if (response.status === 401 || response.status === 403) {
+    forgetCommunityAccessToken()
     throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
+  }
   if (!response.ok) throw new Error(`PAID_FILE_DOWNLOAD_FAILED_${response.status}`)
   const fileName = url.pathname.split('/').pop()?.toLowerCase() ?? ''
   const contentType = response.headers.get('content-type')?.toLowerCase() ?? ''

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -2,7 +2,9 @@ import { contextBridge, ipcRenderer } from 'electron'
 import {
   DESKTOP_COMMUNITY_AUTH_REQUIRED_EVENT,
   isCommunityAuthRequiredError,
+  normalizeCommunityAccessToken,
   normalizeCommunityAuthError,
+  readCommunityAccessTokenFromStorage,
 } from '../shared/community-auth'
 
 function applyDesktopDocumentClasses(): void {
@@ -19,13 +21,23 @@ function applyDesktopDocumentClasses(): void {
 
 let lastSyncedCommunityAuthToken: string | null = null
 
-function syncCommunityAuthToken(options: { force?: boolean } = {}): void {
+function readCommunityAuthTokenSnapshot(): string {
+  return readCommunityAccessTokenFromStorage((key) => window.localStorage?.getItem(key))
+}
+
+function syncCommunityAuthSnapshot(
+  options: { force?: boolean; accessToken?: string | null } = {},
+): void {
   try {
-    const accessToken = window.localStorage?.getItem('accessToken') ?? ''
+    const accessToken =
+      options.accessToken === undefined
+        ? readCommunityAuthTokenSnapshot()
+        : normalizeCommunityAccessToken(options.accessToken)
     if (!options.force && accessToken === lastSyncedCommunityAuthToken) return
     lastSyncedCommunityAuthToken = accessToken
     ipcRenderer.send('desktop:communityAuthSnapshot', {
       accessToken,
+      sourceUrl: window.location.href,
     })
   } catch {
     // Ignore origins where localStorage is unavailable.
@@ -33,11 +45,11 @@ function syncCommunityAuthToken(options: { force?: boolean } = {}): void {
 }
 
 function forceSyncCommunityAuthToken(): void {
-  syncCommunityAuthToken({ force: true })
+  syncCommunityAuthSnapshot({ force: true })
 }
 
 function syncCommunityAuthTokenOnStorage(): void {
-  syncCommunityAuthToken()
+  syncCommunityAuthSnapshot()
 }
 
 function dispatchCommunityAuthRequired(): void {
@@ -108,6 +120,9 @@ const desktopAPI = {
   },
   getCommunityAuthToken: () => {
     return ipcRenderer.invoke('desktop:getCommunityAuthToken') as Promise<string>
+  },
+  syncCommunityAuthToken: (accessToken?: string | null) => {
+    syncCommunityAuthSnapshot({ force: true, accessToken })
   },
   communityFetchJson: (input: {
     path: string
@@ -646,6 +661,6 @@ window.addEventListener('DOMContentLoaded', forceSyncCommunityAuthToken)
 window.addEventListener('load', forceSyncCommunityAuthToken)
 window.addEventListener('focus', forceSyncCommunityAuthToken)
 window.addEventListener('storage', syncCommunityAuthTokenOnStorage)
-window.setInterval(syncCommunityAuthToken, 5000)
+window.setInterval(syncCommunityAuthSnapshot, 5000)
 
 export type DesktopAPI = typeof desktopAPI

--- a/apps/desktop/src/renderer/lib/pet-community.ts
+++ b/apps/desktop/src/renderer/lib/pet-community.ts
@@ -1,6 +1,7 @@
 import {
   DESKTOP_COMMUNITY_AUTH_REQUIRED,
   DESKTOP_COMMUNITY_AUTH_REQUIRED_EVENT,
+  readCommunityAccessTokenFromStorage,
 } from '../../shared/community-auth'
 import type {
   ChannelSubscription,
@@ -75,7 +76,7 @@ export async function readShadowAccessToken(api: ShadowCommunityAuthApi | null):
   } catch {
     // Fall back to the current renderer's storage for non-desktop previews.
   }
-  return localStorage.getItem('accessToken')?.trim() ?? ''
+  return readCommunityAccessTokenFromStorage((key) => localStorage.getItem(key))
 }
 
 export async function fetchShadow<T>(

--- a/apps/desktop/src/shared/community-auth.ts
+++ b/apps/desktop/src/shared/community-auth.ts
@@ -1,6 +1,17 @@
 export const DESKTOP_COMMUNITY_AUTH_REQUIRED = 'AUTH_REQUIRED'
 export const DESKTOP_COMMUNITY_AUTH_REQUIRED_EVENT = 'shadow:desktop-community-auth-required'
 
+const ACCESS_TOKEN_STORAGE_KEYS = ['accessToken', 'shadowAccessToken', 'shadow:accessToken']
+const ACCESS_TOKEN_CONTAINER_KEYS = [
+  'auth',
+  'auth-storage',
+  'shadow-auth',
+  'shadow:auth',
+  'shadow:auth-storage',
+]
+const MAX_TOKEN_SEARCH_DEPTH = 4
+const MAX_TOKEN_SEARCH_KEYS = 80
+
 export class DesktopCommunityAuthRequiredError extends Error {
   readonly code = DESKTOP_COMMUNITY_AUTH_REQUIRED
 
@@ -28,3 +39,139 @@ export function normalizeCommunityAuthError(error: unknown) {
   if (!isCommunityAuthRequiredError(error)) return error
   return new DesktopCommunityAuthRequiredError()
 }
+
+export function normalizeCommunityAccessToken(token: unknown): string {
+  return typeof token === 'string' ? token.trim() : ''
+}
+
+function extractTokenFromValue(value: unknown, depth = 0): string {
+  if (!value || depth > MAX_TOKEN_SEARCH_DEPTH) return ''
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed || (!trimmed.startsWith('{') && !trimmed.startsWith('['))) return ''
+    try {
+      return extractTokenFromValue(JSON.parse(trimmed) as unknown, depth + 1)
+    } catch {
+      return ''
+    }
+  }
+  if (typeof value !== 'object') return ''
+
+  if (Array.isArray(value)) {
+    for (const item of value.slice(0, MAX_TOKEN_SEARCH_KEYS)) {
+      const token = extractTokenFromValue(item, depth + 1)
+      if (token) return token
+    }
+    return ''
+  }
+
+  const record = value as Record<string, unknown>
+  const directToken = normalizeCommunityAccessToken(record.accessToken)
+  if (directToken) return directToken
+
+  for (const item of Object.values(record).slice(0, MAX_TOKEN_SEARCH_KEYS)) {
+    const token = extractTokenFromValue(item, depth + 1)
+    if (token) return token
+  }
+  return ''
+}
+
+export function readCommunityAccessTokenFromStorage(
+  getItem: (key: string) => string | null | undefined,
+): string {
+  for (const key of ACCESS_TOKEN_STORAGE_KEYS) {
+    const token = normalizeCommunityAccessToken(getItem(key))
+    if (token) return token
+  }
+
+  for (const key of ACCESS_TOKEN_CONTAINER_KEYS) {
+    const token = extractTokenFromValue(getItem(key))
+    if (token) return token
+  }
+
+  return ''
+}
+
+export function readCommunityAccessTokenFromStorageRecord(
+  entries: Iterable<readonly [string, unknown]>,
+): string {
+  const byKey = new Map<string, unknown>()
+  let count = 0
+  for (const [key, value] of entries) {
+    if (count >= MAX_TOKEN_SEARCH_KEYS) break
+    byKey.set(key, value)
+    count += 1
+  }
+
+  const directToken = readCommunityAccessTokenFromStorage((key) => {
+    const value = byKey.get(key)
+    return typeof value === 'string' ? value : null
+  })
+  if (directToken) return directToken
+
+  for (const value of byKey.values()) {
+    const token = extractTokenFromValue(value)
+    if (token) return token
+  }
+  return ''
+}
+
+export function communityAccessTokenFromAuthorizationHeader(header: unknown): string {
+  const value = normalizeCommunityAccessToken(header)
+  const match = /^bearer\s+(.+)$/i.exec(value)
+  return normalizeCommunityAccessToken(match?.[1])
+}
+
+export const COMMUNITY_ACCESS_TOKEN_FROM_STORAGE_SCRIPT = `(() => {
+  const directKeys = ${JSON.stringify(ACCESS_TOKEN_STORAGE_KEYS)}
+  const containerKeys = ${JSON.stringify(ACCESS_TOKEN_CONTAINER_KEYS)}
+  const maxDepth = ${MAX_TOKEN_SEARCH_DEPTH}
+  const maxKeys = ${MAX_TOKEN_SEARCH_KEYS}
+  const normalize = (value) => (typeof value === 'string' ? value.trim() : '')
+  const extract = (value, depth = 0) => {
+    if (!value || depth > maxDepth) return ''
+    if (typeof value === 'string') {
+      const trimmed = value.trim()
+      if (!trimmed || (!trimmed.startsWith('{') && !trimmed.startsWith('['))) return ''
+      try {
+        return extract(JSON.parse(trimmed), depth + 1)
+      } catch {
+        return ''
+      }
+    }
+    if (typeof value !== 'object') return ''
+    if (Array.isArray(value)) {
+      for (const item of value.slice(0, maxKeys)) {
+        const token = extract(item, depth + 1)
+        if (token) return token
+      }
+      return ''
+    }
+    const direct = normalize(value.accessToken)
+    if (direct) return direct
+    for (const item of Object.values(value).slice(0, maxKeys)) {
+      const token = extract(item, depth + 1)
+      if (token) return token
+    }
+    return ''
+  }
+
+  try {
+    for (const key of directKeys) {
+      const token = normalize(localStorage.getItem(key))
+      if (token) return token
+    }
+    for (const key of containerKeys) {
+      const token = extract(localStorage.getItem(key))
+      if (token) return token
+    }
+    for (let index = 0; index < Math.min(localStorage.length, maxKeys); index += 1) {
+      const key = localStorage.key(index)
+      const token = key ? extract(localStorage.getItem(key)) : ''
+      if (token) return token
+    }
+  } catch {
+    return ''
+  }
+  return ''
+})()`

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { getApiUrl } from './api-url'
 import { currentAppRedirect } from './auth-redirect'
 import { clearAuthenticatedSession } from './auth-session'
+import { syncDesktopCommunityAuthToken } from './desktop-community-auth'
 
 export class ApiError extends Error {
   status: number
@@ -91,6 +92,7 @@ async function refreshAccessToken(): Promise<string | null> {
     const data = (await res.json()) as { accessToken: string; refreshToken: string }
     localStorage.setItem('accessToken', data.accessToken)
     localStorage.setItem('refreshToken', data.refreshToken)
+    syncDesktopCommunityAuthToken(data.accessToken)
     return data.accessToken
   } catch {
     return null

--- a/apps/web/src/lib/auth-session.ts
+++ b/apps/web/src/lib/auth-session.ts
@@ -1,6 +1,7 @@
 import { useAuthStore } from '../stores/auth.store'
 import { useChatStore } from '../stores/chat.store'
 import { getApiUrl } from './api-url'
+import { syncDesktopCommunityAuthToken } from './desktop-community-auth'
 import { queryClient } from './query-client'
 import { disconnectSocket } from './socket'
 
@@ -45,6 +46,7 @@ function isAuthPath(pathname: string) {
 }
 
 function markAuthenticated(user: AuthenticatedUser, accessToken: string) {
+  syncDesktopCommunityAuthToken(accessToken)
   useAuthStore.setState({ user, accessToken, isAuthenticated: true })
   queryClient.setQueryData(['me'], user)
 }
@@ -73,6 +75,7 @@ async function refreshStoredTokens(): Promise<StoredTokens | null> {
   const data = (await response.json()) as StoredTokens
   localStorage.setItem('accessToken', data.accessToken)
   localStorage.setItem('refreshToken', data.refreshToken)
+  syncDesktopCommunityAuthToken(data.accessToken)
   return data
 }
 

--- a/apps/web/src/lib/desktop-community-auth.ts
+++ b/apps/web/src/lib/desktop-community-auth.ts
@@ -1,0 +1,9 @@
+type DesktopCommunityAuthBridge = {
+  syncCommunityAuthToken?: (accessToken?: string | null) => void
+}
+
+export function syncDesktopCommunityAuthToken(accessToken?: string | null): void {
+  if (typeof window === 'undefined') return
+  const desktopAPI = (window as Window & { desktopAPI?: DesktopCommunityAuthBridge }).desktopAPI
+  desktopAPI?.syncCommunityAuthToken?.(accessToken ?? null)
+}

--- a/apps/web/src/stores/auth.store.ts
+++ b/apps/web/src/stores/auth.store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { syncDesktopCommunityAuthToken } from '../lib/desktop-community-auth'
 import { queryClient } from '../lib/query-client'
 import { useChatStore } from './chat.store'
 
@@ -42,12 +43,14 @@ export const useAuthStore = create<AuthState>((set) => ({
   setAuth: (user, accessToken, refreshToken) => {
     localStorage.setItem('accessToken', accessToken)
     localStorage.setItem('refreshToken', refreshToken)
+    syncDesktopCommunityAuthToken(accessToken)
     set({ user, accessToken, isAuthenticated: true })
   },
 
   logout: () => {
     localStorage.removeItem('accessToken')
     localStorage.removeItem('refreshToken')
+    syncDesktopCommunityAuthToken(null)
     // Clear all query cache to prevent stale data leaking across sessions
     queryClient.removeQueries()
     queryClient.clear()


### PR DESCRIPTION
## Summary
- Add a shared desktop community auth-token reader used by preload, renderer fallback, and main-process window probing.
- Push Web login, refresh, and logout token changes into the Electron bridge immediately.
- Let the main app protocol learn fresh Authorization headers and clear stale cached tokens on 401/403 across community proxy paths.

## Root Cause
The desktop pet calls community APIs through main-process IPC, while the visible community window manages auth in the Web renderer. Token refreshes in the Web app could update localStorage without updating the main-process cache, so pet notification/subscription/chat/store requests could keep using a stale token and surface AUTH_REQUIRED as a failed panel load even when the community window was logged in.

## Impact
Desktop pet community features now share one auth source: Web auth changes explicitly sync to Electron, main-process proxies capture fresh request headers, and stale cached tokens are invalidated uniformly. This prevents logged-in users from seeing the pet side panel fall into the wrong unauthenticated/error state after token refresh.

## Validation
- pnpm lint
- pnpm --dir apps/desktop typecheck
- pnpm --dir apps/web typecheck

Tests and full check suites were not run per request.