### PR TITLE
[codex] Publish production app images only

### DIFF
--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -45,33 +45,6 @@ jobs:
           - name: admin
             image: shadow-admin
             dockerfile: apps/admin/Dockerfile
-          - name: kanban
-            image: shadow-integration-kanban
-            dockerfile: integrations/kanban/Dockerfile
-          - name: skills
-            image: shadow-integration-skills
-            dockerfile: integrations/skills/Dockerfile
-          - name: qna
-            image: shadow-integration-qna
-            dockerfile: integrations/qna/Dockerfile
-          - name: quiz
-            image: shadow-integration-quiz
-            dockerfile: integrations/quiz/Dockerfile
-          - name: trainer
-            image: shadow-integration-trainer
-            dockerfile: integrations/trainer/Dockerfile
-          - name: resume
-            image: shadow-integration-resume
-            dockerfile: integrations/resume/Dockerfile
-          - name: flash
-            image: shadow-integration-flash
-            dockerfile: integrations/flash/Dockerfile
-          - name: space
-            image: shadow-integration-space
-            dockerfile: integrations/space/Dockerfile
-          - name: warbuddy
-            image: shadow-integration-warbuddy
-            dockerfile: integrations/warbuddy/Dockerfile
 
     steps:
       - name: Checkout

--- a/docs/deployment/ci-built-images.md
+++ b/docs/deployment/ci-built-images.md
@@ -7,15 +7,10 @@ passes on `main`:
 - `ghcr.io/buggyblues/shadow-server`
 - `ghcr.io/buggyblues/shadow-web`
 - `ghcr.io/buggyblues/shadow-admin`
-- `ghcr.io/buggyblues/shadow-integration-kanban`
-- `ghcr.io/buggyblues/shadow-integration-skills`
-- `ghcr.io/buggyblues/shadow-integration-qna`
-- `ghcr.io/buggyblues/shadow-integration-quiz`
-- `ghcr.io/buggyblues/shadow-integration-trainer`
-- `ghcr.io/buggyblues/shadow-integration-resume`
-- `ghcr.io/buggyblues/shadow-integration-flash`
-- `ghcr.io/buggyblues/shadow-integration-space`
-- `ghcr.io/buggyblues/shadow-integration-warbuddy`
+
+Integration images are not part of the production host deploy chain. Keep them
+on a separate publishing/deployment path so an integration image issue cannot
+block the main app rollout.
 
 The workflow publishes three useful tag styles:
 

--- a/docs/deployment/production-cd.zh-CN.md
+++ b/docs/deployment/production-cd.zh-CN.md
@@ -5,7 +5,7 @@
 `main` 合入后的链路是：
 
 1. `post-merge-validation` 跑完整测试和构建验证。
-2. `publish-prod-images` 在上一步成功后发布镜像。
+2. `publish-prod-images` 在上一步成功后发布主应用镜像。
 3. `deploy-production` 在镜像发布成功后自动部署主应用到生产服务器。
 
 自动部署使用不可变镜像 tag：`sha-<12 位 commit sha>`。手动部署从 GitHub Actions 的 `deploy-production` workflow 触发，`image_tag` 默认是 `latest`。当前生产服务器只部署 `server`、`web`、`admin` 主应用栈，不部署 integrations。


### PR DESCRIPTION
## Summary
- Limit publish-prod-images to the main app images: server, web, and admin.
- Document that integration images are outside the production host deploy chain.

## Why
The production host now only runs the main app stack. Keeping integration images in the production publish matrix allowed an integration image failure to block the main app deployment even though integrations are not deployed to this host.

## Validation
- git diff --check
- bash scripts/ops/verify-prod-no-build.sh
- Verified publish-prod-images no longer references integration image entries