### PR TITLE
[codex] Guard production deploys and deploy app only

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,20 +11,6 @@ on:
         description: Image tag for server, web, and admin.
         required: false
         default: latest
-      integrations_image_tag:
-        description: Image tag for integrations. Empty uses image_tag.
-        required: false
-        default: ''
-      deploy_app:
-        description: Deploy server, web, and admin.
-        type: boolean
-        required: false
-        default: true
-      deploy_integrations:
-        description: Deploy integration apps.
-        type: boolean
-        required: false
-        default: true
 
 permissions:
   contents: read
@@ -56,7 +42,6 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
           INPUT_IMAGE_TAG: ${{ inputs.image_tag || '' }}
-          INPUT_INTEGRATIONS_IMAGE_TAG: ${{ inputs.integrations_image_tag || '' }}
         run: |
           set -euo pipefail
 
@@ -67,12 +52,7 @@ jobs:
             image_tag="${INPUT_IMAGE_TAG:-latest}"
           fi
 
-          integrations_image_tag="${INPUT_INTEGRATIONS_IMAGE_TAG:-$image_tag}"
-
-          {
-            echo "image_tag=${image_tag}"
-            echo "integrations_image_tag=${integrations_image_tag}"
-          } >> "$GITHUB_OUTPUT"
+          echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare SSH auth
         shell: bash
@@ -109,10 +89,7 @@ jobs:
           PROD_REMOTE_PATH: ${{ vars.PROD_REMOTE_PATH || '/workspace/shadow' }}
           PROD_IMAGE_REGISTRY: ${{ vars.PROD_IMAGE_REGISTRY || 'ghcr.io' }}
           PROD_IMAGE_NAMESPACE: ${{ vars.PROD_IMAGE_NAMESPACE || '' }}
-          DEPLOY_APP_INPUT: ${{ inputs.deploy_app }}
-          DEPLOY_INTEGRATIONS_INPUT: ${{ inputs.deploy_integrations }}
           IMAGE_TAG: ${{ steps.deploy.outputs.image_tag }}
-          INTEGRATIONS_IMAGE_TAG: ${{ steps.deploy.outputs.integrations_image_tag }}
           SSHPASS: ${{ secrets.PROD_SSH_PASSWORD }}
         run: |
           set -euo pipefail
@@ -121,8 +98,6 @@ jobs:
             echo "::add-mask::$PROD_SSH_HOST"
           fi
 
-          deploy_app="${DEPLOY_APP_INPUT:-true}"
-          deploy_integrations="${DEPLOY_INTEGRATIONS_INPUT:-true}"
           image_namespace="${PROD_IMAGE_NAMESPACE:-${GITHUB_REPOSITORY_OWNER,,}}"
 
           args=(
@@ -133,15 +108,6 @@ jobs:
             --image-registry "$PROD_IMAGE_REGISTRY"
             --image-namespace "$image_namespace"
             --image-tag "$IMAGE_TAG"
-            --integrations-image-tag "$INTEGRATIONS_IMAGE_TAG"
           )
-
-          if [ "$deploy_app" != "true" ]; then
-            args+=(--skip-app)
-          fi
-
-          if [ "$deploy_integrations" != "true" ]; then
-            args+=(--skip-integrations)
-          fi
 
           scripts/ops/deploy-prod.sh "${args[@]}"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      - name: Guard production deploy
+        shell: bash
+        run: bash scripts/ops/verify-prod-no-build.sh
+
       - name: Resolve deploy tags
         id: deploy
         shell: bash

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   docker compose -f docker-compose.prod.yml pull server web admin
-#   docker compose -f docker-compose.prod.yml up -d
+#   docker compose -f docker-compose.prod.yml up -d --remove-orphans --no-build
 #
 # ⚠️  All sensitive values MUST be provided via a .env file.
 #     See .env.example for required variables.

--- a/docs/deployment/ci-built-images.md
+++ b/docs/deployment/ci-built-images.md
@@ -39,7 +39,9 @@ docker login ghcr.io
 
 ## Server deploy
 
-Keep secrets in the server-side `.env` file. Choose the image tag there:
+The production deploy host only runs the main app stack: `server`, `web`, and
+`admin`. Keep secrets in the server-side `.env` file. Choose the image tag
+there:
 
 ```dotenv
 SHADOW_IMAGE_REGISTRY=ghcr.io

--- a/docs/deployment/ci-built-images.md
+++ b/docs/deployment/ci-built-images.md
@@ -51,7 +51,7 @@ Then deploy without building on the server:
 
 ```bash
 docker compose -f docker-compose.prod.yml pull server web admin
-docker compose -f docker-compose.prod.yml up -d --remove-orphans
+docker compose -f docker-compose.prod.yml up -d --remove-orphans --no-build
 docker image prune -f
 ```
 

--- a/docs/deployment/production-cd.zh-CN.md
+++ b/docs/deployment/production-cd.zh-CN.md
@@ -63,11 +63,13 @@ scripts/ops/deploy-prod.sh \
 
 ```bash
 docker compose --env-file .env -f docker-compose.prod.yml pull server web admin
-docker compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans
+docker compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans --no-build
 docker compose --env-file .env -f integrations/docker-compose.prod.yaml pull kanban skills qna quiz trainer resume flash space warbuddy
-docker compose --env-file .env -f integrations/docker-compose.prod.yaml up -d --remove-orphans
+docker compose --env-file .env -f integrations/docker-compose.prod.yaml up -d --remove-orphans --no-build
 docker image prune -f
 ```
+
+生产服务器禁止构建镜像。生产 compose 文件不能包含 `build:`，生产部署和迁移脚本只允许拉取已经发布的镜像并用 `--no-build` 重启容器。
 
 ## 从旧服务器迁移数据
 

--- a/docs/deployment/production-cd.zh-CN.md
+++ b/docs/deployment/production-cd.zh-CN.md
@@ -5,10 +5,10 @@
 `main` 合入后的链路是：
 
 1. `post-merge-validation` 跑完整测试和构建验证。
-2. `publish-prod-images` 在上一步成功后发布主应用和 integrations 镜像。
-3. `deploy-production` 在镜像发布成功后自动部署到生产服务器。
+2. `publish-prod-images` 在上一步成功后发布镜像。
+3. `deploy-production` 在镜像发布成功后自动部署主应用到生产服务器。
 
-自动部署使用不可变镜像 tag：`sha-<12 位 commit sha>`。手动部署从 GitHub Actions 的 `deploy-production` workflow 触发，`image_tag` 默认是 `latest`，`integrations_image_tag` 为空时复用 `image_tag`。
+自动部署使用不可变镜像 tag：`sha-<12 位 commit sha>`。手动部署从 GitHub Actions 的 `deploy-production` workflow 触发，`image_tag` 默认是 `latest`。当前生产服务器只部署 `server`、`web`、`admin` 主应用栈，不部署 integrations。
 
 ## GitHub Environment 配置
 
@@ -19,7 +19,7 @@
 | `PROD_SSH_HOST` | Secret | 必填。生产服务器地址，不要提交到代码库，也不要放在普通 variable。 |
 | `PROD_SSH_PRIVATE_KEY` | Secret | 推荐。可登录生产服务器的私钥内容。 |
 | `PROD_SSH_PASSWORD` | Secret | 可选。没有私钥时使用密码登录，workflow 会安装 `sshpass`。 |
-| `PROD_SSH_KNOWN_HOSTS` | Secret | 可选。建议放 `ssh-keyscan "$PROD_SSH_HOST"` 的结果。 |
+| `PROD_SSH_KNOWN_HOSTS` | Secret | 可选。建议放 `ssh-keyscan "$PROD_SSH_HOST"` 的结果；服务器重置系统后必须更新或删除这个 secret，否则旧 host key 缓存会导致 SSH 校验失败。 |
 | `PROD_SSH_USER` | Variable | 可选，默认 `root`。 |
 | `PROD_SSH_PORT` | Variable | 可选，默认 `22`。 |
 | `PROD_REMOTE_PATH` | Variable | 可选，默认 `/workspace/shadow`。 |
@@ -32,7 +32,6 @@
 SHADOW_IMAGE_REGISTRY=ghcr.io
 SHADOW_IMAGE_NAMESPACE=buggyblues
 SHADOW_IMAGE_TAG=sha-0123456789ab
-SHADOW_INTEGRATIONS_IMAGE_TAG=sha-0123456789ab
 ```
 
 如果 GHCR package 是 private，先在服务器登录一次：
@@ -47,7 +46,6 @@ docker login ghcr.io
 
 - Docker Engine 与 Docker Compose v2，或兼容的 `docker-compose`。
 - `/workspace/shadow/.env` 存在，并包含 `docker-compose.prod.yml` 需要的生产变量。
-- integrations 的公网地址变量在 `.env` 中配置，例如 `KANBAN_PUBLIC_BASE_URL`、`FLASH_PUBLIC_BASE_URL`、`SPACE_PUBLIC_BASE_URL`。
 
 手动在本地触发同一套部署脚本：
 
@@ -64,8 +62,6 @@ scripts/ops/deploy-prod.sh \
 ```bash
 docker compose --env-file .env -f docker-compose.prod.yml pull server web admin
 docker compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans --no-build
-docker compose --env-file .env -f integrations/docker-compose.prod.yaml pull kanban skills qna quiz trainer resume flash space warbuddy
-docker compose --env-file .env -f integrations/docker-compose.prod.yaml up -d --remove-orphans --no-build
 docker image prune -f
 ```
 
@@ -89,6 +85,7 @@ scripts/ops/migrate-prod-data.sh sync \
 - 拉取旧服务器 `/workspace/shadow/.env` 到本地备份目录。
 - 用 `pg_dump -Fc` 备份主 Postgres。
 - 自动识别并打包源服务器 `minio` 容器挂载的 MinIO volume。
+- 备份并恢复 `.env` 中引用的 cloud runtime host 文件，例如 `KUBECONFIG_HOST_PATH`、`CLOUD_SAAS_CLUSTER_CONFIG_HOST_PATH` 和 `CLOUD_SAAS_CLUSTER_KUBECONFIG_HOST_PATH`。
 - 上传备份到新服务器 `/workspace/shadow/.migration-backups/<timestamp>`。
 - 覆盖新服务器 `.env`、Postgres 数据和 MinIO 数据。
 - 重新启动目标服务器的生产 compose。

--- a/scripts/ops/deploy-prod.sh
+++ b/scripts/ops/deploy-prod.sh
@@ -93,6 +93,8 @@ if [ -z "$INTEGRATIONS_IMAGE_TAG" ]; then
   INTEGRATIONS_IMAGE_TAG="$IMAGE_TAG"
 fi
 
+bash "$REPO_ROOT/scripts/ops/verify-prod-no-build.sh"
+
 TARGET="${USER}@${HOST}"
 SSH_COMMON=(
   -o ConnectTimeout="${PROD_SSH_CONNECT_TIMEOUT:-20}"
@@ -231,14 +233,14 @@ upsert_env SHADOW_IMAGE_NAMESPACE "$IMAGE_NAMESPACE"
 if [ "$DEPLOY_APP" -eq 1 ]; then
   upsert_env SHADOW_IMAGE_TAG "$IMAGE_TAG"
   compose --env-file .env -f docker-compose.prod.yml pull server web admin
-  compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans
+  compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans --no-build
 fi
 
 if [ "$DEPLOY_INTEGRATIONS" -eq 1 ]; then
   upsert_env SHADOW_INTEGRATIONS_IMAGE_TAG "$INTEGRATIONS_IMAGE_TAG"
   compose --env-file .env -f integrations/docker-compose.prod.yaml pull \
     kanban skills qna quiz trainer resume flash space warbuddy
-  compose --env-file .env -f integrations/docker-compose.prod.yaml up -d --remove-orphans
+  compose --env-file .env -f integrations/docker-compose.prod.yaml up -d --remove-orphans --no-build
 fi
 
 docker image prune -f

--- a/scripts/ops/deploy-prod.sh
+++ b/scripts/ops/deploy-prod.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-  printf '%s\n' "Usage: $0 --host HOST [--user USER] [--port PORT] [--remote-path PATH] [--image-tag TAG] [--integrations-image-tag TAG] [--skip-app] [--skip-integrations] [--dry-run]"
+  printf '%s\n' "Usage: $0 --host HOST [--user USER] [--port PORT] [--remote-path PATH] [--image-tag TAG] [--dry-run]"
 }
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,9 +16,6 @@ REMOTE_PATH="${PROD_REMOTE_PATH:-/workspace/shadow}"
 IMAGE_REGISTRY="${PROD_IMAGE_REGISTRY:-${SHADOW_IMAGE_REGISTRY:-ghcr.io}}"
 IMAGE_NAMESPACE="${PROD_IMAGE_NAMESPACE:-${SHADOW_IMAGE_NAMESPACE:-buggyblues}}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
-INTEGRATIONS_IMAGE_TAG="${INTEGRATIONS_IMAGE_TAG:-}"
-DEPLOY_APP=1
-DEPLOY_INTEGRATIONS=1
 DRY_RUN=0
 
 while [ "$#" -gt 0 ]; do
@@ -51,18 +48,6 @@ while [ "$#" -gt 0 ]; do
       IMAGE_TAG="$2"
       shift 2
       ;;
-    --integrations-image-tag)
-      INTEGRATIONS_IMAGE_TAG="$2"
-      shift 2
-      ;;
-    --skip-app)
-      DEPLOY_APP=0
-      shift
-      ;;
-    --skip-integrations)
-      DEPLOY_INTEGRATIONS=0
-      shift
-      ;;
     --dry-run)
       DRY_RUN=1
       shift
@@ -79,18 +64,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ "$DEPLOY_APP" -eq 0 ] && [ "$DEPLOY_INTEGRATIONS" -eq 0 ]; then
-  printf 'Nothing to deploy: both app and integrations are skipped.\n' >&2
-  exit 2
-fi
-
 if [ -z "$HOST" ]; then
   printf 'Missing deploy host. Pass --host or set PROD_SSH_HOST.\n' >&2
   exit 2
-fi
-
-if [ -z "$INTEGRATIONS_IMAGE_TAG" ]; then
-  INTEGRATIONS_IMAGE_TAG="$IMAGE_TAG"
 fi
 
 bash "$REPO_ROOT/scripts/ops/verify-prod-no-build.sh"
@@ -165,14 +141,12 @@ remote_path_q="$(quote "$REMOTE_PATH")"
 
 printf 'Deploy target: %s@<host>:%s\n' "$USER" "$REMOTE_PATH"
 printf 'App tag: %s\n' "$IMAGE_TAG"
-printf 'Integrations tag: %s\n' "$INTEGRATIONS_IMAGE_TAG"
 
 if [ "$DRY_RUN" -eq 1 ]; then
-  printf '[dry-run] would copy compose files to %s\n' "$TARGET"
+  printf '[dry-run] would copy app compose file to %s\n' "$TARGET"
 else
-  remote_run "mkdir -p ${remote_path_q}/integrations ${remote_path_q}/scripts/ops"
+  remote_run "mkdir -p ${remote_path_q}/scripts/ops"
   retry_cmd "${SCP_CMD[@]}" "$REPO_ROOT/docker-compose.prod.yml" "$TARGET:$REMOTE_PATH/docker-compose.prod.yml"
-  retry_cmd "${SCP_CMD[@]}" "$REPO_ROOT/integrations/docker-compose.prod.yaml" "$TARGET:$REMOTE_PATH/integrations/docker-compose.prod.yaml"
 fi
 
 if [ "$DRY_RUN" -eq 1 ]; then
@@ -181,7 +155,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
 fi
 
 "${SSH_CMD[@]}" "$TARGET" \
-  "REMOTE_PATH=$(quote "$REMOTE_PATH") IMAGE_REGISTRY=$(quote "$IMAGE_REGISTRY") IMAGE_NAMESPACE=$(quote "$IMAGE_NAMESPACE") IMAGE_TAG=$(quote "$IMAGE_TAG") INTEGRATIONS_IMAGE_TAG=$(quote "$INTEGRATIONS_IMAGE_TAG") DEPLOY_APP=${DEPLOY_APP} DEPLOY_INTEGRATIONS=${DEPLOY_INTEGRATIONS} bash -s" <<'REMOTE'
+  "REMOTE_PATH=$(quote "$REMOTE_PATH") IMAGE_REGISTRY=$(quote "$IMAGE_REGISTRY") IMAGE_NAMESPACE=$(quote "$IMAGE_NAMESPACE") IMAGE_TAG=$(quote "$IMAGE_TAG") bash -s" <<'REMOTE'
 set -euo pipefail
 
 cd "$REMOTE_PATH"
@@ -229,27 +203,12 @@ upsert_env() {
 
 upsert_env SHADOW_IMAGE_REGISTRY "$IMAGE_REGISTRY"
 upsert_env SHADOW_IMAGE_NAMESPACE "$IMAGE_NAMESPACE"
+upsert_env SHADOW_IMAGE_TAG "$IMAGE_TAG"
 
-if [ "$DEPLOY_APP" -eq 1 ]; then
-  upsert_env SHADOW_IMAGE_TAG "$IMAGE_TAG"
-  compose --env-file .env -f docker-compose.prod.yml pull server web admin
-  compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans --no-build
-fi
-
-if [ "$DEPLOY_INTEGRATIONS" -eq 1 ]; then
-  upsert_env SHADOW_INTEGRATIONS_IMAGE_TAG "$INTEGRATIONS_IMAGE_TAG"
-  compose --env-file .env -f integrations/docker-compose.prod.yaml pull \
-    kanban skills qna quiz trainer resume flash space warbuddy
-  compose --env-file .env -f integrations/docker-compose.prod.yaml up -d --remove-orphans --no-build
-fi
+compose --env-file .env -f docker-compose.prod.yml pull server web admin
+compose --env-file .env -f docker-compose.prod.yml up -d --remove-orphans --no-build
 
 docker image prune -f
 
-if [ "$DEPLOY_APP" -eq 1 ]; then
-  compose --env-file .env -f docker-compose.prod.yml ps
-fi
-
-if [ "$DEPLOY_INTEGRATIONS" -eq 1 ]; then
-  compose --env-file .env -f integrations/docker-compose.prod.yaml ps
-fi
+compose --env-file .env -f docker-compose.prod.yml ps
 REMOTE

--- a/scripts/ops/migrate-prod-data.sh
+++ b/scripts/ops/migrate-prod-data.sh
@@ -365,7 +365,7 @@ restore_data() {
     scp_to "$TARGET_PORT" "$TARGET" "$BACKUP_DIR/minio.tgz" "$remote_backup_dir/minio.tgz"
   fi
 
-  ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q up -d postgres redis minio"
+  ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q up -d --no-build postgres redis minio"
   ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q stop server web admin || true"
 
   if [ "$SKIP_DB" -eq 0 ]; then
@@ -386,11 +386,11 @@ restore_data() {
     ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q stop minio || true"
     ssh_run "$TARGET_PORT" "$TARGET" \
       "docker run --rm -v ${target_minio_volume_q}:/data -v ${remote_backup_dir_q}:/backup:ro alpine:3.20 sh -lc 'find /data -mindepth 1 -maxdepth 1 -exec rm -rf {} + && tar -C /data -xzf /backup/minio.tgz'"
-    ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q up -d minio"
+    ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q up -d --no-build minio"
   fi
 
   if [ "$START_APP" -eq 1 ]; then
-    ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q up -d --remove-orphans"
+    ssh_run "$TARGET_PORT" "$TARGET" "cd $remote_path_q && $remote_compose compose --env-file .env -f $compose_file_q up -d --remove-orphans --no-build"
   fi
 
   printf 'Restore complete on %s:%s\n' "$TARGET" "$REMOTE_PATH"

--- a/scripts/ops/migrate-prod-data.sh
+++ b/scripts/ops/migrate-prod-data.sh
@@ -9,6 +9,8 @@ usage() {
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 
+bash "$REPO_ROOT/scripts/ops/verify-prod-no-build.sh"
+
 if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
   usage
   exit 0
@@ -30,6 +32,7 @@ BACKUP_DIR="${BACKUP_DIR:-}"
 TARGET_BACKUP_ROOT="${TARGET_BACKUP_ROOT:-$REMOTE_PATH/.migration-backups}"
 SOURCE_MINIO_VOLUME="${SOURCE_MINIO_VOLUME:-}"
 TARGET_MINIO_VOLUME="${TARGET_MINIO_VOLUME:-}"
+RUNTIME_FILE_OWNER="${RUNTIME_FILE_OWNER:-1000:1000}"
 YES=0
 START_APP=1
 SKIP_ENV=0
@@ -251,6 +254,117 @@ fallback_minio_volume() {
     "cd $remote_path_q && if [ -f .env ]; then value=\"\$(grep -E '^SHADOW_MINIO_VOLUME=' .env | tail -n1 | cut -d= -f2-)\"; if [ -n \"\$value\" ]; then printf '%s\n' \"\$value\"; else printf '%s\n' shadow_miniodata; fi; else printf '%s\n' shadow_miniodata; fi"
 }
 
+env_file_value() {
+  local key="$1"
+  local file="$2"
+  local value
+
+  value="$(awk -v key="$key" 'index($0, key "=") == 1 { print substr($0, length(key) + 2) }' "$file" | tail -n1)"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  printf '%s\n' "$value"
+}
+
+runtime_host_paths_from_env() {
+  local env_file="$1"
+  local key
+  local value
+
+  for key in \
+    KUBECONFIG_HOST_PATH \
+    CLOUD_SAAS_CLUSTER_CONFIG_HOST_PATH \
+    CLOUD_SAAS_CLUSTER_KUBECONFIG_HOST_PATH
+  do
+    value="$(env_file_value "$key" "$env_file")"
+    case "$value" in
+      "" | /dev/null) ;;
+      /*) printf '%s\n' "$value" ;;
+      *)
+        printf 'Skipping non-absolute runtime host path from %s: %s\n' "$key" "$value" >&2
+        ;;
+    esac
+  done | awk '!seen[$0]++'
+}
+
+backup_runtime_files() {
+  local env_file="$BACKUP_DIR/.env"
+  local manifest="$BACKUP_DIR/runtime-files.manifest"
+  local count=0
+  local remote_file
+
+  if [ ! -f "$env_file" ]; then
+    return
+  fi
+
+  : > "$manifest"
+
+  while IFS= read -r remote_file; do
+    local remote_file_q
+    local relative_path
+    local local_file
+
+    remote_file_q="$(quote "$remote_file")"
+    relative_path="${remote_file#/}"
+    local_file="$BACKUP_DIR/runtime-files/$relative_path"
+    mkdir -p "$(dirname -- "$local_file")"
+
+    if ssh_run "$SOURCE_PORT" "$SOURCE" "test -f $remote_file_q"; then
+      scp_from "$SOURCE_PORT" "$SOURCE" "$remote_file" "$local_file"
+      chmod 600 "$local_file"
+      printf '%s\t%s\n' "$remote_file" "runtime-files/$relative_path" >> "$manifest"
+      count=$((count + 1))
+    else
+      printf 'Runtime host file missing on source, skipped: %s\n' "$remote_file" >&2
+    fi
+  done < <(runtime_host_paths_from_env "$env_file")
+
+  if [ "$count" -eq 0 ]; then
+    rm -f "$manifest"
+  else
+    chmod 600 "$manifest"
+    printf 'Backed up runtime host files: %s\n' "$count"
+  fi
+}
+
+restore_runtime_files() {
+  local manifest="$BACKUP_DIR/runtime-files.manifest"
+  local remote_file
+  local relative_path
+
+  if [ ! -f "$manifest" ]; then
+    return
+  fi
+
+  while IFS=$'\t' read -r remote_file relative_path; do
+    local local_file
+    local remote_dir
+    local remote_dir_q
+    local remote_file_q
+
+    if [ -z "$remote_file" ] || [ -z "$relative_path" ]; then
+      continue
+    fi
+
+    local_file="$BACKUP_DIR/$relative_path"
+    if [ ! -f "$local_file" ]; then
+      printf 'Missing runtime host file backup: %s\n' "$local_file" >&2
+      exit 2
+    fi
+
+    remote_dir="$(dirname -- "$remote_file")"
+    remote_dir_q="$(quote "$remote_dir")"
+    remote_file_q="$(quote "$remote_file")"
+
+    ssh_run "$TARGET_PORT" "$TARGET" "mkdir -p $remote_dir_q && rm -rf $remote_file_q"
+    scp_to "$TARGET_PORT" "$TARGET" "$local_file" "$remote_file"
+    ssh_run "$TARGET_PORT" "$TARGET" "chown $RUNTIME_FILE_OWNER $remote_file_q && chmod 400 $remote_file_q"
+  done < "$manifest"
+}
+
 backup_data() {
   timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
   BACKUP_DIR="$BACKUP_ROOT/$timestamp"
@@ -288,6 +402,10 @@ backup_data() {
       "docker run --rm -v ${source_minio_volume_q}:/data:ro alpine:3.20 tar -C /data -czf - ." \
       > "$BACKUP_DIR/minio.tgz"
     chmod 600 "$BACKUP_DIR/minio.tgz"
+  fi
+
+  if [ "$SKIP_ENV" -eq 0 ]; then
+    backup_runtime_files
   fi
 
   {
@@ -348,6 +466,8 @@ restore_data() {
     fi
     scp_to "$TARGET_PORT" "$TARGET" "$BACKUP_DIR/.env" "$REMOTE_PATH/.env"
   fi
+
+  restore_runtime_files
 
   if [ "$SKIP_DB" -eq 0 ]; then
     if [ ! -f "$BACKUP_DIR/postgres.dump" ]; then

--- a/scripts/ops/verify-prod-no-build.sh
+++ b/scripts/ops/verify-prod-no-build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+status=0
+
+for file in \
+  "$REPO_ROOT/docker-compose.prod.yml" \
+  "$REPO_ROOT/integrations/docker-compose.prod.yaml"
+do
+  if grep -nE '^[[:space:]]*build[[:space:]]*:' "$file" >&2; then
+    printf 'Production compose files must not define image build sections: %s\n' "${file#$REPO_ROOT/}" >&2
+    status=1
+  fi
+done
+
+for file in \
+  "$REPO_ROOT/scripts/ops/deploy-prod.sh" \
+  "$REPO_ROOT/scripts/ops/migrate-prod-data.sh" \
+  "$REPO_ROOT/.github/workflows/deploy-production.yml"
+do
+  if grep -nE '(^|[[:space:]])--build($|[[:space:]])|docker[[:space:]]+build($|[[:space:]])|docker-compose[[:space:]]+build($|[[:space:]])|docker[[:space:]]+compose[[:space:]]+build($|[[:space:]])' "$file" >&2; then
+    printf 'Production deploy path must not request image builds: %s\n' "${file#$REPO_ROOT/}" >&2
+    status=1
+  fi
+done
+
+exit "$status"


### PR DESCRIPTION
## Summary
- Make deploy-production app-only for the production host: it deploys server, web, and admin with a single image_tag input.
- Keep production hosts from building images by adding a no-build guard and using docker compose up --no-build in deploy and migration paths.
- Extend data migration to back up and restore cloud runtime host files referenced by .env, then set container-readable ownership after restore.
- Document the app-only production host, known_hosts reset handling, and runtime file migration behavior.

## Production notes
- The reset production host has been bootstrapped with Docker/Compose.
- GitHub Environment known_hosts was refreshed for the reset host.
- Initial .env, Postgres, MinIO, and cloud runtime files were migrated from the old host.
- The host is currently running only the main app stack; integrations containers are not running there.

## Validation
- bash -n scripts/ops/verify-prod-no-build.sh scripts/ops/deploy-prod.sh scripts/ops/migrate-prod-data.sh
- bash scripts/ops/verify-prod-no-build.sh
- git diff --check
- Verified production web 200 via port 3000
- Verified production web /api proxy reaches server with expected 401 responses for unauthenticated requests
- Verified MinIO volume contains restored data
- Verified server container is running with zero restarts after runtime file restore