### PR TITLE
[codex] Preserve deploy SSH retry exit code

### DIFF
--- a/scripts/ops/deploy-prod.sh
+++ b/scripts/ops/deploy-prod.sh
@@ -145,9 +145,10 @@ retry_cmd() {
   while :; do
     if "$@"; then
       return 0
+    else
+      status="$?"
     fi
 
-    status="$?"
     if [ "$attempt" -ge "$SSH_RETRIES" ]; then
       return "$status"
     fi


### PR DESCRIPTION
## Summary
- preserve the real SSH/SCP exit status in deploy retry logs
- keep final failure codes accurate for production deploy diagnostics

## Verification
- bash -n scripts/ops/deploy-prod.sh
- confirmed no production IP literals in .github, scripts, or docs