### PR TITLE
fix(desktop): repair PC runtime regressions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -260,9 +260,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Setup WiX Toolset
-        uses: ./.github/actions/setup-wix
-
       - name: Generate icons
         run: pnpm --dir ./apps/desktop generate-icons
 
@@ -282,7 +279,6 @@ jobs:
           name: desktop-windows-package-smoke
           path: |
             apps/desktop/out/make/**/*.exe
-            apps/desktop/out/make/**/*.msi
             apps/desktop/out/make/**/*.nupkg
             apps/desktop/out/make/**/Shadow.wxs
           if-no-files-found: warn

--- a/.github/workflows/release-desktop-artifacts.yml
+++ b/.github/workflows/release-desktop-artifacts.yml
@@ -187,10 +187,6 @@ jobs:
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
 
-      - name: Setup WiX Toolset
-        if: matrix.platform == 'windows'
-        uses: ./.github/actions/setup-wix
-
       - name: Prepare Windows signing
         if: matrix.platform == 'windows'
         shell: pwsh
@@ -242,7 +238,7 @@ jobs:
             extension="${filename##*.}"
             stem="${filename%.*}"
             cp "$file" "$upload_dir/${stem}-${{ matrix.platform }}-x64.${extension}"
-          done < <(find apps/desktop/out/make -type f \( -name '*.exe' -o -name '*.msi' -o -name '*.zip' -o -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \))
+          done < <(find apps/desktop/out/make -type f \( -name '*.exe' -o -name '*.zip' -o -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \))
 
           find "$upload_dir" -type f
 
@@ -340,7 +336,6 @@ jobs:
           files: |
             release-assets/**/*.dmg
             release-assets/**/*.exe
-            release-assets/**/*.msi
             release-assets/**/*.zip
             release-assets/**/*.AppImage
             release-assets/**/*.deb

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -56,7 +56,6 @@ jobs:
             git diff --name-only "$range" -- \
               .github/workflows/release-desktop-artifacts.yml \
               .github/workflows/release-desktop-beta.yml \
-              .github/actions/setup-wix \
               apps/desktop \
               apps/server/src/handlers/desktop-release.handler.ts \
               packages/connector \

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -82,7 +82,6 @@ jobs:
             git diff --name-only "$range" -- \
               .github/workflows/release-desktop-artifacts.yml \
               .github/workflows/release-desktop.yml \
-              .github/actions/setup-wix \
               apps/desktop \
               apps/server/src/handlers/desktop-release.handler.ts \
               packages/connector \

--- a/apps/desktop/__tests__/community-session.test.ts
+++ b/apps/desktop/__tests__/community-session.test.ts
@@ -294,4 +294,23 @@ describe('desktop community session', () => {
     expect(executedAuthUpdateScript(win)).toContain('shadow:desktop-community-auth-updated')
     expect(executedAuthUpdateScript(win)).toContain('revoked')
   })
+
+  it('keeps refresh tickets when an authorized request is rejected after refresh cannot rotate', async () => {
+    const session = await loadCommunitySession()
+    session.communitySessionService.rememberAuthSnapshot(
+      { accessToken: 'expired-access', refreshToken: 'refresh-1' },
+      { reason: 'login' },
+    )
+    electronState.fetch
+      .mockResolvedValueOnce(response({ error: 'expired' }, { status: 401 }))
+      .mockResolvedValueOnce(response({ error: 'temporary' }, { status: 500 }))
+
+    await expect(session.communitySessionService.fetchWithAuth('/api/ping')).rejects.toThrow(
+      'AUTH_REQUIRED',
+    )
+    await expect(session.communitySessionService.readAuthTokens()).resolves.toEqual({
+      accessToken: '',
+      refreshToken: 'refresh-1',
+    })
+  })
 })

--- a/apps/desktop/__tests__/pet-window-drag.test.ts
+++ b/apps/desktop/__tests__/pet-window-drag.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const electronState = vi.hoisted(() => ({
   setPosition: vi.fn(),
   screenToDipPoint: vi.fn(({ x, y }: { x: number; y: number }) => ({ x: x / 1.5, y: y / 1.5 })),
+  browserWindowOptions: [] as Array<Record<string, unknown>>,
 }))
 
 vi.mock('electron', () => {
@@ -10,9 +11,13 @@ vi.mock('electron', () => {
     webContents = {
       openDevTools: vi.fn(),
       setWindowOpenHandler: vi.fn(),
+      on: vi.fn(),
+      getURL: vi.fn(() => 'https://shadowob.com/app/discover'),
     }
 
-    constructor() {}
+    constructor(options: Record<string, unknown>) {
+      electronState.browserWindowOptions.push(options)
+    }
 
     setVisibleOnAllWorkspaces = vi.fn()
     setAlwaysOnTop = vi.fn()
@@ -95,6 +100,20 @@ describe('desktop pet window drag', () => {
     vi.resetModules()
     electronState.setPosition.mockReset()
     electronState.screenToDipPoint.mockClear()
+    electronState.browserWindowOptions = []
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32',
+    })
+  })
+
+  it('keeps the native Windows frame on the community window', async () => {
+    const windowModule = await import('../src/main/services/window.service')
+
+    windowModule.windowService.createWindow()
+
+    expect(electronState.browserWindowOptions[0]?.titleBarStyle).toBe('default')
+    expect(electronState.browserWindowOptions[0]?.autoHideMenuBar).toBe(true)
   })
 
   it('moves with Electron DIP coordinates for scaled Windows displays', async () => {
@@ -106,8 +125,6 @@ describe('desktop pet window drag', () => {
       pointerId: 7,
       screenX: 180,
       screenY: 210,
-      x: 30,
-      y: 60,
     })
 
     expect(electronState.screenToDipPoint).toHaveBeenCalledWith({ x: 150, y: 150 })

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -3,7 +3,6 @@ import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import { MakerDMG } from '@electron-forge/maker-dmg'
 import { MakerSquirrel, type MakerSquirrelConfig } from '@electron-forge/maker-squirrel'
-import { MakerWix, type MakerWixConfig } from '@electron-forge/maker-wix'
 import { MakerZIP } from '@electron-forge/maker-zip'
 import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-natives'
 import type { ForgeConfig } from '@electron-forge/shared-types'
@@ -27,12 +26,6 @@ const companyName = 'ShadowOB Team'
 const copyright = `Copyright © ${new Date().getFullYear()} ${companyName}`
 const desktopUpdateBaseUrl = process.env.DESKTOP_UPDATE_BASE_URL?.replace(/\/+$/, '')
 const dmgBackgroundPath = resolve(__dirname, 'assets', 'dmg-background.png')
-const windowsAppUserModelId = 'com.squirrel.Shadow.Shadow'
-const windowsMsiUpgradeCode = 'A2A5547B-71E9-492A-8C10-E2F66D4F29C0'
-const localizedChineseProductName = '虾豆'
-const windowsMsiLanguage = 2052
-const windowsMsiCodepage = 936
-const windowsMsiCulture = 'zh-cn'
 
 const extraResource: string[] = []
 extraResource.push(
@@ -102,7 +95,7 @@ function nonEmptyEnv(name: string): string | undefined {
 }
 
 type WindowsSignConfig = NonNullable<MakerSquirrelConfig['windowsSign']> &
-  NonNullable<MakerWixConfig['windowsSign']>
+  NonNullable<MakerSquirrelConfig['windowsSign']>
 
 function windowsSignConfig(): WindowsSignConfig | undefined {
   const certificateFile = nonEmptyEnv('WINDOWS_CERTIFICATE_FILE')
@@ -129,19 +122,6 @@ function windowsSignConfig(): WindowsSignConfig | undefined {
 }
 
 const windowsSign = windowsSignConfig()
-
-function configureWindowsMsiLocale(creator: { wixTemplate: string }) {
-  const productTag = '<Product Id="{{ProductCode}}"'
-  if (!creator.wixTemplate.includes(productTag)) {
-    throw new Error('Unable to configure Windows MSI locale: WiX Product template was not found.')
-  }
-
-  // WiX v3 defaults MSI databases to code page 1252, which cannot store the Chinese shortcut name.
-  creator.wixTemplate = creator.wixTemplate.replace(
-    productTag,
-    `${productTag} Codepage="${windowsMsiCodepage}"`,
-  )
-}
 
 const config: ForgeConfig = {
   hooks: {
@@ -239,38 +219,10 @@ const config: ForgeConfig = {
       description: desktopPackage.description ?? 'Shadow Desktop',
       exe: `${productName}.exe`,
       setupExe: `${productName}-${desktopPackage.version ?? '0.0.0'}-windows-x64-setup.exe`,
-      setupMsi: `${productName}-${desktopPackage.version ?? '0.0.0'}-windows-x64-setup.msi`,
       noMsi: true,
       setupIcon: resolve(__dirname, 'assets', 'icon.ico'),
       iconUrl:
         'https://raw.githubusercontent.com/buggyblues/shadow/main/apps/desktop/assets/icon.ico',
-      ...(windowsSign ? { windowsSign } : {}),
-    }),
-    new MakerWix({
-      name: productName,
-      shortName: productName,
-      manufacturer: companyName,
-      description: desktopPackage.description ?? 'Shadow Desktop',
-      exe: `${productName}.exe`,
-      icon: resolve(__dirname, 'assets', 'icon.ico'),
-      appUserModelId: windowsAppUserModelId,
-      upgradeCode: windowsMsiUpgradeCode,
-      programFilesFolderName: productName,
-      shortcutFolderName: localizedChineseProductName,
-      shortcutName: localizedChineseProductName,
-      language: windowsMsiLanguage,
-      cultures: windowsMsiCulture,
-      beforeCreate: configureWindowsMsiLocale,
-      defaultInstallMode: 'perUser',
-      installLevel: 3,
-      features: {
-        autoUpdate: true,
-        autoLaunch: false,
-      },
-      autoRun: true,
-      ui: {
-        chooseDirectory: true,
-      },
       ...(windowsSign ? { windowsSign } : {}),
     }),
     new MakerDMG(

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -42,7 +42,6 @@
     "@electron-forge/cli": "^7.11.2",
     "@electron-forge/maker-dmg": "^7.11.2",
     "@electron-forge/maker-squirrel": "^7.11.2",
-    "@electron-forge/maker-wix": "^7.11.2",
     "@electron-forge/maker-zip": "^7.11.2",
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.2",
     "@playwright/test": "^1.59.0",

--- a/apps/desktop/scripts/verify-package-assets.mjs
+++ b/apps/desktop/scripts/verify-package-assets.mjs
@@ -167,18 +167,15 @@ function verifyWindowsPackage() {
   assertFile(join(root, 'assets', 'icon.ico'), 'Windows source icon')
   const makeDir = join(outDir, 'make')
   const setup = findFirstFile(makeDir, (path) => path.toLowerCase().endsWith('.exe'))
-  const msi = findFirstFile(makeDir, (path) => path.toLowerCase().endsWith('.msi'))
   const releases = findFirstFile(makeDir, (path) => path.toLowerCase().endsWith('releases'))
   const fullNupkg = findFirstFile(makeDir, (path) => path.toLowerCase().endsWith('-full.nupkg'))
   const hasWindowsMakeOutput = Boolean(setup || msi || releases || fullNupkg)
 
   if (hasWindowsMakeOutput) {
     if (!setup) throw new Error('[verify-package-assets] Missing Windows Squirrel setup executable')
-    if (!msi) throw new Error('[verify-package-assets] Missing Windows WiX MSI installer')
     if (!releases) throw new Error('[verify-package-assets] Missing Squirrel RELEASES metadata')
     if (!fullNupkg) throw new Error('[verify-package-assets] Missing Squirrel full NuGet package')
     assertFile(setup, 'Windows Squirrel setup executable')
-    assertFile(msi, 'Windows WiX MSI installer')
     assertFile(releases, 'Squirrel RELEASES metadata')
     assertFile(fullNupkg, 'Squirrel full NuGet package')
   }
@@ -188,7 +185,6 @@ function verifyWindowsPackage() {
       throw new Error('[verify-package-assets] Windows signature verification requires win32 host')
     }
     if (!setup) throw new Error('[verify-package-assets] Missing Windows setup executable')
-    if (!msi) throw new Error('[verify-package-assets] Missing Windows MSI installer')
     const appExe = findFirstFile(
       outDir,
       (path) =>
@@ -197,7 +193,7 @@ function verifyWindowsPackage() {
         path.toLowerCase().endsWith('shadow.exe'),
     )
     if (!appExe) throw new Error('[verify-package-assets] Missing packaged Shadow.exe')
-    for (const file of [setup, msi, appExe]) {
+    for (const file of [setup, appExe]) {
       const status = powershell(`(Get-AuthenticodeSignature -LiteralPath ${ps(file)}).Status`)
       if (status !== 'Valid') {
         throw new Error(

--- a/apps/desktop/src/main/services/community-session.service.ts
+++ b/apps/desktop/src/main/services/community-session.service.ts
@@ -414,7 +414,7 @@ async function fetchCommunityUrlWithAuth(
     }
   }
   if (response.status === 401 || response.status === 403) {
-    forgetCommunityAuthTokens(token)
+    forgetCommunityAccessToken(token)
     throw new Error(DESKTOP_COMMUNITY_AUTH_REQUIRED)
   }
   return response

--- a/apps/desktop/src/main/services/window.service.ts
+++ b/apps/desktop/src/main/services/window.service.ts
@@ -230,7 +230,7 @@ function createWindow(): BrowserWindow {
     minWidth: 940,
     minHeight: 560,
     title: i18nService.appName(),
-    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
+    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     ...(process.platform === 'darwin' && { trafficLightPosition: { x: 14, y: 14 } }),
     ...desktopWindowIcon(),
     autoHideMenuBar: true,
@@ -691,10 +691,14 @@ function movePetWindow(input: PetWindowMoveInput): void {
     win.setPosition(Math.round(nextX), Math.round(nextY), false)
     return
   }
-  const [x = 0, y = 0] = win.getPosition()
-  const dx = Number.isFinite(input?.x) ? Number(input.x) : 0
-  const dy = Number.isFinite(input?.y) ? Number(input.y) : 0
-  win.setPosition(Math.round(x + dx), Math.round(y + dy), false)
+  // Delta fallback is only for legacy renderer builds. New renderers send absolute
+  // screen coordinates so Windows display scaling cannot accumulate movement error.
+  if (Number.isFinite(input?.x) || Number.isFinite(input?.y)) {
+    const [x = 0, y = 0] = win.getPosition()
+    const dx = Number.isFinite(input?.x) ? Number(input.x) : 0
+    const dy = Number.isFinite(input?.y) ? Number(input.y) : 0
+    win.setPosition(Math.round(x + dx), Math.round(y + dy), false)
+  }
 }
 
 function endPetWindowDrag(pointerId?: number): void {

--- a/apps/desktop/src/renderer/pet-app.tsx
+++ b/apps/desktop/src/renderer/pet-app.tsx
@@ -1257,8 +1257,8 @@ export function PetApp() {
     if (!drag || drag.pointerId !== event.pointerId) return
     if (drag.voiceStarted) return
     const delta = {
-      x: event.movementX || event.screenX - drag.lastScreenX || event.clientX - drag.lastClientX,
-      y: event.movementY || event.screenY - drag.lastScreenY || event.clientY - drag.lastClientY,
+      x: event.screenX - drag.lastScreenX || event.clientX - drag.lastClientX,
+      y: event.screenY - drag.lastScreenY || event.clientY - drag.lastClientY,
     }
     if (!delta.x && !delta.y) return
     drag.lastClientX = event.clientX
@@ -1276,7 +1276,6 @@ export function PetApp() {
     if (Math.abs(delta.x) >= 1) setDragDirection(delta.x >= 0 ? 'running-right' : 'running-left')
     if (drag.travel >= 7) clearDragVoiceTimer(drag)
     void api?.pet?.moveWindow?.({
-      ...delta,
       pointerId: drag.pointerId,
       screenX: event.screenX,
       screenY: event.screenY,

--- a/apps/web/src/lib/auth-session.test.ts
+++ b/apps/web/src/lib/auth-session.test.ts
@@ -54,6 +54,7 @@ function testStorage(): Storage {
 }
 
 function setDesktopAPI(api: {
+  isDesktop?: boolean
   getCommunityAuthTokens?: () => Promise<{ accessToken?: string; refreshToken?: string }>
   syncCommunityAuthToken?: (
     accessToken?: string | null,
@@ -63,7 +64,7 @@ function setDesktopAPI(api: {
 }) {
   Object.defineProperty(window, 'desktopAPI', {
     configurable: true,
-    value: api,
+    value: { isDesktop: true, ...api },
   })
   return api
 }
@@ -112,6 +113,23 @@ describe('auth session', () => {
       accessToken: 'desktop-access',
       isAuthenticated: true,
     })
+  })
+
+  it('waits for delayed desktop auth before reporting an empty session', async () => {
+    setDesktopAPI({
+      getCommunityAuthTokens: vi
+        .fn()
+        .mockResolvedValueOnce({ accessToken: '', refreshToken: '' })
+        .mockResolvedValueOnce({ accessToken: '', refreshToken: '' })
+        .mockResolvedValueOnce({ accessToken: 'desktop-access', refreshToken: 'desktop-refresh' }),
+      syncCommunityAuthToken: vi.fn(),
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(user)))
+
+    await expect(ensureAuthenticatedSession()).resolves.toEqual(user)
+
+    expect(testStorage().getItem('accessToken')).toBe('desktop-access')
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
   })
 
   it('does not report logout to desktop when startup has no renderer token', async () => {

--- a/apps/web/src/lib/desktop-community-auth.ts
+++ b/apps/web/src/lib/desktop-community-auth.ts
@@ -21,6 +21,7 @@ type DesktopCommunityAuthBridge = {
 }
 
 const DESKTOP_AUTH_EMPTY_RETRY_MS = 120
+const DESKTOP_AUTH_EMPTY_RETRY_ATTEMPTS = 8
 
 function normalizeDesktopAuthTokens(
   tokens: {
@@ -39,6 +40,20 @@ function normalizeDesktopAuthTokens(
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms))
+}
+
+function readRendererAuthTokens(): {
+  accessToken: string
+  refreshToken: string
+} {
+  try {
+    return normalizeDesktopAuthTokens({
+      accessToken: window.localStorage?.getItem('accessToken'),
+      refreshToken: window.localStorage?.getItem('refreshToken'),
+    })
+  } catch {
+    return { accessToken: '', refreshToken: '' }
+  }
 }
 
 export function syncDesktopCommunityAuthToken(
@@ -62,6 +77,14 @@ export async function readDesktopCommunityAuthTokens(): Promise<{
     await desktopAPI.getCommunityAuthTokens().catch(() => null),
   )
   if (tokens.accessToken || tokens.refreshToken || !desktopAPI.isDesktop) return tokens
-  await delay(DESKTOP_AUTH_EMPTY_RETRY_MS)
-  return normalizeDesktopAuthTokens(await desktopAPI.getCommunityAuthTokens().catch(() => null))
+  for (let attempt = 0; attempt < DESKTOP_AUTH_EMPTY_RETRY_ATTEMPTS; attempt += 1) {
+    const rendererTokens = readRendererAuthTokens()
+    if (rendererTokens.accessToken || rendererTokens.refreshToken) return rendererTokens
+    await delay(DESKTOP_AUTH_EMPTY_RETRY_MS)
+    const retried = normalizeDesktopAuthTokens(
+      await desktopAPI.getCommunityAuthTokens().catch(() => null),
+    )
+    if (retried.accessToken || retried.refreshToken) return retried
+  }
+  return { accessToken: '', refreshToken: '' }
 }

--- a/packages/connector/tsup.config.ts
+++ b/packages/connector/tsup.config.ts
@@ -25,7 +25,7 @@ export default defineConfig([
     banner: {
       js: "import { createRequire } from 'node:module';\nconst require = createRequire(import.meta.url);",
     },
-    noExternal: ['dotenv', 'smol-toml', 'yaml'],
+    noExternal: ['@shadowob/shared', 'dotenv', 'smol-toml', 'yaml'],
     outDir: 'dist',
   },
 ])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,9 +414,6 @@ importers:
       '@electron-forge/maker-squirrel':
         specifier: ^7.11.2
         version: 7.11.2
-      '@electron-forge/maker-wix':
-        specifier: ^7.11.2
-        version: 7.11.2
       '@electron-forge/maker-zip':
         specifier: ^7.11.2
         version: 7.11.2
@@ -2891,9 +2888,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@bitdisaster/exe-icon-extractor@1.0.10':
-    resolution: {integrity: sha512-iTZ8cVGZ5dglNRyFdSj8U60mHIrC8XNIuOHN/NkM5/dQP4nsmpyqeQTAADLLQgoFCNJD+DiwQCv8dR2cCeWP4g==}
-
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
@@ -3148,10 +3142,6 @@ packages:
 
   '@electron-forge/maker-squirrel@7.11.2':
     resolution: {integrity: sha512-4CILo57ZDEQH1mJxjhYCSXuv+WaU7oPq67KqiTLEUOEzmiPg9u9/z7FXE34H/Tn5aKWN3dy+ngAETzv6iERCGg==}
-    engines: {node: '>= 16.4.0'}
-
-  '@electron-forge/maker-wix@7.11.2':
-    resolution: {integrity: sha512-uf+wmWCqTA23m0KabkQT7m+lyEtdB/Hbtn9Rb8KVSK4FPLrcSC/glYLlHKJhg6DikQraZVfD8JcUPKyZ1YTX2A==}
     engines: {node: '>= 16.4.0'}
 
   '@electron-forge/maker-zip@7.11.2':
@@ -4809,10 +4799,6 @@ packages:
 
   '@lydell/node-pty@1.2.0-beta.12':
     resolution: {integrity: sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==}
-
-  '@malept/cross-spawn-promise@1.1.1':
-    resolution: {integrity: sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==}
-    engines: {node: '>= 10'}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -9516,10 +9502,6 @@ packages:
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
 
-  cross-spawn-windows-exe@1.2.0:
-    resolution: {integrity: sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==}
-    engines: {node: '>= 10'}
-
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
     engines: {node: '>=4.8'}
@@ -10142,10 +10124,6 @@ packages:
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
-
-  electron-wix-msi@5.1.3:
-    resolution: {integrity: sha512-EYj1cm1nZoVHmIIx3o0aKt784lxdEpJnXbEnyypklUCnglqSb7ni+1xi1Vp/gtrGS/mzIxnWBT+x5fIfuDjhvA==}
-    engines: {node: '>=14.0.0'}
 
   electron@41.0.3:
     resolution: {integrity: sha512-IDjx8liW1q+r7+MOip5W1Eo1eMwJzVObmYrd9yz2dPCkS7XlgLq3qPVMR80TpiROFp73iY30kTzMdpA6fEVs3A==}
@@ -12147,10 +12125,6 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-
-  klaw@4.1.0:
-    resolution: {integrity: sha512-1zGZ9MF9H22UnkpVeuaGKOjfA2t6WrfdrJmGjy16ykcjnKQDmHVX+KI477rpbGevz/5FD4MC3xf1oxylBgcaQw==}
-    engines: {node: '>=14.14.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -14196,14 +14170,6 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
-
-  rcedit@4.0.1:
-    resolution: {integrity: sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg==}
-    engines: {node: '>= 14.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  rcinfo@0.1.3:
-    resolution: {integrity: sha512-c2XV2aYgY7x3BscO+/B/nCTtMvnclZ8w5D7R6zgK4sGOQnE0MjlXhOPynno7yp6Iw1RPNSXBwXwB1svZVRfcSw==}
 
   react-day-picker@9.14.0:
     resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
@@ -18362,9 +18328,6 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.8':
     optional: true
 
-  '@bitdisaster/exe-icon-extractor@1.0.10':
-    optional: true
-
   '@borewit/text-codec@0.2.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
@@ -18757,20 +18720,6 @@ snapshots:
       fs-extra: 10.1.0
     optionalDependencies:
       electron-winstaller: 5.4.0
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-
-  '@electron-forge/maker-wix@7.11.2':
-    dependencies:
-      '@electron-forge/core-utils': 7.11.2
-      '@electron-forge/maker-base': 7.11.2
-      '@electron-forge/shared-types': 7.11.2
-      chalk: 4.1.2
-      electron-wix-msi: 5.1.3
-      log-symbols: 4.1.0
-      parse-author: 2.0.0
-      semver: 7.7.4
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -20509,10 +20458,6 @@ snapshots:
       '@lydell/node-pty-linux-x64': 1.2.0-beta.12
       '@lydell/node-pty-win32-arm64': 1.2.0-beta.12
       '@lydell/node-pty-win32-x64': 1.2.0-beta.12
-
-  '@malept/cross-spawn-promise@1.1.1':
-    dependencies:
-      cross-spawn: 7.0.6
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
@@ -26196,12 +26141,6 @@ snapshots:
 
   cross-dirname@0.1.0: {}
 
-  cross-spawn-windows-exe@1.2.0:
-    dependencies:
-      '@malept/cross-spawn-promise': 1.1.1
-      is-wsl: 2.2.0
-      which: 2.0.2
-
   cross-spawn@6.0.6:
     dependencies:
       nice-try: 1.0.5
@@ -26745,21 +26684,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  electron-wix-msi@5.1.3:
-    dependencies:
-      '@electron/windows-sign': 1.2.2
-      debug: 4.4.3
-      fs-extra: 10.1.0
-      klaw: 4.1.0
-      lodash: 4.18.1
-      rcedit: 4.0.1
-      rcinfo: 0.1.3
-      semver: 7.7.4
-    optionalDependencies:
-      '@bitdisaster/exe-icon-extractor': 1.0.10
-    transitivePeerDependencies:
-      - supports-color
 
   electron@41.0.3:
     dependencies:
@@ -29307,8 +29231,6 @@ snapshots:
   khroma@2.1.0: {}
 
   kind-of@6.0.3: {}
-
-  klaw@4.1.0: {}
 
   kleur@3.0.3: {}
 
@@ -32101,12 +32023,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-
-  rcedit@4.0.1:
-    dependencies:
-      cross-spawn-windows-exe: 1.2.0
-
-  rcinfo@0.1.3: {}
 
   react-day-picker@9.14.0(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary
- restore the native Windows frame for the community window while keeping the app menu hidden
- make desktop pet dragging use absolute screen coordinates so DPI scaling does not accumulate drift
- bundle connector CLI workspace dependencies so packaged desktop builds can start connector scanning without @shadowob/shared module errors
- stop producing/uploading WiX MSI artifacts and keep Windows distribution on Squirrel Setup.exe to avoid Program Files permission failures
- make desktop/web auth handoff wait for delayed desktop tokens and preserve refresh tokens when a request rejects an expired access token

## Root Cause
- The main community window used a hidden Windows title bar, removing native window controls on PC.
- The pet renderer sent both movement deltas and screen coordinates; after the window moved, those deltas could diverge from the cursor under display scaling.
- The packaged connector CLI imported @shadowob/shared from resources/dist/cli.js, but the desktop package only shipped connector dist resources, not connector node_modules.
- WiX MSI artifacts encouraged machine-wide Program Files installs, which fail for non-admin users. Squirrel is retained as the Windows installer path.
- Web route guards could decide the session was empty before preload finished injecting desktop auth, and main could discard refresh tokens on an access-token rejection.

## Verification
- pnpm lint
- pnpm -C apps/desktop typecheck
- pnpm -C apps/web typecheck
- pnpm -C packages/connector typecheck
- pnpm -C apps/desktop exec vitest run -c vitest.config.ts
- pnpm -C apps/web exec vitest run src/lib/auth-session.test.ts
- pnpm --filter @shadowob/connector build
- pnpm --filter @shadowob/desktop build
- node packages/connector/dist/cli.js --help
- git diff --check