### PR TITLE
Fix main release pipelines

### DIFF
--- a/.github/workflows/publish-openclaw-runner.yml
+++ b/.github/workflows/publish-openclaw-runner.yml
@@ -21,7 +21,6 @@ on:
           - openclaw-runner
           - claude-runner
           - codex-runner
-          - gemini-runner
           - opencode-runner
           - hermes-runner
 
@@ -93,9 +92,6 @@ jobs:
           - image: codex-runner
             image_name: buggyblues/codex-runner
             dockerfile: apps/cloud/images/codex-runner/Dockerfile
-          - image: gemini-runner
-            image_name: buggyblues/gemini-runner
-            dockerfile: apps/cloud/images/gemini-runner/Dockerfile
           - image: opencode-runner
             image_name: buggyblues/opencode-runner
             dockerfile: apps/cloud/images/opencode-runner/Dockerfile
@@ -169,5 +165,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image }},ignore-error=true

--- a/apps/cloud/images/openclaw-runner/Dockerfile
+++ b/apps/cloud/images/openclaw-runner/Dockerfile
@@ -151,8 +151,10 @@ RUN apt-get update && \
       xdg-utils && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /ms-playwright && \
-	    npx -y "playwright@${PLAYWRIGHT_VERSION}" install --no-shell chromium && \
-    ln -sf "$(find /ms-playwright -path '*/chrome-linux/chrome' -type f | head -n1)" /usr/bin/chromium && \
+    npx -y "playwright@${PLAYWRIGHT_VERSION}" install --no-shell chromium && \
+    chromium_path="$(find /ms-playwright -type f -name chrome -print -quit)" && \
+    test -n "$chromium_path" && \
+    ln -sf "$chromium_path" /usr/bin/chromium && \
     chmod -R 755 /ms-playwright
 
 # Create non-root user shadow:1000

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const root = resolve(__dirname, '..')
+const sharedRoot = resolve(root, '../../packages/shared')
 const connectorRoot = resolve(root, '../../packages/connector')
 const env = { ...process.env, NODE_ENV: 'production' }
 
@@ -19,6 +20,13 @@ execSync('npx rspack build -c rspack.main.config.mjs --mode production', {
 console.log('[build] Building preload...')
 execSync('npx rspack build -c rspack.preload.config.mjs --mode production', {
   cwd: root,
+  stdio: 'inherit',
+  env,
+})
+
+console.log('[build] Building shared package...')
+execSync('pnpm build', {
+  cwd: sharedRoot,
   stdio: 'inherit',
   env,
 })


### PR DESCRIPTION
## Summary
- build @shadowob/shared before @shadowob/connector in the desktop release build
- remove the deleted Gemini runner from the runner image publish matrix
- make OpenClaw Chromium linking resilient to Playwright browser directory changes and isolate runner image GHA cache scopes

## Verification
- pnpm biome check apps/desktop/scripts/build.mjs
- pnpm --dir apps/desktop build
- docker build --platform linux/amd64 -t shadowob/openclaw-runner:main-ci-clean -f apps/cloud/images/openclaw-runner/Dockerfile .
- docker run --rm --platform linux/amd64 --entrypoint /bin/sh shadowob/openclaw-runner:main-ci-clean -lc 'set -eu; test -x /usr/bin/chromium; /usr/bin/chromium --version; command -v openclaw; command -v shadowob; command -v shadowob-connector; node --version'