### PR TITLE
[codex] Fix integrations compose dev startup

### DIFF
--- a/integrations/flash/Dockerfile
+++ b/integrations/flash/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY .npmrc ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/sdk/bin ./packages/sdk/bin

--- a/integrations/kanban/Dockerfile
+++ b/integrations/kanban/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY .npmrc ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/sdk/bin ./packages/sdk/bin

--- a/integrations/qna/Dockerfile
+++ b/integrations/qna/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY .npmrc ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/sdk/bin ./packages/sdk/bin

--- a/integrations/quiz/Dockerfile
+++ b/integrations/quiz/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY .npmrc ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/sdk/bin ./packages/sdk/bin

--- a/integrations/resume/Dockerfile
+++ b/integrations/resume/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY .npmrc ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/sdk/bin ./packages/sdk/bin

--- a/integrations/skills/Dockerfile
+++ b/integrations/skills/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY .npmrc ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/sdk/bin ./packages/sdk/bin

--- a/integrations/space/Dockerfile
+++ b/integrations/space/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY .npmrc ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/sdk/bin ./packages/sdk/bin

--- a/integrations/trainer/Dockerfile
+++ b/integrations/trainer/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY .npmrc ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/sdk/bin ./packages/sdk/bin

--- a/integrations/warbuddy/Dockerfile
+++ b/integrations/warbuddy/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY .npmrc ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/sdk/bin ./packages/sdk/bin

--- a/integrations/warbuddy/src/server.ts
+++ b/integrations/warbuddy/src/server.ts
@@ -325,6 +325,9 @@ function errorResponse(c: Context, error: unknown) {
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
 app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
 app.get('/assets/*', serveStatic({ root: './dist/client' }))
+if (process.env.WARBUDDY_VITE_DEV_SERVER_URL) {
+  app.get('/src/client/assets/*', serveStatic({ root: '.' }))
+}
 app.get('/shadow/server', (c) => c.html(shellPage()))
 app.get('/shadow/server/*', (c) => c.html(shellPage()))
 app.get('/api/maps', (c) => c.json({ maps: listMaps() }))


### PR DESCRIPTION
## Summary
- copy the root patches directory into every integration Docker build context before pnpm install
- serve WarBuddy source assets from the app server during Vite dev mode so 4218 asset URLs resolve

## Root Cause
The root package uses pnpm patchedDependencies, but integration Dockerfiles did not include the patch files before running pnpm install. WarBuddy dev mode also let CSS asset URLs resolve against the 4218 app server, which did not serve /src/client/assets/*.

## Validation
- pnpm --filter @shadowob/warbuddy-app typecheck
- docker compose -f integrations/docker-compose.yaml build kanban skills qna quiz trainer resume flash space warbuddy
- WarBuddy compose dev started on 4218/5178
- curl verified WarBuddy PNG, atlas, and MP3 source asset URLs return 200
- in-app browser verified WarBuddy page renders assets