### PR TITLE
[codex] Add production CD and migration ops

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,139 @@
+name: deploy-production
+
+on:
+  workflow_run:
+    workflows: [publish-prod-images]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Image tag for server, web, and admin.
+        required: false
+        default: latest
+      integrations_image_tag:
+        description: Image tag for integrations. Empty uses image_tag.
+        required: false
+        default: ''
+      deploy_app:
+        description: Deploy server, web, and admin.
+        type: boolean
+        required: false
+        default: true
+      deploy_integrations:
+        description: Deploy integration apps.
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy production
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment: ShadowOB Production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Resolve deploy tags
+        id: deploy
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag || '' }}
+          INPUT_INTEGRATIONS_IMAGE_TAG: ${{ inputs.integrations_image_tag || '' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            short_sha="$(printf '%s' "$WORKFLOW_HEAD_SHA" | cut -c1-12)"
+            image_tag="sha-${short_sha}"
+          else
+            image_tag="${INPUT_IMAGE_TAG:-latest}"
+          fi
+
+          integrations_image_tag="${INPUT_INTEGRATIONS_IMAGE_TAG:-$image_tag}"
+
+          {
+            echo "image_tag=${image_tag}"
+            echo "integrations_image_tag=${integrations_image_tag}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare SSH auth
+        shell: bash
+        env:
+          PROD_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          PROD_SSH_PASSWORD: ${{ secrets.PROD_SSH_PASSWORD }}
+          PROD_SSH_KNOWN_HOSTS: ${{ secrets.PROD_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+
+          install -m 700 -d "$HOME/.ssh"
+
+          if [ -n "$PROD_SSH_PRIVATE_KEY" ]; then
+            key_path="$HOME/.ssh/prod_deploy_key"
+            printf '%s\n' "$PROD_SSH_PRIVATE_KEY" > "$key_path"
+            chmod 600 "$key_path"
+            echo "PROD_SSH_KEY_PATH=${key_path}" >> "$GITHUB_ENV"
+          elif [ -n "$PROD_SSH_PASSWORD" ]; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq sshpass
+          fi
+
+          if [ -n "$PROD_SSH_KNOWN_HOSTS" ]; then
+            printf '%s\n' "$PROD_SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+            chmod 600 "$HOME/.ssh/known_hosts"
+          fi
+
+      - name: Deploy over SSH
+        shell: bash
+        env:
+          PROD_SSH_HOST: ${{ vars.PROD_SSH_HOST || '' }}
+          PROD_SSH_USER: ${{ vars.PROD_SSH_USER || 'root' }}
+          PROD_SSH_PORT: ${{ vars.PROD_SSH_PORT || '22' }}
+          PROD_REMOTE_PATH: ${{ vars.PROD_REMOTE_PATH || '/workspace/shadow' }}
+          PROD_IMAGE_REGISTRY: ${{ vars.PROD_IMAGE_REGISTRY || 'ghcr.io' }}
+          PROD_IMAGE_NAMESPACE: ${{ vars.PROD_IMAGE_NAMESPACE || '' }}
+          DEPLOY_APP_INPUT: ${{ inputs.deploy_app }}
+          DEPLOY_INTEGRATIONS_INPUT: ${{ inputs.deploy_integrations }}
+          IMAGE_TAG: ${{ steps.deploy.outputs.image_tag }}
+          INTEGRATIONS_IMAGE_TAG: ${{ steps.deploy.outputs.integrations_image_tag }}
+          SSHPASS: ${{ secrets.PROD_SSH_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          deploy_app="${DEPLOY_APP_INPUT:-true}"
+          deploy_integrations="${DEPLOY_INTEGRATIONS_INPUT:-true}"
+          image_namespace="${PROD_IMAGE_NAMESPACE:-${GITHUB_REPOSITORY_OWNER,,}}"
+
+          args=(
+            --host "$PROD_SSH_HOST"
+            --user "$PROD_SSH_USER"
+            --port "$PROD_SSH_PORT"
+            --remote-path "$PROD_REMOTE_PATH"
+            --image-registry "$PROD_IMAGE_REGISTRY"
+            --image-namespace "$image_namespace"
+            --image-tag "$IMAGE_TAG"
+            --integrations-image-tag "$INTEGRATIONS_IMAGE_TAG"
+          )
+
+          if [ "$deploy_app" != "true" ]; then
+            args+=(--skip-app)
+          fi
+
+          if [ "$deploy_integrations" != "true" ]; then
+            args+=(--skip-integrations)
+          fi
+
+          scripts/ops/deploy-prod.sh "${args[@]}"

--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -45,6 +45,33 @@ jobs:
           - name: admin
             image: shadow-admin
             dockerfile: apps/admin/Dockerfile
+          - name: kanban
+            image: shadow-integration-kanban
+            dockerfile: integrations/kanban/Dockerfile
+          - name: skills
+            image: shadow-integration-skills
+            dockerfile: integrations/skills/Dockerfile
+          - name: qna
+            image: shadow-integration-qna
+            dockerfile: integrations/qna/Dockerfile
+          - name: quiz
+            image: shadow-integration-quiz
+            dockerfile: integrations/quiz/Dockerfile
+          - name: trainer
+            image: shadow-integration-trainer
+            dockerfile: integrations/trainer/Dockerfile
+          - name: resume
+            image: shadow-integration-resume
+            dockerfile: integrations/resume/Dockerfile
+          - name: flash
+            image: shadow-integration-flash
+            dockerfile: integrations/flash/Dockerfile
+          - name: space
+            image: shadow-integration-space
+            dockerfile: integrations/space/Dockerfile
+          - name: warbuddy
+            image: shadow-integration-warbuddy
+            dockerfile: integrations/warbuddy/Dockerfile
 
     steps:
       - name: Checkout

--- a/docs/deployment/ci-built-images.md
+++ b/docs/deployment/ci-built-images.md
@@ -7,6 +7,15 @@ passes on `main`:
 - `ghcr.io/buggyblues/shadow-server`
 - `ghcr.io/buggyblues/shadow-web`
 - `ghcr.io/buggyblues/shadow-admin`
+- `ghcr.io/buggyblues/shadow-integration-kanban`
+- `ghcr.io/buggyblues/shadow-integration-skills`
+- `ghcr.io/buggyblues/shadow-integration-qna`
+- `ghcr.io/buggyblues/shadow-integration-quiz`
+- `ghcr.io/buggyblues/shadow-integration-trainer`
+- `ghcr.io/buggyblues/shadow-integration-resume`
+- `ghcr.io/buggyblues/shadow-integration-flash`
+- `ghcr.io/buggyblues/shadow-integration-space`
+- `ghcr.io/buggyblues/shadow-integration-warbuddy`
 
 The workflow publishes three useful tag styles:
 
@@ -48,3 +57,6 @@ docker image prune -f
 
 Rollback is just changing `SHADOW_IMAGE_TAG` back to the previous
 `sha-<12-char-sha>` tag and running the same commands again.
+
+See [production-cd.zh-CN.md](production-cd.zh-CN.md) for the automated deploy
+workflow, manual deploy inputs, and data migration runbook.

--- a/docs/deployment/production-cd.zh-CN.md
+++ b/docs/deployment/production-cd.zh-CN.md
@@ -1,0 +1,148 @@
+# 生产 CD 与迁移 Runbook
+
+## 发布与部署链路
+
+`main` 合入后的链路是：
+
+1. `post-merge-validation` 跑完整测试和构建验证。
+2. `publish-prod-images` 在上一步成功后发布主应用和 integrations 镜像。
+3. `deploy-production` 在镜像发布成功后自动部署到生产服务器。
+
+自动部署使用不可变镜像 tag：`sha-<12 位 commit sha>`。手动部署从 GitHub Actions 的 `deploy-production` workflow 触发，`image_tag` 默认是 `latest`，`integrations_image_tag` 为空时复用 `image_tag`。
+
+## GitHub Environment 配置
+
+在 GitHub 的 `ShadowOB Production` environment 中配置：
+
+| 名称 | 类型 | 说明 |
+| --- | --- | --- |
+| `PROD_SSH_PRIVATE_KEY` | Secret | 推荐。可登录生产服务器的私钥内容。 |
+| `PROD_SSH_PASSWORD` | Secret | 可选。没有私钥时使用密码登录，workflow 会安装 `sshpass`。 |
+| `PROD_SSH_KNOWN_HOSTS` | Secret | 可选。建议放 `ssh-keyscan "$PROD_SSH_HOST"` 的结果。 |
+| `PROD_SSH_HOST` | Variable | 必填。生产服务器地址，不要提交到代码库。 |
+| `PROD_SSH_USER` | Variable | 可选，默认 `root`。 |
+| `PROD_SSH_PORT` | Variable | 可选，默认 `22`。 |
+| `PROD_REMOTE_PATH` | Variable | 可选，默认 `/workspace/shadow`。 |
+| `PROD_IMAGE_REGISTRY` | Variable | 可选，默认 `ghcr.io`。 |
+| `PROD_IMAGE_NAMESPACE` | Variable | 可选，默认仓库 owner 的小写值。 |
+
+生产业务密钥仍保留在服务器 `/workspace/shadow/.env`，不要放进仓库。部署脚本只会维护镜像相关变量：
+
+```dotenv
+SHADOW_IMAGE_REGISTRY=ghcr.io
+SHADOW_IMAGE_NAMESPACE=buggyblues
+SHADOW_IMAGE_TAG=sha-0123456789ab
+SHADOW_INTEGRATIONS_IMAGE_TAG=sha-0123456789ab
+```
+
+如果 GHCR package 是 private，先在服务器登录一次：
+
+```bash
+docker login ghcr.io
+```
+
+## 服务器前置条件
+
+目标服务器需要：
+
+- Docker Engine 与 Docker Compose v2，或兼容的 `docker-compose`。
+- `/workspace/shadow/.env` 存在，并包含 `docker-compose.prod.yml` 需要的生产变量。
+- integrations 的公网地址变量在 `.env` 中配置，例如 `KANBAN_PUBLIC_BASE_URL`、`FLASH_PUBLIC_BASE_URL`、`SPACE_PUBLIC_BASE_URL`。
+
+手动在本地触发同一套部署脚本：
+
+```bash
+scripts/ops/deploy-prod.sh \
+  --host "$PROD_SSH_HOST" \
+  --user root \
+  --remote-path /workspace/shadow \
+  --image-tag latest
+```
+
+部署脚本会上传最新 compose 文件，然后执行：
+
+```bash
+docker compose --env-file .env -f docker-compose.prod.yml pull server web admin
+docker compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans
+docker compose --env-file .env -f integrations/docker-compose.prod.yaml pull kanban skills qna quiz trainer resume flash space warbuddy
+docker compose --env-file .env -f integrations/docker-compose.prod.yaml up -d --remove-orphans
+docker image prune -f
+```
+
+## 从旧服务器迁移数据
+
+迁移脚本通过参数或环境变量读取源服务器和目标服务器地址。不要把真实 IP 提交到代码库。
+
+一次完整同步：
+
+```bash
+scripts/ops/migrate-prod-data.sh sync \
+  --source "$SOURCE_SSH_TARGET" \
+  --target "$TARGET_SSH_TARGET" \
+  --yes
+```
+
+这个命令会：
+
+- 拉取旧服务器 `/workspace/shadow/.env` 到本地备份目录。
+- 用 `pg_dump -Fc` 备份主 Postgres。
+- 自动识别并打包源服务器 `minio` 容器挂载的 MinIO volume。
+- 上传备份到新服务器 `/workspace/shadow/.migration-backups/<timestamp>`。
+- 覆盖新服务器 `.env`、Postgres 数据和 MinIO 数据。
+- 重新启动目标服务器的生产 compose。
+
+脚本会优先从远端正在运行的 `minio` 容器挂载中识别实际 volume 名称。如果容器未运行，才回退到 `.env` 的 `SHADOW_MINIO_VOLUME` 或默认值。如果需要覆盖自动识别结果，显式传入：
+
+```bash
+scripts/ops/migrate-prod-data.sh sync \
+  --source "$SOURCE_SSH_TARGET" \
+  --target "$TARGET_SSH_TARGET" \
+  --source-minio-volume old_shadow_miniodata \
+  --target-minio-volume shadow_miniodata \
+  --yes
+```
+
+只通过 SSH dump 主 Postgres 和 MinIO 到本地，不迁移 `.env`、不恢复：
+
+```bash
+scripts/ops/dump-prod-data.sh \
+  --source "$SOURCE_SSH_TARGET" \
+  --remote-path /workspace/shadow
+```
+
+只备份不恢复：
+
+```bash
+scripts/ops/migrate-prod-data.sh backup --source "$SOURCE_SSH_TARGET"
+```
+
+从已有本地备份恢复：
+
+```bash
+scripts/ops/migrate-prod-data.sh restore \
+  --target "$TARGET_SSH_TARGET" \
+  --backup-dir .tmp/prod-migrations/20260608T120000Z \
+  --yes
+```
+
+迁移可以重复执行。每次恢复都会覆盖目标服务器的主 Postgres 和 MinIO 数据；最终切流前，先停止旧服务器写入或进入维护窗口，再执行最后一次 `sync`。
+
+## 回滚
+
+主应用回滚：
+
+```bash
+scripts/ops/deploy-prod.sh \
+  --host "$PROD_SSH_HOST" \
+  --image-tag sha-上一版12位sha \
+  --skip-integrations
+```
+
+integrations 回滚：
+
+```bash
+scripts/ops/deploy-prod.sh \
+  --host "$PROD_SSH_HOST" \
+  --integrations-image-tag sha-上一版12位sha \
+  --skip-app
+```

--- a/integrations/docker-compose.prod.yaml
+++ b/integrations/docker-compose.prod.yaml
@@ -1,0 +1,208 @@
+name: shadow-integrations
+
+x-integration-defaults: &integration-defaults
+  pull_policy: always
+  restart: unless-stopped
+  extra_hosts:
+    - host.docker.internal:host-gateway
+
+services:
+  kanban:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-kanban:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4201'
+      SHADOW_SERVER_URL: ${SHADOW_SERVER_URL:-http://host.docker.internal:3002}
+      SHADOW_APP_PUBLIC_BASE_URL: ${KANBAN_PUBLIC_BASE_URL:-http://localhost:4201}
+      SHADOW_APP_API_BASE_URL: ${KANBAN_API_BASE_URL:-http://host.docker.internal:4201}
+      KANBAN_DATA_FILE: /data/kanban-board.json
+    ports:
+      - ${KANBAN_PORT:-4201}:4201
+    volumes:
+      - kanban-data:/data
+
+  skills:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-skills:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4220'
+      SHADOW_SERVER_URL: ${SHADOW_SERVER_URL:-http://host.docker.internal:3002}
+      SHADOW_APP_PUBLIC_BASE_URL: ${SKILLS_PUBLIC_BASE_URL:-http://localhost:4220}
+      SHADOW_APP_API_BASE_URL: ${SKILLS_API_BASE_URL:-http://host.docker.internal:4220}
+      SKILLS_DATA_FILE: /data/skills-library.json
+    ports:
+      - ${SKILLS_PORT:-4220}:4220
+    volumes:
+      - skills-data:/data
+
+  qna:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-qna:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4210'
+      SHADOW_SERVER_URL: ${SHADOW_SERVER_URL:-http://host.docker.internal:3002}
+      SHADOW_APP_PUBLIC_BASE_URL: ${QNA_PUBLIC_BASE_URL:-http://localhost:4210}
+      SHADOW_APP_API_BASE_URL: ${QNA_API_BASE_URL:-http://host.docker.internal:4210}
+      QNA_DATA_FILE: /data/qna.json
+    ports:
+      - ${QNA_PORT:-4210}:4210
+    volumes:
+      - qna-data:/data
+
+  quiz:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-quiz:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4211'
+      SHADOW_SERVER_URL: ${SHADOW_SERVER_URL:-http://host.docker.internal:3002}
+      SHADOW_APP_PUBLIC_BASE_URL: ${QUIZ_PUBLIC_BASE_URL:-http://localhost:4211}
+      SHADOW_APP_API_BASE_URL: ${QUIZ_API_BASE_URL:-http://host.docker.internal:4211}
+      QUIZ_DATA_FILE: /data/quiz.json
+    ports:
+      - ${QUIZ_PORT:-4211}:4211
+    volumes:
+      - quiz-data:/data
+
+  trainer:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-trainer:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4213'
+      SHADOW_SERVER_URL: ${SHADOW_SERVER_URL:-http://host.docker.internal:3002}
+      SHADOW_APP_PUBLIC_BASE_URL: ${TRAINER_PUBLIC_BASE_URL:-http://localhost:4213}
+      SHADOW_APP_API_BASE_URL: ${TRAINER_API_BASE_URL:-http://host.docker.internal:4213}
+      TRAINER_DATA_FILE: /data/trainer.json
+    ports:
+      - ${TRAINER_PORT:-4213}:4213
+    volumes:
+      - trainer-data:/data
+
+  resume:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-resume:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4214'
+      SHADOW_SERVER_URL: ${SHADOW_SERVER_URL:-http://host.docker.internal:3002}
+      SHADOW_APP_PUBLIC_BASE_URL: ${RESUME_PUBLIC_BASE_URL:-http://localhost:4214}
+      SHADOW_APP_API_BASE_URL: ${RESUME_API_BASE_URL:-http://host.docker.internal:4214}
+      RESUME_DATA_FILE: /data/resume.json
+    ports:
+      - ${RESUME_PORT:-4214}:4214
+    volumes:
+      - resume-data:/data
+
+  flash-postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${FLASH_POSTGRES_DB:-flash}
+      POSTGRES_USER: ${FLASH_POSTGRES_USER:-flash}
+      POSTGRES_PASSWORD: ${FLASH_POSTGRES_PASSWORD:-flash}
+    ports:
+      - ${FLASH_POSTGRES_PORT:-5434}:5432
+    volumes:
+      - flash-postgres-data:/var/lib/postgresql/data
+
+  flash-redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - ${FLASH_REDIS_PORT:-6381}:6379
+    volumes:
+      - flash-redis-data:/data
+
+  flash:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-flash:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4216'
+      SHADOW_SERVER_URL: ${SHADOW_SERVER_URL:-http://host.docker.internal:3002}
+      SHADOW_WEB_BASE_URL: ${SHADOW_WEB_BASE_URL:-http://localhost:3000}
+      SHADOW_APP_PUBLIC_BASE_URL: ${FLASH_PUBLIC_BASE_URL:-http://localhost:4216}
+      SHADOW_APP_API_BASE_URL: ${FLASH_API_BASE_URL:-http://host.docker.internal:4216}
+      FLASH_OAUTH_CLIENT_ID: ${FLASH_OAUTH_CLIENT_ID:-}
+      FLASH_OAUTH_CLIENT_SECRET: ${FLASH_OAUTH_CLIENT_SECRET:-}
+      FLASH_OAUTH_COOKIE_SECRET: ${FLASH_OAUTH_COOKIE_SECRET:-}
+      FLASH_OAUTH_SCOPE: ${FLASH_OAUTH_SCOPE:-user:read}
+      DATABASE_URL: postgres://${FLASH_POSTGRES_USER:-flash}:${FLASH_POSTGRES_PASSWORD:-flash}@flash-postgres:5432/${FLASH_POSTGRES_DB:-flash}
+      REDIS_URL: redis://flash-redis:6379
+    ports:
+      - ${FLASH_PORT:-4216}:4216
+    depends_on:
+      - flash-postgres
+      - flash-redis
+
+  space-postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${SPACE_POSTGRES_DB:-space}
+      POSTGRES_USER: ${SPACE_POSTGRES_USER:-space}
+      POSTGRES_PASSWORD: ${SPACE_POSTGRES_PASSWORD:-space}
+    ports:
+      - ${SPACE_POSTGRES_PORT:-5435}:5432
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${SPACE_POSTGRES_USER:-space} -d ${SPACE_POSTGRES_DB:-space}']
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    volumes:
+      - space-postgres-data:/var/lib/postgresql/data
+
+  space:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-space:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4217'
+      SHADOW_SERVER_URL: ${SHADOW_SERVER_URL:-http://host.docker.internal:3002}
+      SHADOW_WEB_BASE_URL: ${SHADOW_WEB_BASE_URL:-http://localhost:3000}
+      SHADOW_APP_PUBLIC_BASE_URL: ${SPACE_PUBLIC_BASE_URL:-http://localhost:4217}
+      SHADOW_APP_API_BASE_URL: ${SPACE_API_BASE_URL:-http://host.docker.internal:4217}
+      SPACE_OAUTH_CLIENT_ID: ${SPACE_OAUTH_CLIENT_ID:-}
+      SPACE_OAUTH_CLIENT_SECRET: ${SPACE_OAUTH_CLIENT_SECRET:-}
+      SPACE_OAUTH_COOKIE_SECRET: ${SPACE_OAUTH_COOKIE_SECRET:-}
+      SPACE_OAUTH_SCOPE: ${SPACE_OAUTH_SCOPE:-user:read}
+      SPACE_CDN_DIR: /data/cdn
+      SPACE_CDN_PUBLIC_BASE_URL: ${SPACE_CDN_PUBLIC_BASE_URL:-http://localhost:4217/cdn}
+      SPACE_CDN_DRIVER: ${SPACE_CDN_DRIVER:-local}
+      SPACE_MINIO_ENDPOINT: ${SPACE_MINIO_ENDPOINT:-}
+      SPACE_MINIO_PORT: ${SPACE_MINIO_PORT:-9000}
+      SPACE_MINIO_USE_SSL: ${SPACE_MINIO_USE_SSL:-false}
+      SPACE_MINIO_ACCESS_KEY: ${SPACE_MINIO_ACCESS_KEY:-minioadmin}
+      SPACE_MINIO_SECRET_KEY: ${SPACE_MINIO_SECRET_KEY:-minioadmin}
+      SPACE_MINIO_BUCKET: ${SPACE_MINIO_BUCKET:-shadow}
+      DATABASE_URL: postgres://${SPACE_POSTGRES_USER:-space}:${SPACE_POSTGRES_PASSWORD:-space}@space-postgres:5432/${SPACE_POSTGRES_DB:-space}
+    ports:
+      - ${SPACE_PORT:-4217}:4217
+    depends_on:
+      space-postgres:
+        condition: service_healthy
+    volumes:
+      - space-data:/data
+
+  warbuddy:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-warbuddy:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4218'
+      SHADOW_SERVER_URL: ${SHADOW_SERVER_URL:-http://host.docker.internal:3002}
+      SHADOW_APP_PUBLIC_BASE_URL: ${WARBUDDY_PUBLIC_BASE_URL:-http://localhost:4218}
+      SHADOW_APP_API_BASE_URL: ${WARBUDDY_API_BASE_URL:-http://host.docker.internal:4218}
+      WARBUDDY_DATA_FILE: /data/warbuddy.json
+    ports:
+      - ${WARBUDDY_PORT:-4218}:4218
+    volumes:
+      - warbuddy-data:/data
+
+volumes:
+  kanban-data:
+  skills-data:
+  qna-data:
+  quiz-data:
+  trainer-data:
+  resume-data:
+  flash-postgres-data:
+  flash-redis-data:
+  space-data:
+  space-postgres-data:
+  warbuddy-data:

--- a/scripts/ops/deploy-prod.sh
+++ b/scripts/ops/deploy-prod.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  printf '%s\n' "Usage: $0 --host HOST [--user USER] [--port PORT] [--remote-path PATH] [--image-tag TAG] [--integrations-image-tag TAG] [--skip-app] [--skip-integrations] [--dry-run]"
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+HOST="${PROD_SSH_HOST:-}"
+USER="${PROD_SSH_USER:-root}"
+PORT="${PROD_SSH_PORT:-22}"
+REMOTE_PATH="${PROD_REMOTE_PATH:-/workspace/shadow}"
+IMAGE_REGISTRY="${PROD_IMAGE_REGISTRY:-${SHADOW_IMAGE_REGISTRY:-ghcr.io}}"
+IMAGE_NAMESPACE="${PROD_IMAGE_NAMESPACE:-${SHADOW_IMAGE_NAMESPACE:-buggyblues}}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+INTEGRATIONS_IMAGE_TAG="${INTEGRATIONS_IMAGE_TAG:-}"
+DEPLOY_APP=1
+DEPLOY_INTEGRATIONS=1
+DRY_RUN=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --user)
+      USER="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --remote-path)
+      REMOTE_PATH="$2"
+      shift 2
+      ;;
+    --image-registry)
+      IMAGE_REGISTRY="$2"
+      shift 2
+      ;;
+    --image-namespace)
+      IMAGE_NAMESPACE="$2"
+      shift 2
+      ;;
+    --image-tag)
+      IMAGE_TAG="$2"
+      shift 2
+      ;;
+    --integrations-image-tag)
+      INTEGRATIONS_IMAGE_TAG="$2"
+      shift 2
+      ;;
+    --skip-app)
+      DEPLOY_APP=0
+      shift
+      ;;
+    --skip-integrations)
+      DEPLOY_INTEGRATIONS=0
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$DEPLOY_APP" -eq 0 ] && [ "$DEPLOY_INTEGRATIONS" -eq 0 ]; then
+  printf 'Nothing to deploy: both app and integrations are skipped.\n' >&2
+  exit 2
+fi
+
+if [ -z "$HOST" ]; then
+  printf 'Missing deploy host. Pass --host or set PROD_SSH_HOST.\n' >&2
+  exit 2
+fi
+
+if [ -z "$INTEGRATIONS_IMAGE_TAG" ]; then
+  INTEGRATIONS_IMAGE_TAG="$IMAGE_TAG"
+fi
+
+TARGET="${USER}@${HOST}"
+SSH_COMMON=(-o ServerAliveInterval=30 -o StrictHostKeyChecking=accept-new)
+SSH_CMD=(ssh "${SSH_COMMON[@]}")
+SCP_CMD=(scp "${SSH_COMMON[@]}")
+
+if [ "$PORT" != "22" ]; then
+  SSH_CMD+=(-p "$PORT")
+  SCP_CMD+=(-P "$PORT")
+fi
+
+KEY_PATH="${PROD_SSH_KEY_PATH:-${SSH_KEY_PATH:-}}"
+if [ -n "$KEY_PATH" ]; then
+  SSH_CMD+=(-i "$KEY_PATH")
+  SCP_CMD+=(-i "$KEY_PATH")
+fi
+
+if [ -n "${SSHPASS:-}" ] && [ -z "$KEY_PATH" ]; then
+  if ! command -v sshpass >/dev/null 2>&1; then
+    printf 'SSHPASS is set, but sshpass is not installed.\n' >&2
+    exit 127
+  fi
+  SSH_CMD=(sshpass -e "${SSH_CMD[@]}")
+  SCP_CMD=(sshpass -e "${SCP_CMD[@]}")
+fi
+
+quote() {
+  printf '%q' "$1"
+}
+
+remote_run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '[dry-run] ssh %s %s\n' "$TARGET" "$*"
+    return 0
+  fi
+
+  "${SSH_CMD[@]}" "$TARGET" "$@"
+}
+
+remote_path_q="$(quote "$REMOTE_PATH")"
+
+printf 'Deploy target: %s:%s\n' "$TARGET" "$REMOTE_PATH"
+printf 'App tag: %s\n' "$IMAGE_TAG"
+printf 'Integrations tag: %s\n' "$INTEGRATIONS_IMAGE_TAG"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '[dry-run] would copy compose files to %s\n' "$TARGET"
+else
+  remote_run "mkdir -p ${remote_path_q}/integrations ${remote_path_q}/scripts/ops"
+  "${SCP_CMD[@]}" "$REPO_ROOT/docker-compose.prod.yml" "$TARGET:$REMOTE_PATH/docker-compose.prod.yml"
+  "${SCP_CMD[@]}" "$REPO_ROOT/integrations/docker-compose.prod.yaml" "$TARGET:$REMOTE_PATH/integrations/docker-compose.prod.yaml"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '[dry-run] would deploy on %s\n' "$TARGET"
+  exit 0
+fi
+
+"${SSH_CMD[@]}" "$TARGET" \
+  "REMOTE_PATH=$(quote "$REMOTE_PATH") IMAGE_REGISTRY=$(quote "$IMAGE_REGISTRY") IMAGE_NAMESPACE=$(quote "$IMAGE_NAMESPACE") IMAGE_TAG=$(quote "$IMAGE_TAG") INTEGRATIONS_IMAGE_TAG=$(quote "$INTEGRATIONS_IMAGE_TAG") DEPLOY_APP=${DEPLOY_APP} DEPLOY_INTEGRATIONS=${DEPLOY_INTEGRATIONS} bash -s" <<'REMOTE'
+set -euo pipefail
+
+cd "$REMOTE_PATH"
+
+compose() {
+  if docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose "$@"
+  else
+    printf 'docker compose or docker-compose is required on the remote host.\n' >&2
+    return 127
+  fi
+}
+
+upsert_env() {
+  key="$1"
+  value="$2"
+  file=".env"
+  tmp="$(mktemp)"
+
+  if [ ! -f "$file" ]; then
+    printf 'Missing %s/%s. Create it before deployment.\n' "$REMOTE_PATH" "$file" >&2
+    exit 1
+  fi
+
+  awk -v key="$key" -v value="$value" '
+    BEGIN { replaced = 0 }
+    $0 ~ "^" key "=" {
+      print key "=" value
+      replaced = 1
+      next
+    }
+    { print }
+    END {
+      if (replaced == 0) {
+        print key "=" value
+      }
+    }
+  ' "$file" > "$tmp"
+
+  cat "$tmp" > "$file"
+  rm -f "$tmp"
+}
+
+upsert_env SHADOW_IMAGE_REGISTRY "$IMAGE_REGISTRY"
+upsert_env SHADOW_IMAGE_NAMESPACE "$IMAGE_NAMESPACE"
+
+if [ "$DEPLOY_APP" -eq 1 ]; then
+  upsert_env SHADOW_IMAGE_TAG "$IMAGE_TAG"
+  compose --env-file .env -f docker-compose.prod.yml pull server web admin
+  compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans
+fi
+
+if [ "$DEPLOY_INTEGRATIONS" -eq 1 ]; then
+  upsert_env SHADOW_INTEGRATIONS_IMAGE_TAG "$INTEGRATIONS_IMAGE_TAG"
+  compose --env-file .env -f integrations/docker-compose.prod.yaml pull \
+    kanban skills qna quiz trainer resume flash space warbuddy
+  compose --env-file .env -f integrations/docker-compose.prod.yaml up -d --remove-orphans
+fi
+
+docker image prune -f
+
+if [ "$DEPLOY_APP" -eq 1 ]; then
+  compose --env-file .env -f docker-compose.prod.yml ps
+fi
+
+if [ "$DEPLOY_INTEGRATIONS" -eq 1 ]; then
+  compose --env-file .env -f integrations/docker-compose.prod.yaml ps
+fi
+REMOTE

--- a/scripts/ops/dump-prod-data.sh
+++ b/scripts/ops/dump-prod-data.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  printf '%s\n' "Usage: $0 --source USER@HOST [--remote-path PATH] [--backup-root DIR] [--source-port PORT] [--source-minio-volume VOLUME]"
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+exec "$SCRIPT_DIR/migrate-prod-data.sh" backup --skip-env "$@"

--- a/scripts/ops/migrate-prod-data.sh
+++ b/scripts/ops/migrate-prod-data.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  printf '%s\n' "Usage: $0 sync|backup|restore [--source USER@HOST] [--target USER@HOST] [--remote-path PATH] [--backup-root DIR] [--backup-dir DIR] [--yes] [--no-start-app]"
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+ACTION="${1:-}"
+if [ -n "$ACTION" ]; then
+  shift
+fi
+
+SOURCE="${SOURCE_SSH_TARGET:-}"
+TARGET="${TARGET_SSH_TARGET:-}"
+SOURCE_PORT="${SOURCE_SSH_PORT:-22}"
+TARGET_PORT="${TARGET_SSH_PORT:-22}"
+REMOTE_PATH="${REMOTE_PATH:-/workspace/shadow}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+BACKUP_ROOT="${BACKUP_ROOT:-$REPO_ROOT/.tmp/prod-migrations}"
+BACKUP_DIR="${BACKUP_DIR:-}"
+TARGET_BACKUP_ROOT="${TARGET_BACKUP_ROOT:-$REMOTE_PATH/.migration-backups}"
+SOURCE_MINIO_VOLUME="${SOURCE_MINIO_VOLUME:-}"
+TARGET_MINIO_VOLUME="${TARGET_MINIO_VOLUME:-}"
+YES=0
+START_APP=1
+SKIP_ENV=0
+SKIP_DB=0
+SKIP_MINIO=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --source)
+      SOURCE="$2"
+      shift 2
+      ;;
+    --target)
+      TARGET="$2"
+      shift 2
+      ;;
+    --source-port)
+      SOURCE_PORT="$2"
+      shift 2
+      ;;
+    --target-port)
+      TARGET_PORT="$2"
+      shift 2
+      ;;
+    --remote-path)
+      REMOTE_PATH="$2"
+      shift 2
+      ;;
+    --compose-file)
+      COMPOSE_FILE="$2"
+      shift 2
+      ;;
+    --backup-root)
+      BACKUP_ROOT="$2"
+      shift 2
+      ;;
+    --backup-dir)
+      BACKUP_DIR="$2"
+      shift 2
+      ;;
+    --target-backup-root)
+      TARGET_BACKUP_ROOT="$2"
+      shift 2
+      ;;
+    --source-minio-volume)
+      SOURCE_MINIO_VOLUME="$2"
+      shift 2
+      ;;
+    --target-minio-volume)
+      TARGET_MINIO_VOLUME="$2"
+      shift 2
+      ;;
+    --skip-env)
+      SKIP_ENV=1
+      shift
+      ;;
+    --skip-db)
+      SKIP_DB=1
+      shift
+      ;;
+    --skip-minio)
+      SKIP_MINIO=1
+      shift
+      ;;
+    --yes)
+      YES=1
+      shift
+      ;;
+    --no-start-app)
+      START_APP=0
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$ACTION" in
+  sync | backup | restore) ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [ "$ACTION" = "backup" ] || [ "$ACTION" = "sync" ]; then
+  if [ -z "$SOURCE" ]; then
+    printf 'Missing source SSH target. Pass --source or set SOURCE_SSH_TARGET.\n' >&2
+    exit 2
+  fi
+fi
+
+if [ "$ACTION" = "restore" ] || [ "$ACTION" = "sync" ]; then
+  if [ -z "$TARGET" ]; then
+    printf 'Missing target SSH target. Pass --target or set TARGET_SSH_TARGET.\n' >&2
+    exit 2
+  fi
+fi
+
+SSH_COMMON=(-o ServerAliveInterval=30 -o StrictHostKeyChecking=accept-new)
+KEY_PATH="${PROD_SSH_KEY_PATH:-${SSH_KEY_PATH:-}}"
+
+quote() {
+  printf '%q' "$1"
+}
+
+ssh_run() {
+  local port="$1"
+  local target="$2"
+  shift 2
+
+  local cmd
+  cmd=(ssh "${SSH_COMMON[@]}")
+  if [ "$port" != "22" ]; then
+    cmd+=(-p "$port")
+  fi
+  if [ -n "$KEY_PATH" ]; then
+    cmd+=(-i "$KEY_PATH")
+  fi
+  if [ -n "${SSHPASS:-}" ] && [ -z "$KEY_PATH" ]; then
+    if ! command -v sshpass >/dev/null 2>&1; then
+      printf 'SSHPASS is set, but sshpass is not installed.\n' >&2
+      exit 127
+    fi
+    cmd=(sshpass -e "${cmd[@]}")
+  fi
+
+  "${cmd[@]}" "$target" "$@"
+}
+
+scp_to() {
+  local port="$1"
+  local target="$2"
+  local source_path="$3"
+  local remote_path="$4"
+  local remote_path_q
+  remote_path_q="$(quote "$remote_path")"
+
+  if command -v rsync >/dev/null 2>&1 && ssh_run "$port" "$target" "command -v rsync >/dev/null 2>&1"; then
+    local rsync_ssh
+    rsync_ssh="ssh -o ServerAliveInterval=30 -o StrictHostKeyChecking=accept-new"
+    if [ "$port" != "22" ]; then
+      rsync_ssh="$rsync_ssh -p $port"
+    fi
+    if [ -n "$KEY_PATH" ]; then
+      rsync_ssh="$rsync_ssh -i $KEY_PATH"
+    fi
+    if [ -n "${SSHPASS:-}" ] && [ -z "$KEY_PATH" ]; then
+      SSHPASS="$SSHPASS" sshpass -e rsync -a --partial --inplace -e "$rsync_ssh" "$source_path" "$target:$remote_path"
+    else
+      rsync -a --partial --inplace -e "$rsync_ssh" "$source_path" "$target:$remote_path"
+    fi
+    return
+  fi
+
+  local cmd
+  cmd=(ssh "${SSH_COMMON[@]}")
+  if [ "$port" != "22" ]; then
+    cmd+=(-p "$port")
+  fi
+  if [ -n "$KEY_PATH" ]; then
+    cmd+=(-i "$KEY_PATH")
+  fi
+  if [ -n "${SSHPASS:-}" ] && [ -z "$KEY_PATH" ]; then
+    cmd=(sshpass -e "${cmd[@]}")
+  fi
+
+  "${cmd[@]}" "$target" "cat > $remote_path_q" < "$source_path"
+}
+
+scp_from() {
+  local port="$1"
+  local target="$2"
+  local remote_path="$3"
+  local local_path="$4"
+  local remote_path_q
+  remote_path_q="$(quote "$remote_path")"
+
+  local cmd
+  cmd=(ssh "${SSH_COMMON[@]}")
+  if [ "$port" != "22" ]; then
+    cmd+=(-p "$port")
+  fi
+  if [ -n "$KEY_PATH" ]; then
+    cmd+=(-i "$KEY_PATH")
+  fi
+  if [ -n "${SSHPASS:-}" ] && [ -z "$KEY_PATH" ]; then
+    cmd=(sshpass -e "${cmd[@]}")
+  fi
+
+  "${cmd[@]}" "$target" "cat $remote_path_q" > "$local_path"
+}
+
+remote_compose='compose() { if docker compose version >/dev/null 2>&1; then docker compose "$@"; elif command -v docker-compose >/dev/null 2>&1; then docker-compose "$@"; else printf "docker compose or docker-compose is required.\n" >&2; return 127; fi; };'
+
+detect_minio_volume() {
+  local port="$1"
+  local target="$2"
+  local remote_path_q="$3"
+  local compose_file_q="$4"
+
+  ssh_run "$port" "$target" \
+    "cd $remote_path_q && $remote_compose container_id=\"\$(compose --env-file .env -f $compose_file_q ps -q minio 2>/dev/null || true)\"; if [ -n \"\$container_id\" ]; then docker inspect \"\$container_id\" --format '{{range .Mounts}}{{if eq .Destination \"/data\"}}{{.Name}}{{end}}{{end}}'; fi"
+}
+
+fallback_minio_volume() {
+  local port="$1"
+  local target="$2"
+  local remote_path_q="$3"
+
+  ssh_run "$port" "$target" \
+    "cd $remote_path_q && if [ -f .env ]; then value=\"\$(grep -E '^SHADOW_MINIO_VOLUME=' .env | tail -n1 | cut -d= -f2-)\"; if [ -n \"\$value\" ]; then printf '%s\n' \"\$value\"; else printf '%s\n' shadow_miniodata; fi; else printf '%s\n' shadow_miniodata; fi"
+}
+
+backup_data() {
+  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  BACKUP_DIR="$BACKUP_ROOT/$timestamp"
+  mkdir -p "$BACKUP_DIR"
+  chmod 700 "$BACKUP_DIR"
+
+  remote_path_q="$(quote "$REMOTE_PATH")"
+  compose_file_q="$(quote "$COMPOSE_FILE")"
+
+  printf 'Creating local backup in %s\n' "$BACKUP_DIR"
+
+  if [ "$SKIP_ENV" -eq 0 ]; then
+    scp_from "$SOURCE_PORT" "$SOURCE" "$REMOTE_PATH/.env" "$BACKUP_DIR/.env"
+    chmod 600 "$BACKUP_DIR/.env"
+  fi
+
+  if [ "$SKIP_DB" -eq 0 ]; then
+    ssh_run "$SOURCE_PORT" "$SOURCE" \
+      "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q exec -T postgres sh -lc 'pg_dump -U \"\$POSTGRES_USER\" -d \"\${POSTGRES_DB:-shadow}\" -Fc'" \
+      > "$BACKUP_DIR/postgres.dump"
+    chmod 600 "$BACKUP_DIR/postgres.dump"
+  fi
+
+  if [ "$SKIP_MINIO" -eq 0 ]; then
+    if [ -z "$SOURCE_MINIO_VOLUME" ]; then
+      SOURCE_MINIO_VOLUME="$(detect_minio_volume "$SOURCE_PORT" "$SOURCE" "$remote_path_q" "$compose_file_q")"
+    fi
+    if [ -z "$SOURCE_MINIO_VOLUME" ]; then
+      SOURCE_MINIO_VOLUME="$(fallback_minio_volume "$SOURCE_PORT" "$SOURCE" "$remote_path_q")"
+    fi
+    source_minio_volume_q="$(quote "$SOURCE_MINIO_VOLUME")"
+    printf 'Backing up MinIO volume: %s\n' "$SOURCE_MINIO_VOLUME"
+    ssh_run "$SOURCE_PORT" "$SOURCE" "docker image inspect alpine:3.20 >/dev/null 2>&1 || docker pull alpine:3.20 >/dev/null"
+    ssh_run "$SOURCE_PORT" "$SOURCE" \
+      "docker run --rm -v ${source_minio_volume_q}:/data:ro alpine:3.20 tar -C /data -czf - ." \
+      > "$BACKUP_DIR/minio.tgz"
+    chmod 600 "$BACKUP_DIR/minio.tgz"
+  fi
+
+  {
+    printf 'created_at=%s\n' "$timestamp"
+    printf 'source=%s\n' "$SOURCE"
+    printf 'remote_path=%s\n' "$REMOTE_PATH"
+    printf 'compose_file=%s\n' "$COMPOSE_FILE"
+    printf 'source_minio_volume=%s\n' "$SOURCE_MINIO_VOLUME"
+  } > "$BACKUP_DIR/manifest.env"
+
+  printf 'Backup complete: %s\n' "$BACKUP_DIR"
+}
+
+confirm_restore() {
+  if [ "$YES" -eq 1 ]; then
+    return 0
+  fi
+
+  printf 'This will overwrite Postgres and MinIO data on %s:%s. Continue? [y/N] ' "$TARGET" "$REMOTE_PATH" >&2
+  read -r answer
+  case "$answer" in
+    y | Y | yes | YES) ;;
+    *)
+      printf 'Restore cancelled.\n' >&2
+      exit 1
+      ;;
+  esac
+}
+
+restore_data() {
+  if [ -z "$BACKUP_DIR" ]; then
+    printf '--backup-dir is required for restore.\n' >&2
+    exit 2
+  fi
+
+  if [ ! -d "$BACKUP_DIR" ]; then
+    printf 'Backup directory does not exist: %s\n' "$BACKUP_DIR" >&2
+    exit 2
+  fi
+
+  confirm_restore
+
+  remote_path_q="$(quote "$REMOTE_PATH")"
+  compose_file_q="$(quote "$COMPOSE_FILE")"
+  remote_backup_dir="$TARGET_BACKUP_ROOT/$(basename "$BACKUP_DIR")"
+  remote_backup_dir_q="$(quote "$remote_backup_dir")"
+
+  ssh_run "$TARGET_PORT" "$TARGET" "mkdir -p $remote_path_q $remote_backup_dir_q"
+
+  if [ -f "$REPO_ROOT/docker-compose.prod.yml" ]; then
+    scp_to "$TARGET_PORT" "$TARGET" "$REPO_ROOT/docker-compose.prod.yml" "$REMOTE_PATH/docker-compose.prod.yml"
+  fi
+
+  if [ "$SKIP_ENV" -eq 0 ]; then
+    if [ ! -f "$BACKUP_DIR/.env" ]; then
+      printf 'Missing backup .env: %s/.env\n' "$BACKUP_DIR" >&2
+      exit 2
+    fi
+    scp_to "$TARGET_PORT" "$TARGET" "$BACKUP_DIR/.env" "$REMOTE_PATH/.env"
+  fi
+
+  if [ "$SKIP_DB" -eq 0 ]; then
+    if [ ! -f "$BACKUP_DIR/postgres.dump" ]; then
+      printf 'Missing database dump: %s/postgres.dump\n' "$BACKUP_DIR" >&2
+      exit 2
+    fi
+    scp_to "$TARGET_PORT" "$TARGET" "$BACKUP_DIR/postgres.dump" "$remote_backup_dir/postgres.dump"
+  fi
+
+  if [ "$SKIP_MINIO" -eq 0 ]; then
+    if [ ! -f "$BACKUP_DIR/minio.tgz" ]; then
+      printf 'Missing MinIO archive: %s/minio.tgz\n' "$BACKUP_DIR" >&2
+      exit 2
+    fi
+    scp_to "$TARGET_PORT" "$TARGET" "$BACKUP_DIR/minio.tgz" "$remote_backup_dir/minio.tgz"
+  fi
+
+  ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q up -d postgres redis minio"
+  ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q stop server web admin || true"
+
+  if [ "$SKIP_DB" -eq 0 ]; then
+    ssh_run "$TARGET_PORT" "$TARGET" \
+      "cd $remote_path_q && $remote_compose container_id=\"\$(compose --env-file .env -f $compose_file_q ps -q postgres)\" && docker cp $remote_backup_dir_q/postgres.dump \"\$container_id:/tmp/shadow-postgres.dump\" && compose --env-file .env -f $compose_file_q exec -T postgres sh -lc 'pg_restore --clean --if-exists --no-owner -U \"\$POSTGRES_USER\" -d \"\${POSTGRES_DB:-shadow}\" /tmp/shadow-postgres.dump && rm -f /tmp/shadow-postgres.dump'"
+  fi
+
+  if [ "$SKIP_MINIO" -eq 0 ]; then
+    if [ -z "$TARGET_MINIO_VOLUME" ]; then
+      TARGET_MINIO_VOLUME="$(detect_minio_volume "$TARGET_PORT" "$TARGET" "$remote_path_q" "$compose_file_q")"
+    fi
+    if [ -z "$TARGET_MINIO_VOLUME" ]; then
+      TARGET_MINIO_VOLUME="$(fallback_minio_volume "$TARGET_PORT" "$TARGET" "$remote_path_q")"
+    fi
+    target_minio_volume_q="$(quote "$TARGET_MINIO_VOLUME")"
+    printf 'Restoring MinIO volume: %s\n' "$TARGET_MINIO_VOLUME"
+    ssh_run "$TARGET_PORT" "$TARGET" "docker image inspect alpine:3.20 >/dev/null 2>&1 || docker pull alpine:3.20 >/dev/null"
+    ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q stop minio || true"
+    ssh_run "$TARGET_PORT" "$TARGET" \
+      "docker run --rm -v ${target_minio_volume_q}:/data -v ${remote_backup_dir_q}:/backup:ro alpine:3.20 sh -lc 'find /data -mindepth 1 -maxdepth 1 -exec rm -rf {} + && tar -C /data -xzf /backup/minio.tgz'"
+    ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q up -d minio"
+  fi
+
+  if [ "$START_APP" -eq 1 ]; then
+    ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q up -d --remove-orphans"
+  fi
+
+  printf 'Restore complete on %s:%s\n' "$TARGET" "$REMOTE_PATH"
+}
+
+if [ "$ACTION" = "backup" ] || [ "$ACTION" = "sync" ]; then
+  backup_data
+fi
+
+if [ "$ACTION" = "restore" ] || [ "$ACTION" = "sync" ]; then
+  restore_data
+fi


### PR DESCRIPTION
## Summary

- add a production deploy workflow bound to the ShadowOB Production environment
- publish CI-built images for integration apps alongside server/web/admin
- add production compose, SSH deploy, dump, and repeatable migration scripts
- document GitHub environment setup, manual deployment, rollback, and migration operations

## Root Cause

Production deploys and migration steps were manual, and integrations still used build-based compose configuration. The first migration also showed that MinIO volume names can differ between hosts, so the migration script now detects the running MinIO container mount before falling back to .env/default values.

## Validation

- pnpm lint
- pnpm typecheck
- bash -n scripts/ops/deploy-prod.sh scripts/ops/migrate-prod-data.sh scripts/ops/dump-prod-data.sh
- docker compose -f integrations/docker-compose.prod.yaml config --quiet
- YAML parse check for deploy-production, publish-prod-images, and integrations prod compose
- searched the repository for production IP literals and found none
