### PR TITLE
[codex] Gate releases and verify desktop Windows packaging

### DIFF
--- a/.github/actions/setup-wix/action.yml
+++ b/.github/actions/setup-wix/action.yml
@@ -1,0 +1,41 @@
+name: Setup WiX Toolset
+description: Locate or install WiX Toolset v3 for Windows desktop MSI packaging.
+
+runs:
+  using: composite
+  steps:
+    - name: Locate or install WiX Toolset
+      shell: pwsh
+      run: |
+        $candle = Get-Command candle.exe -ErrorAction SilentlyContinue
+        $light = Get-Command light.exe -ErrorAction SilentlyContinue
+
+        if (-not $candle -or -not $light) {
+          choco install wixtoolset -y --no-progress
+          $candle = Get-Command candle.exe -ErrorAction SilentlyContinue
+          $light = Get-Command light.exe -ErrorAction SilentlyContinue
+        }
+
+        if (-not $candle -or -not $light) {
+          $wixRoot = Get-ChildItem -LiteralPath ${env:ProgramFiles(x86)} -Directory -Filter 'WiX Toolset v3*' |
+            Sort-Object Name -Descending |
+            Select-Object -First 1
+          if ($wixRoot) {
+            $wixBin = Join-Path $wixRoot.FullName 'bin'
+            if (Test-Path (Join-Path $wixBin 'candle.exe')) {
+              $wixBin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+              $env:PATH = "$wixBin;$env:PATH"
+              $candle = Get-Command candle.exe -ErrorAction SilentlyContinue
+              $light = Get-Command light.exe -ErrorAction SilentlyContinue
+            }
+          }
+        } elseif ($candle.Source) {
+          Split-Path -Parent $candle.Source | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+        }
+
+        if (-not $candle -or -not $light) {
+          throw 'WiX Toolset candle.exe/light.exe were not found after installation.'
+        }
+
+        Write-Host "Using WiX candle: $($candle.Source)"
+        Write-Host "Using WiX light: $($light.Source)"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -233,9 +233,70 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.e2e.yml down -v --remove-orphans
 
+  desktop-windows-package-smoke:
+    name: Desktop Windows package smoke
+    runs-on: windows-latest
+    needs: changed-files
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      needs.changed-files.outputs.desktop == 'true' ||
+      needs.changed-files.outputs.packages == 'true' ||
+      needs.changed-files.outputs.ci == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.19.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup WiX Toolset
+        uses: ./.github/actions/setup-wix
+
+      - name: Generate icons
+        run: pnpm --dir ./apps/desktop generate-icons
+
+      - name: Build Windows desktop artifacts
+        env:
+          WINDOWS_SIGN_DESCRIPTION: Shadow
+          WINDOWS_SIGN_WEBSITE: https://shadowob.com
+        run: pnpm --dir ./apps/desktop release:win
+
+      - name: Verify packaged icon and metadata
+        run: node ./apps/desktop/scripts/verify-package-assets.mjs --platform=win32 --arch=x64
+
+      - name: Upload package smoke output
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: desktop-windows-package-smoke
+          path: |
+            apps/desktop/out/make/**/*.exe
+            apps/desktop/out/make/**/*.msi
+            apps/desktop/out/make/**/*.nupkg
+            apps/desktop/out/make/**/Shadow.wxs
+          if-no-files-found: warn
+
   report:
     name: PR report comment
-    needs: [changed-files, lint-and-typecheck, security-static, tests, e2e, react-doctor]
+    needs:
+      - changed-files
+      - lint-and-typecheck
+      - security-static
+      - tests
+      - e2e
+      - react-doctor
+      - desktop-windows-package-smoke
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -261,6 +322,7 @@ jobs:
             echo "| Security static checks | **${{ needs.security-static.result }}** |"
             echo "| Tests | **${{ needs.tests.result }}** |"
             echo "| E2E | **${{ needs.e2e.result }}** |"
+            echo "| Desktop Windows package smoke | **${{ needs.desktop-windows-package-smoke.result }}** |"
             echo ""
             echo "### 变更范围"
             echo ""

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -45,7 +45,7 @@ permissions:
 
 concurrency:
   group: publish-sdk
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   release-sdk:
@@ -54,6 +54,9 @@ jobs:
       ${{
         github.event_name == 'workflow_dispatch' ||
         (github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.head_commit.author.name != 'dependabot[bot]' &&
+        !contains(github.event.workflow_run.head_commit.message || '', 'dependabot[bot]') &&
         !startsWith(github.event.workflow_run.head_commit.message || '', 'chore(release): packages v'))
       }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release-desktop-artifacts.yml
+++ b/.github/workflows/release-desktop-artifacts.yml
@@ -187,42 +187,9 @@ jobs:
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
 
-      - name: Install WiX Toolset
+      - name: Setup WiX Toolset
         if: matrix.platform == 'windows'
-        shell: pwsh
-        run: |
-          $candle = Get-Command candle.exe -ErrorAction SilentlyContinue
-          $light = Get-Command light.exe -ErrorAction SilentlyContinue
-
-          if (-not $candle -or -not $light) {
-            choco install wixtoolset -y --no-progress
-            $candle = Get-Command candle.exe -ErrorAction SilentlyContinue
-            $light = Get-Command light.exe -ErrorAction SilentlyContinue
-          }
-
-          if (-not $candle -or -not $light) {
-            $wixRoot = Get-ChildItem -LiteralPath ${env:ProgramFiles(x86)} -Directory -Filter 'WiX Toolset v3*' |
-              Sort-Object Name -Descending |
-              Select-Object -First 1
-            if ($wixRoot) {
-              $wixBin = Join-Path $wixRoot.FullName 'bin'
-              if (Test-Path (Join-Path $wixBin 'candle.exe')) {
-                $wixBin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-                $env:PATH = "$wixBin;$env:PATH"
-                $candle = Get-Command candle.exe -ErrorAction SilentlyContinue
-                $light = Get-Command light.exe -ErrorAction SilentlyContinue
-              }
-            }
-          } elseif ($candle.Source) {
-            Split-Path -Parent $candle.Source | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-          }
-
-          if (-not $candle -or -not $light) {
-            throw 'WiX Toolset candle.exe/light.exe were not found after installation.'
-          }
-
-          Write-Host "Using WiX candle: $($candle.Source)"
-          Write-Host "Using WiX light: $($light.Source)"
+        uses: ./.github/actions/setup-wix
 
       - name: Prepare Windows signing
         if: matrix.platform == 'windows'

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -56,6 +56,7 @@ jobs:
             git diff --name-only "$range" -- \
               .github/workflows/release-desktop-artifacts.yml \
               .github/workflows/release-desktop-beta.yml \
+              .github/actions/setup-wix \
               apps/desktop \
               apps/server/src/handlers/desktop-release.handler.ts \
               packages/connector \

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -82,6 +82,7 @@ jobs:
             git diff --name-only "$range" -- \
               .github/workflows/release-desktop-artifacts.yml \
               .github/workflows/release-desktop.yml \
+              .github/actions/setup-wix \
               apps/desktop \
               apps/server/src/handlers/desktop-release.handler.ts \
               packages/connector \

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: desktop-stable-release
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   gate:
@@ -27,6 +27,8 @@ jobs:
       github.event_name != 'workflow_run' ||
       (github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_commit.author.name != 'dependabot[bot]' &&
+      !contains(github.event.workflow_run.head_commit.message || '', 'dependabot[bot]') &&
       !startsWith(github.event.workflow_run.head_commit.message || '', 'chore(release): mobile v') &&
       !startsWith(github.event.workflow_run.head_commit.message || '', 'chore(release): desktop v') &&
       !startsWith(github.event.workflow_run.head_commit.message || '', 'chore(release): apps v'))
@@ -49,10 +51,23 @@ jobs:
           FORCE: ${{ inputs.force || 'false' }}
         run: |
           set -euo pipefail
-          git fetch --force --tags
+          git fetch --force origin "+refs/heads/main:refs/remotes/origin/main" --tags
 
           force="${FORCE:-false}"
           head_sha="$(git rev-parse HEAD)"
+          latest_main_sha="$(git rev-parse refs/remotes/origin/main)"
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ] && [ "$head_sha" != "$latest_main_sha" ]; then
+            {
+              echo "should_release=false"
+              echo "base="
+              echo "head_sha=${head_sha}"
+              echo "changed_files="
+            } >> "$GITHUB_OUTPUT"
+            echo "Skipping stale desktop release for ${head_sha}; current main is ${latest_main_sha}."
+            exit 0
+          fi
+
           base="$(git tag --list 'desktop-v*' --sort=-creatordate | head -n 1 || true)"
 
           if [ -n "$base" ]; then

--- a/.github/workflows/release-mobile-testflight.yml
+++ b/.github/workflows/release-mobile-testflight.yml
@@ -26,7 +26,7 @@ permissions:
 
 concurrency:
   group: mobile-testflight-release
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   gate:
@@ -36,6 +36,8 @@ jobs:
       github.event_name != 'workflow_run' ||
       (github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_commit.author.name != 'dependabot[bot]' &&
+      !contains(github.event.workflow_run.head_commit.message || '', 'dependabot[bot]') &&
       !startsWith(github.event.workflow_run.head_commit.message || '', 'chore(release): mobile v') &&
       !startsWith(github.event.workflow_run.head_commit.message || '', 'chore(release): desktop v') &&
       !startsWith(github.event.workflow_run.head_commit.message || '', 'chore(release): apps v'))
@@ -59,13 +61,26 @@ jobs:
           FORCE: ${{ inputs.force || 'false' }}
         run: |
           set -euo pipefail
-          git fetch --force --tags
+          git fetch --force origin "+refs/heads/main:refs/remotes/origin/main" --tags
 
           today="$(TZ=Asia/Shanghai date +%Y%m%d)"
           daily_tag="mobile-testflight-${today}"
           tag="$daily_tag"
           force="${FORCE:-false}"
           head_sha="$(git rev-parse HEAD)"
+          latest_main_sha="$(git rev-parse refs/remotes/origin/main)"
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ] && [ "$head_sha" != "$latest_main_sha" ]; then
+            {
+              echo "should_release=false"
+              echo "tag=${daily_tag}"
+              echo "base="
+              echo "head_sha=${head_sha}"
+              echo "changed_files="
+            } >> "$GITHUB_OUTPUT"
+            echo "Skipping stale mobile TestFlight release for ${head_sha}; current main is ${latest_main_sha}."
+            exit 0
+          fi
 
           if [ "$force" != "true" ] && git rev-parse -q --verify "refs/tags/${daily_tag}" >/dev/null; then
             {

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -30,6 +30,8 @@ const dmgBackgroundPath = resolve(__dirname, 'assets', 'dmg-background.png')
 const windowsAppUserModelId = 'com.squirrel.Shadow.Shadow'
 const windowsMsiUpgradeCode = 'A2A5547B-71E9-492A-8C10-E2F66D4F29C0'
 const localizedChineseProductName = '虾豆'
+const windowsMsiLanguage = 2052
+const windowsMsiCodepage = 936
 
 const extraResource: string[] = []
 extraResource.push(
@@ -126,6 +128,19 @@ function windowsSignConfig(): WindowsSignConfig | undefined {
 }
 
 const windowsSign = windowsSignConfig()
+
+function configureWindowsMsiLocale(creator: { wixTemplate: string }) {
+  const productTag = '<Product Id="{{ProductCode}}"'
+  if (!creator.wixTemplate.includes(productTag)) {
+    throw new Error('Unable to configure Windows MSI locale: WiX Product template was not found.')
+  }
+
+  // WiX v3 defaults MSI databases to code page 1252, which cannot store the Chinese shortcut name.
+  creator.wixTemplate = creator.wixTemplate.replace(
+    productTag,
+    `${productTag} Codepage="${windowsMsiCodepage}"`,
+  )
+}
 
 const config: ForgeConfig = {
   hooks: {
@@ -242,7 +257,8 @@ const config: ForgeConfig = {
       programFilesFolderName: productName,
       shortcutFolderName: localizedChineseProductName,
       shortcutName: localizedChineseProductName,
-      language: 1033,
+      language: windowsMsiLanguage,
+      beforeCreate: configureWindowsMsiLocale,
       defaultInstallMode: 'perUser',
       installLevel: 3,
       features: {

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -32,6 +32,7 @@ const windowsMsiUpgradeCode = 'A2A5547B-71E9-492A-8C10-E2F66D4F29C0'
 const localizedChineseProductName = '虾豆'
 const windowsMsiLanguage = 2052
 const windowsMsiCodepage = 936
+const windowsMsiCulture = 'zh-cn'
 
 const extraResource: string[] = []
 extraResource.push(
@@ -258,6 +259,7 @@ const config: ForgeConfig = {
       shortcutFolderName: localizedChineseProductName,
       shortcutName: localizedChineseProductName,
       language: windowsMsiLanguage,
+      cultures: windowsMsiCulture,
       beforeCreate: configureWindowsMsiLocale,
       defaultInstallMode: 'perUser',
       installLevel: 3,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -41,7 +41,7 @@
     "expo": "~54.0.35",
     "expo-apple-authentication": "~8.0.8",
     "expo-asset": "~12.0.13",
-    "expo-audio": "~56.0.11",
+    "expo-audio": "~1.1.1",
     "expo-auth-session": "^7.0.11",
     "expo-camera": "~17.0.10",
     "expo-clipboard": "~8.0.8",

--- a/apps/mobile/vitest.setup.ts
+++ b/apps/mobile/vitest.setup.ts
@@ -254,6 +254,41 @@ vi.mock('expo-secure-store', () => ({
   deleteItemAsync: vi.fn(() => Promise.resolve()),
 }))
 
+vi.mock('@react-native-async-storage/async-storage', () => {
+  const storage = new Map<string, string>()
+  const asyncStorage = {
+    getItem: vi.fn((key: string) => Promise.resolve(storage.get(key) ?? null)),
+    setItem: vi.fn((key: string, value: string) => {
+      storage.set(key, value)
+      return Promise.resolve()
+    }),
+    removeItem: vi.fn((key: string) => {
+      storage.delete(key)
+      return Promise.resolve()
+    }),
+    clear: vi.fn(() => {
+      storage.clear()
+      return Promise.resolve()
+    }),
+    multiGet: vi.fn((keys: string[]) =>
+      Promise.resolve(keys.map((key) => [key, storage.get(key) ?? null])),
+    ),
+    multiSet: vi.fn((entries: [string, string][]) => {
+      entries.forEach(([key, value]) => storage.set(key, value))
+      return Promise.resolve()
+    }),
+    multiRemove: vi.fn((keys: string[]) => {
+      keys.forEach((key) => storage.delete(key))
+      return Promise.resolve()
+    }),
+  }
+  return {
+    __esModule: true,
+    default: asyncStorage,
+    ...asyncStorage,
+  }
+})
+
 vi.mock('expo-image-picker', () => ({
   __esModule: true,
   default: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,8 +532,8 @@ importers:
         specifier: ~12.0.13
         version: 12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-audio:
-        specifier: ~56.0.11
-        version: 56.0.11(expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: ~1.1.1
+        version: 1.1.1(expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-auth-session:
         specifier: ^7.0.11
         version: 7.0.11(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -10494,8 +10494,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  expo-audio@56.0.11:
-    resolution: {integrity: sha512-naionxilr49IpEjmMqCj5gXHCSfOsgu3nZ/KXndexR05Tv6dET7dmespyZkcMrADJN07gA5hyqPUC5WqWuaFLw==}
+  expo-audio@1.1.1:
+    resolution: {integrity: sha512-CPCpJ+0AEHdzWROc0f00Zh6e+irLSl2ALos/LPvxEeIcJw1APfBa4DuHPkL4CQCWsVe7EnUjFpdwpqsEUWcP0g==}
     peerDependencies:
       expo: '*'
       expo-asset: '*'
@@ -27241,7 +27241,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-audio@56.0.11(expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-audio@1.1.1(expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-asset: 12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

This PR stops automated release churn, restores TestFlight verification, and fixes the Windows desktop MSI packaging failure.

- Skips desktop, mobile TestFlight, and package publish workflows when the triggering post-merge commit is from `dependabot[bot]`.
- Enables `cancel-in-progress` for stable desktop, mobile TestFlight, and package publish workflows so newer release runs cancel older ones.
- Adds a latest-`main` guard to desktop and mobile release gates so stale workflow_run completions skip instead of publishing an older commit.
- Reverts `expo-audio` to the Expo SDK 54-compatible `~1.1.1`, fixing `expo install --check` in `release-mobile-testflight`.
- Mocks AsyncStorage in mobile Vitest setup so local Node 26 test runs do not depend on real `localStorage`.
- Fixes the Windows WiX MSI locale by generating the MSI with Simplified Chinese language `2052`, code page `936`, and WixUI culture `zh-cn`, so the Chinese shortcut/start-menu name `虾豆` no longer fails WiX `LGHT0311`.
- Adds a PR workflow Windows desktop package smoke job that installs WiX through the same local action used by release, runs `pnpm --dir ./apps/desktop release:win`, and verifies the generated Squirrel/WiX artifacts.

## Root Cause

A dependabot merge bumped `expo-audio` from `1.1.1` to `56.0.11`. The post-merge release workflows treated that dependency-only merge as releasable, generated release commits, and then TestFlight failed during `pnpm mobile:verify:ios` because `expo install --check` expected `expo-audio@~1.1.1` for Expo SDK 54.

The latest desktop release then reached WiX successfully, but `light.exe` failed with `LGHT0311` because the MSI database defaulted to code page `1252` while the WiX template contained the Chinese shortcut/start-menu name `虾豆`. `Product/@Codepage=936` is present in the generated `.wxs`; because WixUI is enabled, the build also needs `light.exe -cultures:zh-cn` so WixUI localization does not pull the package back to the default 1252 culture.

## Validation

Local checks run:

- `pnpm install --frozen-lockfile --lockfile-only`
- `pnpm mobile:verify:ios`
- `pnpm --dir apps/mobile expo:check`
- `pnpm --dir apps/mobile bundle:ios`
- `pnpm biome check apps/mobile/package.json apps/mobile/vitest.setup.ts`
- `pnpm --dir apps/desktop typecheck`
- `pnpm biome check apps/desktop/forge.config.ts`
- YAML parse check for touched workflow/action files
- Forge config smoke check for `MakerWix` `language=2052`, `Codepage=936`, and `cultures=zh-cn`
- `git diff --check origin/main...HEAD`

Remote validation now expected in PR checks:

- `pr-checks / Desktop Windows package smoke` builds the Windows release artifacts on `windows-latest` before merge.

## Notes

This PR is intentionally not auto-merged. Please review and merge manually.