### PR TITLE
[codex] Refresh desktop community auth in the main process

### DIFF
--- a/apps/desktop/src/main/connector-daemon.ts
+++ b/apps/desktop/src/main/connector-daemon.ts
@@ -4,8 +4,10 @@ import { hostname } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { app, BrowserWindow, ipcMain, net } from 'electron'
 import {
-  COMMUNITY_ACCESS_TOKEN_FROM_STORAGE_SCRIPT,
+  COMMUNITY_AUTH_TOKENS_FROM_STORAGE_SCRIPT,
+  type CommunityAuthTokens,
   communityAccessTokenFromAuthorizationHeader,
+  DESKTOP_COMMUNITY_AUTH_REQUIRED,
   normalizeCommunityAccessToken,
 } from '../shared/community-auth'
 import {
@@ -103,6 +105,8 @@ const AUTH_POLL_INTERVAL_MS = 800
 const AUTH_TIMEOUT_MS = 120_000
 const HOSTED_COMMUNITY_ORIGIN = 'https://shadowob.com'
 let lastCommunityAccessToken = ''
+let lastCommunityRefreshToken = ''
+let communityTokenRefreshPromise: Promise<string> | null = null
 
 function connectorRoot(): string {
   const packagedRoot = process.resourcesPath
@@ -215,34 +219,55 @@ function connectorBootstrapOrigins(settings: DesktopRuntimeSettings): string[] {
   )
 }
 
-async function readAccessTokenFromWindow(win: BrowserWindow | null): Promise<string> {
-  if (!win || win.isDestroyed() || win.webContents.isDestroyed() || win.webContents.isLoading()) {
-    return ''
-  }
-  try {
-    const token = (await win.webContents.executeJavaScript(
-      COMMUNITY_ACCESS_TOKEN_FROM_STORAGE_SCRIPT,
-      true,
-    )) as unknown
-    const normalizedToken = normalizeCommunityAccessToken(token)
-    if (normalizedToken) lastCommunityAccessToken = normalizedToken
-    return normalizedToken
-  } catch {
-    return ''
+function normalizeCommunityAuthTokens(tokens: unknown): CommunityAuthTokens {
+  const record = tokens && typeof tokens === 'object' ? (tokens as Record<string, unknown>) : {}
+  return {
+    accessToken: normalizeCommunityAccessToken(record.accessToken),
+    refreshToken: normalizeCommunityAccessToken(record.refreshToken),
   }
 }
 
-async function readAccessTokenFromOpenWindows(): Promise<string> {
-  for (const win of BrowserWindow.getAllWindows()) {
-    const token = await readAccessTokenFromWindow(win)
-    if (token) return token
+function rememberCommunityAuthTokens(tokens: Partial<CommunityAuthTokens>): void {
+  const accessToken = normalizeCommunityAccessToken(tokens.accessToken)
+  const refreshToken = normalizeCommunityAccessToken(tokens.refreshToken)
+  if (accessToken) lastCommunityAccessToken = accessToken
+  if (refreshToken) lastCommunityRefreshToken = refreshToken
+}
+
+async function readAuthTokensFromWindow(win: BrowserWindow | null): Promise<CommunityAuthTokens> {
+  if (!win || win.isDestroyed() || win.webContents.isDestroyed() || win.webContents.isLoading()) {
+    return { accessToken: '', refreshToken: '' }
   }
-  return ''
+  try {
+    const tokens = (await win.webContents.executeJavaScript(
+      COMMUNITY_AUTH_TOKENS_FROM_STORAGE_SCRIPT,
+      true,
+    )) as unknown
+    const normalizedTokens = normalizeCommunityAuthTokens(tokens)
+    rememberCommunityAuthTokens(normalizedTokens)
+    return normalizedTokens
+  } catch {
+    return { accessToken: '', refreshToken: '' }
+  }
+}
+
+async function readAuthTokensFromOpenWindows(): Promise<CommunityAuthTokens> {
+  let refreshToken = ''
+  for (const win of BrowserWindow.getAllWindows()) {
+    const tokens = await readAuthTokensFromWindow(win)
+    if (tokens.accessToken) return tokens
+    refreshToken ||= tokens.refreshToken
+  }
+  return { accessToken: '', refreshToken }
 }
 
 export function rememberCommunityAccessToken(token: string | null | undefined): void {
   const normalizedToken = normalizeCommunityAccessToken(token)
   if (normalizedToken) lastCommunityAccessToken = normalizedToken
+}
+
+export function rememberCommunityAuthSnapshot(tokens: Partial<CommunityAuthTokens>): void {
+  rememberCommunityAuthTokens(tokens)
 }
 
 export function rememberCommunityAuthorizationHeader(header: string | null | undefined): void {
@@ -256,12 +281,48 @@ export function forgetCommunityAccessToken(token?: string | null): void {
   }
 }
 
+export function forgetCommunityAuthTokens(token?: string | null): void {
+  forgetCommunityAccessToken(token)
+  if (!token || !lastCommunityAccessToken) lastCommunityRefreshToken = ''
+}
+
+export async function readCommunityAuthTokens(): Promise<CommunityAuthTokens> {
+  const mainTokens = await readAuthTokensFromWindow(getMainWindow())
+  if (mainTokens.accessToken) {
+    return {
+      accessToken: mainTokens.accessToken,
+      refreshToken: mainTokens.refreshToken || lastCommunityRefreshToken,
+    }
+  }
+
+  const authWindowTokens = await readAuthTokensFromWindow(getConnectorAuthWindow())
+  if (authWindowTokens.accessToken) {
+    return {
+      accessToken: authWindowTokens.accessToken,
+      refreshToken: authWindowTokens.refreshToken || lastCommunityRefreshToken,
+    }
+  }
+
+  const openWindowTokens = await readAuthTokensFromOpenWindows()
+  if (openWindowTokens.accessToken) {
+    return {
+      accessToken: openWindowTokens.accessToken,
+      refreshToken: openWindowTokens.refreshToken || lastCommunityRefreshToken,
+    }
+  }
+
+  return {
+    accessToken: lastCommunityAccessToken,
+    refreshToken:
+      mainTokens.refreshToken ||
+      authWindowTokens.refreshToken ||
+      openWindowTokens.refreshToken ||
+      lastCommunityRefreshToken,
+  }
+}
+
 export async function readCommunityAccessToken(): Promise<string> {
-  const token =
-    (await readAccessTokenFromWindow(getMainWindow())) ||
-    (await readAccessTokenFromWindow(getConnectorAuthWindow())) ||
-    (await readAccessTokenFromOpenWindows())
-  return token || lastCommunityAccessToken
+  return (await readCommunityAuthTokens()).accessToken
 }
 
 function communityApiUrl(settings: DesktopRuntimeSettings, path: string): string {
@@ -269,20 +330,135 @@ function communityApiUrl(settings: DesktopRuntimeSettings, path: string): string
   return `${origin}${path}`
 }
 
-async function fetchCommunityJson<T>(path: string, options: RequestInit = {}): Promise<T | null> {
-  const token = await readCommunityAccessToken()
-  if (!token) return null
-  const settings = readDesktopSettings()
-  const response = await net.fetch(communityApiUrl(settings, path), {
+function shouldWriteCommunityAuthToWindow(win: BrowserWindow): boolean {
+  try {
+    const url = new URL(win.webContents.getURL())
+    return url.protocol === 'app:' || url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+async function writeCommunityAuthTokensToWindow(
+  win: BrowserWindow,
+  tokens: Partial<CommunityAuthTokens>,
+): Promise<void> {
+  if (
+    win.isDestroyed() ||
+    win.webContents.isDestroyed() ||
+    win.webContents.isLoading() ||
+    !shouldWriteCommunityAuthToWindow(win)
+  ) {
+    return
+  }
+  const accessToken = normalizeCommunityAccessToken(tokens.accessToken)
+  const refreshToken = normalizeCommunityAccessToken(tokens.refreshToken)
+  const script = `(() => {
+    try {
+      const accessToken = ${JSON.stringify(accessToken)}
+      const refreshToken = ${JSON.stringify(refreshToken)}
+      if (accessToken) localStorage.setItem('accessToken', accessToken)
+      else localStorage.removeItem('accessToken')
+      if (refreshToken) localStorage.setItem('refreshToken', refreshToken)
+      else localStorage.removeItem('refreshToken')
+    } catch {}
+  })()`
+  await win.webContents.executeJavaScript(script, true).catch(() => undefined)
+}
+
+async function writeCommunityAuthTokensToOpenWindows(
+  tokens: Partial<CommunityAuthTokens>,
+): Promise<void> {
+  await Promise.all(
+    BrowserWindow.getAllWindows().map((win) => writeCommunityAuthTokensToWindow(win, tokens)),
+  )
+}
+
+async function refreshCommunityAccessTokenOnce(): Promise<string> {
+  const tokens = await readCommunityAuthTokens()
+  if (!tokens.refreshToken) return ''
+
+  const response = await net.fetch(communityApiUrl(readDesktopSettings(), '/api/auth/refresh'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ refreshToken: tokens.refreshToken }),
+  })
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      forgetCommunityAuthTokens()
+      await writeCommunityAuthTokensToOpenWindows({ accessToken: '', refreshToken: '' })
+    }
+    return ''
+  }
+
+  const payload = normalizeCommunityAuthTokens(await response.json().catch(() => ({})))
+  if (!payload.accessToken) return ''
+  rememberCommunityAuthTokens(payload)
+  await writeCommunityAuthTokensToOpenWindows(payload)
+  return payload.accessToken
+}
+
+export async function refreshCommunityAccessToken(): Promise<string> {
+  communityTokenRefreshPromise ??= refreshCommunityAccessTokenOnce().finally(() => {
+    communityTokenRefreshPromise = null
+  })
+  return communityTokenRefreshPromise
+}
+
+function withCommunityAuthorization(
+  options: RequestInit,
+  token: string,
+): RequestInit & { headers: Record<string, string> } {
+  return {
     ...options,
     headers: {
-      Authorization: `Bearer ${token}`,
       ...((options.headers as Record<string, string> | undefined) ?? {}),
+      Authorization: `Bearer ${token}`,
     },
+  }
+}
+
+export async function fetchCommunityUrlWithAuth(
+  url: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  let token = await readCommunityAccessToken()
+  if (!token) token = await refreshCommunityAccessToken()
+  if (!token) throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
+
+  let response = await net.fetch(url, withCommunityAuthorization(options, token))
+  if (response.status === 401 || response.status === 403) {
+    const refreshedToken = await refreshCommunityAccessToken()
+    if (refreshedToken && refreshedToken !== token) {
+      token = refreshedToken
+      response = await net.fetch(url, withCommunityAuthorization(options, token))
+    }
+  }
+  if (response.status === 401 || response.status === 403) {
+    forgetCommunityAuthTokens(token)
+    await writeCommunityAuthTokensToOpenWindows({ accessToken: '', refreshToken: '' })
+    throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
+  }
+  return response
+}
+
+export function fetchCommunityWithAuth(path: string, options: RequestInit = {}): Promise<Response> {
+  return fetchCommunityUrlWithAuth(communityApiUrl(readDesktopSettings(), path), options)
+}
+
+async function fetchCommunityJson<T>(path: string, options: RequestInit = {}): Promise<T | null> {
+  const response = await fetchCommunityWithAuth(path, options).catch((error: unknown) => {
+    if (error instanceof Error && error.message.includes(DESKTOP_COMMUNITY_AUTH_REQUIRED)) {
+      return null
+    }
+    throw error
   })
+  if (!response) return null
   if (!response.ok) {
     const body = await response.text().catch(() => '')
-    if (response.status === 401 || response.status === 403) forgetCommunityAccessToken(token)
     throw new Error(`Community API ${path} failed (${response.status})${body ? `: ${body}` : ''}`)
   }
   return (await response.json()) as T
@@ -391,6 +567,13 @@ async function bootstrapConnectorApiKey(
 ): Promise<{ apiKey: string; serverBaseUrl: string }> {
   let token = await waitForCommunityAccessToken()
   let bootstrap = await requestConnectorBootstrap(settings, token)
+  if (bootstrap.response.status === 401 || bootstrap.response.status === 403) {
+    const refreshedToken = await refreshCommunityAccessToken()
+    if (refreshedToken && refreshedToken !== token) {
+      token = refreshedToken
+      bootstrap = await requestConnectorBootstrap(settings, refreshedToken)
+    }
+  }
   if (bootstrap.response.status === 401 || bootstrap.response.status === 403) {
     showConnectorAuthWindow()
     const deadline = Date.now() + AUTH_TIMEOUT_MS

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,10 +13,7 @@ import {
   session,
   shell,
 } from 'electron'
-import {
-  DESKTOP_COMMUNITY_AUTH_REQUIRED,
-  normalizeCommunityAccessToken,
-} from '../shared/community-auth'
+import { normalizeCommunityAccessToken } from '../shared/community-auth'
 
 // Suppress EPIPE errors that occur when a child process dies while the main
 // process writes to its stdio pipe (e.g. gateway process exit).
@@ -27,10 +24,12 @@ process.on('uncaughtException', (err) => {
 
 import { setupAutoUpdater } from './auto-updater'
 import {
-  forgetCommunityAccessToken,
+  fetchCommunityUrlWithAuth,
+  fetchCommunityWithAuth,
+  forgetCommunityAuthTokens,
   readCommunityAccessToken,
-  rememberCommunityAccessToken,
   rememberCommunityAuthorizationHeader,
+  rememberCommunityAuthSnapshot,
   setupConnectorDaemonHandlers,
   startConnectorDaemonIfEnabled,
   stopConnectorDaemon,
@@ -261,9 +260,8 @@ function isCommunityAuthSnapshotSource(sourceUrl: string): boolean {
   try {
     const url = new URL(sourceUrl)
     if (url.protocol === 'app:' && url.hostname === 'shadow') return true
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
-    const serverOrigin = new URL(getDesktopServerBaseUrl()).origin
-    return url.origin === serverOrigin
+    if (url.protocol === 'http:' || url.protocol === 'https:') return true
+    return false
   } catch {
     return false
   }
@@ -292,14 +290,9 @@ async function fetchReaderResource(rawUrl: string, title: string): Promise<Reade
     contentType = inferContentType(url)
     fileName = sanitizeFileName(title || basename(filePath))
   } else {
-    const headers = new Headers({ Accept: '*/*' })
-    const token = await readCommunityAccessToken()
-    if (token && isTrustedCommunityUrl(url)) headers.set('Authorization', `Bearer ${token}`)
-    const response = await net.fetch(url.toString(), { headers })
-    if (response.status === 401 || response.status === 403) {
-      forgetCommunityAccessToken(token)
-      throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
-    }
+    const response = isTrustedCommunityUrl(url)
+      ? await fetchCommunityUrlWithAuth(url.toString(), { headers: { Accept: '*/*' } })
+      : await net.fetch(url.toString(), { headers: { Accept: '*/*' } })
     if (!response.ok) throw new Error(`READER_FETCH_FAILED_${response.status}`)
     buffer = Buffer.from(await response.arrayBuffer())
     contentType = inferContentType(url, response.headers.get('content-type') ?? '')
@@ -329,24 +322,11 @@ async function fetchReaderResource(rawUrl: string, title: string): Promise<Reade
 }
 
 async function resolveReaderAttachmentUrl(attachmentId: string): Promise<string> {
-  const token = await readCommunityAccessToken()
-  if (!token) throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
-  const response = await net.fetch(
-    `${getDesktopServerBaseUrl()}/api/attachments/${encodeURIComponent(
-      attachmentId,
-    )}/media-url?disposition=inline`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    },
+  const response = await fetchCommunityWithAuth(
+    `/api/attachments/${encodeURIComponent(attachmentId)}/media-url?disposition=inline`,
+    { headers: { 'Content-Type': 'application/json' } },
   )
   const text = await response.text()
-  if (response.status === 401 || response.status === 403) {
-    forgetCommunityAccessToken(token)
-    throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
-  }
   if (!response.ok) throw new Error(text || `READER_ATTACHMENT_URL_FAILED_${response.status}`)
   const payload = text ? (JSON.parse(text) as { url?: unknown }) : {}
   if (typeof payload.url !== 'string' || !payload.url)
@@ -618,16 +598,18 @@ app.on('ready', async () => {
       event,
       payload: {
         accessToken?: unknown
+        refreshToken?: unknown
         sourceUrl?: unknown
       },
     ) => {
       const token = normalizeCommunityAccessToken(payload?.accessToken)
+      const refreshToken = normalizeCommunityAccessToken(payload?.refreshToken)
       const sourceUrl =
         typeof payload?.sourceUrl === 'string' ? payload.sourceUrl : event.sender.getURL()
-      if (token) {
-        rememberCommunityAccessToken(token)
+      if (token || refreshToken) {
+        rememberCommunityAuthSnapshot({ accessToken: token, refreshToken })
       } else if (isCommunityAuthSnapshotSource(sourceUrl)) {
-        forgetCommunityAccessToken()
+        forgetCommunityAuthTokens()
       }
     },
   )
@@ -643,23 +625,16 @@ app.on('ready', async () => {
         headers?: Record<string, string>
       },
     ) => {
-      const token = await readCommunityAccessToken()
-      if (!token) throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
       const path = normalizeCommunityApiPath(input.path)
-      const response = await net.fetch(`${getDesktopServerBaseUrl()}${path}`, {
+      const response = await fetchCommunityWithAuth(path, {
         method: input.method ?? 'GET',
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
           ...(input.headers ?? {}),
         },
         body: input.body === undefined ? undefined : JSON.stringify(input.body),
       })
       const text = await response.text()
-      if (response.status === 401 || response.status === 403) {
-        forgetCommunityAccessToken(token)
-        throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
-      }
       if (!response.ok) throw new Error(text || `REQUEST_FAILED_${response.status}`)
       return text ? (JSON.parse(text) as unknown) : null
     },
@@ -673,22 +648,15 @@ app.on('ready', async () => {
         body: Record<string, unknown>
       },
     ) => {
-      const token = await readCommunityAccessToken()
-      if (!token) throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
-      const response = await net.fetch(`${getDesktopServerBaseUrl()}/api/ai/v1/chat/completions`, {
+      const response = await fetchCommunityWithAuth('/api/ai/v1/chat/completions', {
         method: 'POST',
         headers: {
           Accept: 'text/event-stream',
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ ...input.body, stream: true }),
       })
       if (!response.ok) {
-        if (response.status === 401 || response.status === 403) {
-          forgetCommunityAccessToken(token)
-          throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
-        }
         const text = await response.text().catch(() => '')
         throw new Error(text || `REQUEST_FAILED_${response.status}`)
       }

--- a/apps/desktop/src/main/notifications.ts
+++ b/apps/desktop/src/main/notifications.ts
@@ -1,6 +1,5 @@
-import { app, ipcMain, Notification, net } from 'electron'
-import { readCommunityAccessToken } from './connector-daemon'
-import { getDesktopServerBaseUrl } from './desktop-settings'
+import { app, ipcMain, Notification } from 'electron'
+import { fetchCommunityWithAuth } from './connector-daemon'
 import { setTrayAttention } from './tray'
 import { sendPetShortcut, showCommunityWindow } from './window'
 
@@ -28,10 +27,7 @@ function withMessageSearch(path: string, messageId?: string): string {
 }
 
 async function communityFetchJson<T>(path: string): Promise<T> {
-  const token = await readCommunityAccessToken()
-  const response = await net.fetch(`${getDesktopServerBaseUrl()}${path}`, {
-    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-  })
+  const response = await fetchCommunityWithAuth(path)
   if (!response.ok) throw new Error(`REQUEST_FAILED_${response.status}`)
   return (await response.json()) as T
 }

--- a/apps/desktop/src/main/pet-assets.ts
+++ b/apps/desktop/src/main/pet-assets.ts
@@ -14,7 +14,7 @@ import { basename, dirname, join, normalize, relative, sep } from 'node:path'
 import { app, dialog, ipcMain, nativeImage, net } from 'electron'
 import JSZip from 'jszip'
 import { DESKTOP_COMMUNITY_AUTH_REQUIRED } from '../shared/community-auth'
-import { forgetCommunityAccessToken, readCommunityAccessToken } from './connector-daemon'
+import { fetchCommunityWithAuth, forgetCommunityAccessToken } from './connector-daemon'
 import {
   broadcastDesktopSettings,
   type DesktopPetAssetPack,
@@ -453,21 +453,14 @@ async function importPetPackFromArchive(
 }
 
 async function fetchMarketplaceJson<T>(path: string, init?: RequestInit): Promise<T> {
-  const token = await readCommunityAccessToken()
-  if (!token) throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
-  const response = await net.fetch(`${getDesktopServerBaseUrl()}${path}`, {
+  const response = await fetchCommunityWithAuth(path, {
     ...init,
     headers: {
-      Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
       ...(init?.headers ?? {}),
     },
   })
   const text = await response.text()
-  if (response.status === 401 || response.status === 403) {
-    forgetCommunityAccessToken(token)
-    throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
-  }
   if (!response.ok) throw new Error(text || `REQUEST_FAILED_${response.status}`)
   return (text ? JSON.parse(text) : null) as T
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -4,7 +4,7 @@ import {
   isCommunityAuthRequiredError,
   normalizeCommunityAccessToken,
   normalizeCommunityAuthError,
-  readCommunityAccessTokenFromStorage,
+  readCommunityAuthTokensFromStorage,
 } from '../shared/community-auth'
 
 function applyDesktopDocumentClasses(): void {
@@ -19,24 +19,31 @@ function applyDesktopDocumentClasses(): void {
   window.addEventListener('DOMContentLoaded', apply, { once: true })
 }
 
-let lastSyncedCommunityAuthToken: string | null = null
+let lastSyncedCommunityAuthSnapshot: string | null = null
 
-function readCommunityAuthTokenSnapshot(): string {
-  return readCommunityAccessTokenFromStorage((key) => window.localStorage?.getItem(key))
+function readCommunityAuthSnapshot(): { accessToken: string; refreshToken: string } {
+  return readCommunityAuthTokensFromStorage((key) => window.localStorage?.getItem(key))
 }
 
 function syncCommunityAuthSnapshot(
-  options: { force?: boolean; accessToken?: string | null } = {},
+  options: { force?: boolean; accessToken?: string | null; refreshToken?: string | null } = {},
 ): void {
   try {
+    const storedTokens = readCommunityAuthSnapshot()
     const accessToken =
       options.accessToken === undefined
-        ? readCommunityAuthTokenSnapshot()
+        ? storedTokens.accessToken
         : normalizeCommunityAccessToken(options.accessToken)
-    if (!options.force && accessToken === lastSyncedCommunityAuthToken) return
-    lastSyncedCommunityAuthToken = accessToken
+    const refreshToken =
+      options.refreshToken === undefined
+        ? storedTokens.refreshToken
+        : normalizeCommunityAccessToken(options.refreshToken)
+    const snapshotKey = `${accessToken}\n${refreshToken}`
+    if (!options.force && snapshotKey === lastSyncedCommunityAuthSnapshot) return
+    lastSyncedCommunityAuthSnapshot = snapshotKey
     ipcRenderer.send('desktop:communityAuthSnapshot', {
       accessToken,
+      refreshToken,
       sourceUrl: window.location.href,
     })
   } catch {
@@ -121,8 +128,8 @@ const desktopAPI = {
   getCommunityAuthToken: () => {
     return ipcRenderer.invoke('desktop:getCommunityAuthToken') as Promise<string>
   },
-  syncCommunityAuthToken: (accessToken?: string | null) => {
-    syncCommunityAuthSnapshot({ force: true, accessToken })
+  syncCommunityAuthToken: (accessToken?: string | null, refreshToken?: string | null) => {
+    syncCommunityAuthSnapshot({ force: true, accessToken, refreshToken })
   },
   communityFetchJson: (input: {
     path: string

--- a/apps/desktop/src/shared/community-auth.ts
+++ b/apps/desktop/src/shared/community-auth.ts
@@ -2,7 +2,8 @@ export const DESKTOP_COMMUNITY_AUTH_REQUIRED = 'AUTH_REQUIRED'
 export const DESKTOP_COMMUNITY_AUTH_REQUIRED_EVENT = 'shadow:desktop-community-auth-required'
 
 const ACCESS_TOKEN_STORAGE_KEYS = ['accessToken', 'shadowAccessToken', 'shadow:accessToken']
-const ACCESS_TOKEN_CONTAINER_KEYS = [
+const REFRESH_TOKEN_STORAGE_KEYS = ['refreshToken', 'shadowRefreshToken', 'shadow:refreshToken']
+const TOKEN_CONTAINER_KEYS = [
   'auth',
   'auth-storage',
   'shadow-auth',
@@ -11,6 +12,11 @@ const ACCESS_TOKEN_CONTAINER_KEYS = [
 ]
 const MAX_TOKEN_SEARCH_DEPTH = 4
 const MAX_TOKEN_SEARCH_KEYS = 80
+
+export type CommunityAuthTokens = {
+  accessToken: string
+  refreshToken: string
+}
 
 export class DesktopCommunityAuthRequiredError extends Error {
   readonly code = DESKTOP_COMMUNITY_AUTH_REQUIRED
@@ -44,13 +50,17 @@ export function normalizeCommunityAccessToken(token: unknown): string {
   return typeof token === 'string' ? token.trim() : ''
 }
 
-function extractTokenFromValue(value: unknown, depth = 0): string {
+function extractTokenFromValue(
+  value: unknown,
+  tokenKey: 'accessToken' | 'refreshToken',
+  depth = 0,
+): string {
   if (!value || depth > MAX_TOKEN_SEARCH_DEPTH) return ''
   if (typeof value === 'string') {
     const trimmed = value.trim()
     if (!trimmed || (!trimmed.startsWith('{') && !trimmed.startsWith('['))) return ''
     try {
-      return extractTokenFromValue(JSON.parse(trimmed) as unknown, depth + 1)
+      return extractTokenFromValue(JSON.parse(trimmed) as unknown, tokenKey, depth + 1)
     } catch {
       return ''
     }
@@ -59,42 +69,65 @@ function extractTokenFromValue(value: unknown, depth = 0): string {
 
   if (Array.isArray(value)) {
     for (const item of value.slice(0, MAX_TOKEN_SEARCH_KEYS)) {
-      const token = extractTokenFromValue(item, depth + 1)
+      const token = extractTokenFromValue(item, tokenKey, depth + 1)
       if (token) return token
     }
     return ''
   }
 
   const record = value as Record<string, unknown>
-  const directToken = normalizeCommunityAccessToken(record.accessToken)
+  const directToken = normalizeCommunityAccessToken(record[tokenKey])
   if (directToken) return directToken
 
   for (const item of Object.values(record).slice(0, MAX_TOKEN_SEARCH_KEYS)) {
-    const token = extractTokenFromValue(item, depth + 1)
+    const token = extractTokenFromValue(item, tokenKey, depth + 1)
     if (token) return token
   }
+  return ''
+}
+
+function readCommunityTokenFromStorage(
+  getItem: (key: string) => string | null | undefined,
+  storageKeys: string[],
+  tokenKey: 'accessToken' | 'refreshToken',
+): string {
+  for (const key of storageKeys) {
+    const token = normalizeCommunityAccessToken(getItem(key))
+    if (token) return token
+  }
+
+  for (const key of TOKEN_CONTAINER_KEYS) {
+    const token = extractTokenFromValue(getItem(key), tokenKey)
+    if (token) return token
+  }
+
   return ''
 }
 
 export function readCommunityAccessTokenFromStorage(
   getItem: (key: string) => string | null | undefined,
 ): string {
-  for (const key of ACCESS_TOKEN_STORAGE_KEYS) {
-    const token = normalizeCommunityAccessToken(getItem(key))
-    if (token) return token
-  }
-
-  for (const key of ACCESS_TOKEN_CONTAINER_KEYS) {
-    const token = extractTokenFromValue(getItem(key))
-    if (token) return token
-  }
-
-  return ''
+  return readCommunityTokenFromStorage(getItem, ACCESS_TOKEN_STORAGE_KEYS, 'accessToken')
 }
 
-export function readCommunityAccessTokenFromStorageRecord(
-  entries: Iterable<readonly [string, unknown]>,
+export function readCommunityRefreshTokenFromStorage(
+  getItem: (key: string) => string | null | undefined,
 ): string {
+  return readCommunityTokenFromStorage(getItem, REFRESH_TOKEN_STORAGE_KEYS, 'refreshToken')
+}
+
+export function readCommunityAuthTokensFromStorage(
+  getItem: (key: string) => string | null | undefined,
+): CommunityAuthTokens {
+  return {
+    accessToken: readCommunityAccessTokenFromStorage(getItem),
+    refreshToken: readCommunityRefreshTokenFromStorage(getItem),
+  }
+}
+
+export function readCommunityAuthTokensFromStorageRecord(
+  entries: Iterable<readonly [string, unknown]>,
+): CommunityAuthTokens {
   const byKey = new Map<string, unknown>()
   let count = 0
   for (const [key, value] of entries) {
@@ -107,13 +140,22 @@ export function readCommunityAccessTokenFromStorageRecord(
     const value = byKey.get(key)
     return typeof value === 'string' ? value : null
   })
-  if (directToken) return directToken
-
-  for (const value of byKey.values()) {
-    const token = extractTokenFromValue(value)
-    if (token) return token
+  const directRefreshToken = readCommunityRefreshTokenFromStorage((key) => {
+    const value = byKey.get(key)
+    return typeof value === 'string' ? value : null
+  })
+  if (directToken || directRefreshToken) {
+    return { accessToken: directToken, refreshToken: directRefreshToken }
   }
-  return ''
+
+  let accessToken = ''
+  let refreshToken = ''
+  for (const value of byKey.values()) {
+    accessToken ||= extractTokenFromValue(value, 'accessToken')
+    refreshToken ||= extractTokenFromValue(value, 'refreshToken')
+    if (accessToken && refreshToken) break
+  }
+  return { accessToken, refreshToken }
 }
 
 export function communityAccessTokenFromAuthorizationHeader(header: unknown): string {
@@ -122,19 +164,20 @@ export function communityAccessTokenFromAuthorizationHeader(header: unknown): st
   return normalizeCommunityAccessToken(match?.[1])
 }
 
-export const COMMUNITY_ACCESS_TOKEN_FROM_STORAGE_SCRIPT = `(() => {
-  const directKeys = ${JSON.stringify(ACCESS_TOKEN_STORAGE_KEYS)}
-  const containerKeys = ${JSON.stringify(ACCESS_TOKEN_CONTAINER_KEYS)}
+export const COMMUNITY_AUTH_TOKENS_FROM_STORAGE_SCRIPT = `(() => {
+  const accessKeys = ${JSON.stringify(ACCESS_TOKEN_STORAGE_KEYS)}
+  const refreshKeys = ${JSON.stringify(REFRESH_TOKEN_STORAGE_KEYS)}
+  const containerKeys = ${JSON.stringify(TOKEN_CONTAINER_KEYS)}
   const maxDepth = ${MAX_TOKEN_SEARCH_DEPTH}
   const maxKeys = ${MAX_TOKEN_SEARCH_KEYS}
   const normalize = (value) => (typeof value === 'string' ? value.trim() : '')
-  const extract = (value, depth = 0) => {
+  const extract = (value, tokenKey, depth = 0) => {
     if (!value || depth > maxDepth) return ''
     if (typeof value === 'string') {
       const trimmed = value.trim()
       if (!trimmed || (!trimmed.startsWith('{') && !trimmed.startsWith('['))) return ''
       try {
-        return extract(JSON.parse(trimmed), depth + 1)
+        return extract(JSON.parse(trimmed), tokenKey, depth + 1)
       } catch {
         return ''
       }
@@ -142,36 +185,47 @@ export const COMMUNITY_ACCESS_TOKEN_FROM_STORAGE_SCRIPT = `(() => {
     if (typeof value !== 'object') return ''
     if (Array.isArray(value)) {
       for (const item of value.slice(0, maxKeys)) {
-        const token = extract(item, depth + 1)
+        const token = extract(item, tokenKey, depth + 1)
         if (token) return token
       }
       return ''
     }
-    const direct = normalize(value.accessToken)
+    const direct = normalize(value[tokenKey])
     if (direct) return direct
     for (const item of Object.values(value).slice(0, maxKeys)) {
-      const token = extract(item, depth + 1)
+      const token = extract(item, tokenKey, depth + 1)
+      if (token) return token
+    }
+    return ''
+  }
+  const readToken = (keys, tokenKey) => {
+    for (const key of keys) {
+      const token = normalize(localStorage.getItem(key))
+      if (token) return token
+    }
+    for (const key of containerKeys) {
+      const token = extract(localStorage.getItem(key), tokenKey)
+      if (token) return token
+    }
+    for (let index = 0; index < Math.min(localStorage.length, maxKeys); index += 1) {
+      const key = localStorage.key(index)
+      const token = key ? extract(localStorage.getItem(key), tokenKey) : ''
       if (token) return token
     }
     return ''
   }
 
   try {
-    for (const key of directKeys) {
-      const token = normalize(localStorage.getItem(key))
-      if (token) return token
-    }
-    for (const key of containerKeys) {
-      const token = extract(localStorage.getItem(key))
-      if (token) return token
-    }
-    for (let index = 0; index < Math.min(localStorage.length, maxKeys); index += 1) {
-      const key = localStorage.key(index)
-      const token = key ? extract(localStorage.getItem(key)) : ''
-      if (token) return token
+    return {
+      accessToken: readToken(accessKeys, 'accessToken'),
+      refreshToken: readToken(refreshKeys, 'refreshToken'),
     }
   } catch {
-    return ''
+    return { accessToken: '', refreshToken: '' }
   }
-  return ''
+})()`
+
+export const COMMUNITY_ACCESS_TOKEN_FROM_STORAGE_SCRIPT = `(() => {
+  const tokens = ${COMMUNITY_AUTH_TOKENS_FROM_STORAGE_SCRIPT}
+  return tokens.accessToken || ''
 })()`

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -92,7 +92,7 @@ async function refreshAccessToken(): Promise<string | null> {
     const data = (await res.json()) as { accessToken: string; refreshToken: string }
     localStorage.setItem('accessToken', data.accessToken)
     localStorage.setItem('refreshToken', data.refreshToken)
-    syncDesktopCommunityAuthToken(data.accessToken)
+    syncDesktopCommunityAuthToken(data.accessToken, data.refreshToken)
     return data.accessToken
   } catch {
     return null

--- a/apps/web/src/lib/auth-session.ts
+++ b/apps/web/src/lib/auth-session.ts
@@ -75,7 +75,7 @@ async function refreshStoredTokens(): Promise<StoredTokens | null> {
   const data = (await response.json()) as StoredTokens
   localStorage.setItem('accessToken', data.accessToken)
   localStorage.setItem('refreshToken', data.refreshToken)
-  syncDesktopCommunityAuthToken(data.accessToken)
+  syncDesktopCommunityAuthToken(data.accessToken, data.refreshToken)
   return data
 }
 

--- a/apps/web/src/lib/desktop-community-auth.ts
+++ b/apps/web/src/lib/desktop-community-auth.ts
@@ -1,9 +1,12 @@
 type DesktopCommunityAuthBridge = {
-  syncCommunityAuthToken?: (accessToken?: string | null) => void
+  syncCommunityAuthToken?: (accessToken?: string | null, refreshToken?: string | null) => void
 }
 
-export function syncDesktopCommunityAuthToken(accessToken?: string | null): void {
+export function syncDesktopCommunityAuthToken(
+  accessToken?: string | null,
+  refreshToken?: string | null,
+): void {
   if (typeof window === 'undefined') return
   const desktopAPI = (window as Window & { desktopAPI?: DesktopCommunityAuthBridge }).desktopAPI
-  desktopAPI?.syncCommunityAuthToken?.(accessToken ?? null)
+  desktopAPI?.syncCommunityAuthToken?.(accessToken ?? null, refreshToken)
 }

--- a/apps/web/src/stores/auth.store.ts
+++ b/apps/web/src/stores/auth.store.ts
@@ -43,14 +43,14 @@ export const useAuthStore = create<AuthState>((set) => ({
   setAuth: (user, accessToken, refreshToken) => {
     localStorage.setItem('accessToken', accessToken)
     localStorage.setItem('refreshToken', refreshToken)
-    syncDesktopCommunityAuthToken(accessToken)
+    syncDesktopCommunityAuthToken(accessToken, refreshToken)
     set({ user, accessToken, isAuthenticated: true })
   },
 
   logout: () => {
     localStorage.removeItem('accessToken')
     localStorage.removeItem('refreshToken')
-    syncDesktopCommunityAuthToken(null)
+    syncDesktopCommunityAuthToken(null, null)
     // Clear all query cache to prevent stale data leaking across sessions
     queryClient.removeQueries()
     queryClient.clear()


### PR DESCRIPTION
## Summary
- Move desktop community IPC/API requests onto a shared main-process authenticated fetch helper.
- Read and cache both access and refresh tokens from Electron community windows and preload snapshots.
- Refresh expired access tokens in the main process, write the renewed tokens back into community windows, and retry the original request once.
- Reuse the same auth-refresh path for desktop notifications, reader attachment access, pet asset marketplace imports, connector community reads, and chat/model proxy requests.

## Root Cause
The previous fix synchronized token snapshots, but the failing runtime stack was a 401/403 after the main process had already sent an access token. That means the desktop pet proxy was holding an expired access token. Unlike the Web renderer fetch layer, the Electron main-process IPC handler did not know how to use the refresh token, so it converted ordinary token expiry into AUTH_REQUIRED and caused repeated panel failures.

## Impact
Desktop pet community features now behave like the Web client: an expired access token is refreshed in the shared main-process auth boundary before notification/subscription/chat/store requests fail. Only a missing or rejected refresh token becomes a real login-required state.

## Validation
- pnpm lint
- pnpm --dir apps/desktop typecheck
- pnpm --dir apps/web typecheck
- pnpm --dir apps/desktop build

Tests and full check suites were not run per request.