### PR TITLE
Add integrations runtime CD

### DIFF
--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -1,0 +1,113 @@
+name: deploy-integrations-production
+
+on:
+  workflow_run:
+    workflows: [publish-integrations-runtime]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Image tag for shadow-integrations.
+        required: false
+        default: latest
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-integrations-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy production integrations
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment: ShadowOB Production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Guard production deploy
+        shell: bash
+        run: bash scripts/ops/verify-prod-no-build.sh
+
+      - name: Resolve deploy tag
+        id: deploy
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag || '' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            short_sha="$(printf '%s' "$WORKFLOW_HEAD_SHA" | cut -c1-12)"
+            image_tag="sha-${short_sha}"
+          else
+            image_tag="${INPUT_IMAGE_TAG:-latest}"
+          fi
+
+          echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare SSH auth
+        shell: bash
+        env:
+          PROD_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          PROD_SSH_PASSWORD: ${{ secrets.PROD_SSH_PASSWORD }}
+          PROD_SSH_KNOWN_HOSTS: ${{ secrets.PROD_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+
+          install -m 700 -d "$HOME/.ssh"
+
+          if [ -n "$PROD_SSH_PRIVATE_KEY" ]; then
+            key_path="$HOME/.ssh/prod_deploy_key"
+            printf '%s\n' "$PROD_SSH_PRIVATE_KEY" > "$key_path"
+            chmod 600 "$key_path"
+            echo "PROD_SSH_KEY_PATH=${key_path}" >> "$GITHUB_ENV"
+          elif [ -n "$PROD_SSH_PASSWORD" ]; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq sshpass
+          fi
+
+          if [ -n "$PROD_SSH_KNOWN_HOSTS" ]; then
+            printf '%s\n' "$PROD_SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+            chmod 600 "$HOME/.ssh/known_hosts"
+          fi
+
+      - name: Deploy integrations over SSH
+        shell: bash
+        env:
+          PROD_SSH_HOST: ${{ secrets.PROD_SSH_HOST || '' }}
+          PROD_SSH_USER: ${{ vars.PROD_SSH_USER || 'root' }}
+          PROD_SSH_PORT: ${{ vars.PROD_SSH_PORT || '22' }}
+          PROD_REMOTE_PATH: ${{ vars.PROD_REMOTE_PATH || '/workspace/shadow' }}
+          PROD_IMAGE_REGISTRY: ${{ vars.PROD_IMAGE_REGISTRY || 'ghcr.io' }}
+          PROD_IMAGE_NAMESPACE: ${{ vars.PROD_IMAGE_NAMESPACE || '' }}
+          IMAGE_TAG: ${{ steps.deploy.outputs.image_tag }}
+          SSHPASS: ${{ secrets.PROD_SSH_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$PROD_SSH_HOST" ]; then
+            echo "::add-mask::$PROD_SSH_HOST"
+          fi
+
+          image_namespace="${PROD_IMAGE_NAMESPACE:-${GITHUB_REPOSITORY_OWNER,,}}"
+
+          args=(
+            --host "$PROD_SSH_HOST"
+            --user "$PROD_SSH_USER"
+            --port "$PROD_SSH_PORT"
+            --remote-path "$PROD_REMOTE_PATH"
+            --image-registry "$PROD_IMAGE_REGISTRY"
+            --image-namespace "$image_namespace"
+            --image-tag "$IMAGE_TAG"
+          )
+
+          scripts/ops/deploy-integrations-prod.sh "${args[@]}"

--- a/.github/workflows/publish-integrations-runtime.yml
+++ b/.github/workflows/publish-integrations-runtime.yml
@@ -1,0 +1,107 @@
+name: publish-integrations-runtime
+
+on:
+  workflow_run:
+    workflows: [post-merge-validation]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Optional extra image tag to publish
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-integrations-runtime-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build and push integrations runtime image
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Pre-pull BuildKit image
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if docker pull moby/buildkit:buildx-stable-1; then
+              exit 0
+            fi
+            if [ "$attempt" = "3" ]; then
+              echo "Failed to pull BuildKit image after ${attempt} attempts."
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image tags
+        id: image
+        shell: bash
+        env:
+          EXTRA_TAG: ${{ inputs.tag || '' }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          IMAGE_NAME: shadow-integrations
+        run: |
+          set -euo pipefail
+          owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          image="${REGISTRY}/${owner}/${IMAGE_NAME}"
+          short_sha="$(printf '%s' "$HEAD_SHA" | cut -c1-12)"
+          branch_tag="$(printf '%s' "$HEAD_BRANCH" | tr '/[:upper:]' '-[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+|-+$//g')"
+
+          {
+            echo "ref=${image}:sha-${short_sha}"
+            echo "tags<<EOF"
+            echo "${image}:sha-${short_sha}"
+            if [ -n "$branch_tag" ]; then
+              echo "${image}:${branch_tag}"
+            fi
+            if [ "$HEAD_BRANCH" = "main" ]; then
+              echo "${image}:latest"
+            fi
+            if [ -n "$EXTRA_TAG" ]; then
+              echo "${image}:${EXTRA_TAG}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: integrations/runtime/Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event.workflow_run.head_sha || github.sha }}
+          cache-from: type=gha,scope=shadow-integrations
+          cache-to: type=gha,mode=max,scope=shadow-integrations
+
+      - name: Print deployment tag
+        run: echo "Published ${{ steps.image.outputs.ref }}"

--- a/docs/deployment/production-cd.zh-CN.md
+++ b/docs/deployment/production-cd.zh-CN.md
@@ -10,6 +10,8 @@
 
 自动部署使用不可变镜像 tag：`sha-<12 位 commit sha>`。手动部署从 GitHub Actions 的 `deploy-production` workflow 触发，`image_tag` 默认是 `latest`。当前生产服务器只部署 `server`、`web`、`admin` 主应用栈，不部署 integrations。
 
+轻量 integrations 的中期形态是单独的 `shadow-integrations` 聚合 runtime。它由 `publish-integrations-runtime` workflow 发布镜像，发布成功后触发 `deploy-integrations-production` 自动部署 `integrations-runtime`。这条链路独立于主应用 `deploy-production`，避免 integrations 故障阻塞主站 CD。需要手动部署时，触发 `deploy-integrations-production` 并选择 `image_tag`。
+
 ## GitHub Environment 配置
 
 在 GitHub 的 `ShadowOB Production` environment 中配置：
@@ -126,6 +128,56 @@ scripts/ops/migrate-prod-data.sh restore \
 
 迁移可以重复执行。每次恢复都会覆盖目标服务器的主 Postgres 和 MinIO 数据；最终切流前，先停止旧服务器写入或进入维护窗口，再执行最后一次 `sync`。
 
+## Integrations Runtime
+
+聚合 runtime 包含：
+
+- `kanban`
+- `qna`
+- `quiz`
+- `trainer`
+- `resume`
+- `skills`
+- `warbuddy`
+
+`flash` 和 `space` 仍保留为单独服务。生产 compose 默认不启动旧的独立轻量 app 容器。
+
+手动发布 runtime 镜像：
+
+```bash
+gh workflow run publish-integrations-runtime.yml -f tag=latest
+```
+
+手动部署已发布 runtime 镜像：
+
+```bash
+gh workflow run deploy-integrations-production.yml -f image_tag=latest
+```
+
+部署前在目标机器的 integrations 环境文件中配置每个 app 的域名和 base URL：
+
+```dotenv
+SHADOW_INTEGRATIONS_IMAGE_TAG=latest
+INTEGRATIONS_RUNTIME_PORT=4200
+INTEGRATIONS_SHADOW_SERVER_URL=https://shadowob.com
+INTEGRATIONS_SHADOW_WEB_BASE_URL=https://shadowob.com
+
+KANBAN_HOSTS=kanban.example.com
+KANBAN_PUBLIC_BASE_URL=https://kanban.example.com
+KANBAN_API_BASE_URL=https://kanban.example.com
+```
+
+每个轻量 app 都使用同样的 `*_HOSTS`、`*_PUBLIC_BASE_URL`、`*_API_BASE_URL` 配置形态。`INTEGRATIONS_SHADOW_SERVER_URL` 和 `INTEGRATIONS_SHADOW_WEB_BASE_URL` 是 integrations runtime 专用覆盖项，避免复用主应用容器内部的 `SHADOW_SERVER_URL`。真实 IP、密钥、Token 和机器地址只放在 GitHub Secrets、目标机器 `.env` 或本地 shell env，不能提交到仓库。
+
+Nginx 配置要点：
+
+- WebSocket：转发 `Upgrade` 和 `Connection` 头，`warbuddy` 的 `/api/live/rooms/*` 需要长连接。
+- 上传限制：Q&A 图片和 Skills package 上传需要设置合理的 `client_max_body_size`。
+- SPA cache：`/shadow/server` 和 HTML shell 不缓存，hashed `/assets/*` 可以长缓存。
+- 路由：生产推荐按 Host 分发到同一个 runtime 端口；runtime 的 `/<slug>/...` 前缀转发只作为调试兜底。
+
+生产服务器仍禁止构建镜像。只允许拉取 GitHub Actions 已发布的 `shadow-integrations:<tag>`，再用 `docker compose up -d --no-build` 启动。
+
 ## 回滚
 
 主应用回滚：
@@ -133,15 +185,5 @@ scripts/ops/migrate-prod-data.sh restore \
 ```bash
 scripts/ops/deploy-prod.sh \
   --host "$PROD_SSH_HOST" \
-  --image-tag sha-上一版12位sha \
-  --skip-integrations
-```
-
-integrations 回滚：
-
-```bash
-scripts/ops/deploy-prod.sh \
-  --host "$PROD_SSH_HOST" \
-  --integrations-image-tag sha-上一版12位sha \
-  --skip-app
+  --image-tag sha-上一版12位sha
 ```

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,6 +1,6 @@
 # Shadow App Integrations
 
-This directory contains runnable Apps. `kanban` is the canonical copyable demo; `qna`, `quiz`, `trainer`, `resume`, `flash`, `space`, and `warbuddy` show richer product patterns.
+This directory contains runnable Apps. `kanban` is the canonical copyable demo; `qna`, `quiz`, `trainer`, `resume`, `skills`, `flash`, `space`, and `warbuddy` show richer product patterns.
 
 Run all standard demos locally:
 
@@ -11,6 +11,37 @@ docker compose -f integrations/docker-compose.yaml --env-file integrations/.env 
 
 Most apps keep JSON state in a named compose volume. `flash` uses its own PostgreSQL and Redis compose services for persistent boards and realtime rooms. Override ports, public iframe URLs, API URLs, and `SHADOW_SERVER_URL` in `integrations/.env`.
 
+## Production Runtime
+
+The production compose file uses one combined `shadow-integrations` runtime for the lightweight apps:
+
+- `kanban`
+- `qna`
+- `quiz`
+- `trainer`
+- `resume`
+- `skills`
+- `warbuddy`
+
+Their source trees stay separate under `integrations/<app>`, but production runs them in one Node process on port `4200`. The runtime routes by `Host` first and also supports `/<slug>/...` as a fallback for local debugging. `flash` and `space` remain separate services because they have heavier runtime dependencies.
+
+Build and publish the combined image with the `publish-integrations-runtime` GitHub Actions workflow. Deploy it by pulling `shadow-integrations:<tag>` and starting `integrations-runtime` from `integrations/docker-compose.prod.yaml`; the production compose file does not contain `build:` sections.
+
+Important runtime env vars:
+
+```dotenv
+SHADOW_INTEGRATIONS_IMAGE_TAG=latest
+INTEGRATIONS_RUNTIME_PORT=4200
+
+KANBAN_HOSTS=kanban.example.com
+KANBAN_PUBLIC_BASE_URL=https://kanban.example.com
+KANBAN_API_BASE_URL=http://host.docker.internal:4200
+```
+
+Repeat the `*_HOSTS`, `*_PUBLIC_BASE_URL`, and `*_API_BASE_URL` pattern for each lightweight app. Use comma-separated hosts when an app has aliases. Keep real infrastructure addresses and secrets out of the repository.
+
+For Nginx, forward WebSocket upgrades to the same runtime for `warbuddy`, set upload limits high enough for Q&A image uploads and Skills packages, cache hashed `/assets/*` responses aggressively, and avoid caching SPA shell routes such as `/shadow/server`.
+
 For independent app development with Vite client HMR and a watched server process:
 
 ```bash
@@ -19,6 +50,7 @@ pnpm -C integrations/qna compose:dev
 pnpm -C integrations/quiz compose:dev
 pnpm -C integrations/trainer compose:dev
 pnpm -C integrations/resume compose:dev
+pnpm -C integrations/skills compose:dev
 pnpm -C integrations/flash compose:dev
 pnpm -C integrations/space compose:dev
 pnpm -C integrations/warbuddy compose:dev
@@ -35,6 +67,7 @@ pnpm -C integrations/qna typegen
 pnpm -C integrations/quiz typegen
 pnpm -C integrations/trainer typegen
 pnpm -C integrations/resume typegen
+pnpm -C integrations/skills typegen
 pnpm -C integrations/flash typegen
 pnpm -C integrations/space typegen
 pnpm -C integrations/warbuddy typegen

--- a/integrations/docker-compose.prod.yaml
+++ b/integrations/docker-compose.prod.yaml
@@ -7,8 +7,49 @@ x-integration-defaults: &integration-defaults
     - host.docker.internal:host-gateway
 
 services:
+  integrations-runtime:
+    <<: *integration-defaults
+    image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integrations:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
+    environment:
+      PORT: '4200'
+      INTEGRATIONS_DATA_DIR: /data
+      SHADOW_SERVER_URL: ${INTEGRATIONS_SHADOW_SERVER_URL:-${SHADOW_SERVER_URL:-http://host.docker.internal:3002}}
+      SHADOW_WEB_BASE_URL: ${INTEGRATIONS_SHADOW_WEB_BASE_URL:-${SHADOW_WEB_BASE_URL:-http://localhost:3000}}
+      KANBAN_HOSTS: ${KANBAN_HOSTS:-kanban.localhost,kanban-app.localhost}
+      KANBAN_PUBLIC_BASE_URL: ${KANBAN_PUBLIC_BASE_URL:-http://localhost:4200}
+      KANBAN_API_BASE_URL: ${KANBAN_API_BASE_URL:-http://host.docker.internal:4200}
+      QNA_HOSTS: ${QNA_HOSTS:-qna.localhost,qna-app.localhost}
+      QNA_PUBLIC_BASE_URL: ${QNA_PUBLIC_BASE_URL:-http://localhost:4200}
+      QNA_API_BASE_URL: ${QNA_API_BASE_URL:-http://host.docker.internal:4200}
+      QNA_DATA_FILE: /data/qna.json
+      QNA_UPLOAD_DIR: /data/uploads/qna
+      QUIZ_HOSTS: ${QUIZ_HOSTS:-quiz.localhost,quiz-app.localhost}
+      QUIZ_PUBLIC_BASE_URL: ${QUIZ_PUBLIC_BASE_URL:-http://localhost:4200}
+      QUIZ_API_BASE_URL: ${QUIZ_API_BASE_URL:-http://host.docker.internal:4200}
+      TRAINER_HOSTS: ${TRAINER_HOSTS:-trainer.localhost,trainer-app.localhost}
+      TRAINER_PUBLIC_BASE_URL: ${TRAINER_PUBLIC_BASE_URL:-http://localhost:4200}
+      TRAINER_API_BASE_URL: ${TRAINER_API_BASE_URL:-http://host.docker.internal:4200}
+      RESUME_HOSTS: ${RESUME_HOSTS:-resume.localhost,resume-app.localhost}
+      RESUME_PUBLIC_BASE_URL: ${RESUME_PUBLIC_BASE_URL:-http://localhost:4200}
+      RESUME_API_BASE_URL: ${RESUME_API_BASE_URL:-http://host.docker.internal:4200}
+      SKILLS_HOSTS: ${SKILLS_HOSTS:-skills.localhost,skills-app.localhost}
+      SKILLS_PUBLIC_BASE_URL: ${SKILLS_PUBLIC_BASE_URL:-http://localhost:4200}
+      SKILLS_API_BASE_URL: ${SKILLS_API_BASE_URL:-http://host.docker.internal:4200}
+      WARBUDDY_HOSTS: ${WARBUDDY_HOSTS:-warbuddy.localhost,warbuddy-app.localhost}
+      WARBUDDY_PUBLIC_BASE_URL: ${WARBUDDY_PUBLIC_BASE_URL:-http://localhost:4200}
+      WARBUDDY_API_BASE_URL: ${WARBUDDY_API_BASE_URL:-http://host.docker.internal:4200}
+      WARBUDDY_OAUTH_CLIENT_ID: ${WARBUDDY_OAUTH_CLIENT_ID:-}
+      WARBUDDY_OAUTH_CLIENT_SECRET: ${WARBUDDY_OAUTH_CLIENT_SECRET:-}
+      WARBUDDY_OAUTH_COOKIE_SECRET: ${WARBUDDY_OAUTH_COOKIE_SECRET:-}
+      WARBUDDY_OAUTH_SCOPE: ${WARBUDDY_OAUTH_SCOPE:-user:read}
+    ports:
+      - ${INTEGRATIONS_RUNTIME_PORT:-4200}:4200
+    volumes:
+      - integrations-runtime-data:/data
+
   kanban:
     <<: *integration-defaults
+    profiles: ['legacy-integrations']
     image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-kanban:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
     environment:
       PORT: '4201'
@@ -23,6 +64,7 @@ services:
 
   skills:
     <<: *integration-defaults
+    profiles: ['legacy-integrations']
     image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-skills:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
     environment:
       PORT: '4220'
@@ -37,6 +79,7 @@ services:
 
   qna:
     <<: *integration-defaults
+    profiles: ['legacy-integrations']
     image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-qna:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
     environment:
       PORT: '4210'
@@ -51,6 +94,7 @@ services:
 
   quiz:
     <<: *integration-defaults
+    profiles: ['legacy-integrations']
     image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-quiz:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
     environment:
       PORT: '4211'
@@ -65,6 +109,7 @@ services:
 
   trainer:
     <<: *integration-defaults
+    profiles: ['legacy-integrations']
     image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-trainer:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
     environment:
       PORT: '4213'
@@ -79,6 +124,7 @@ services:
 
   resume:
     <<: *integration-defaults
+    profiles: ['legacy-integrations']
     image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-resume:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
     environment:
       PORT: '4214'
@@ -182,6 +228,7 @@ services:
 
   warbuddy:
     <<: *integration-defaults
+    profiles: ['legacy-integrations']
     image: ${SHADOW_IMAGE_REGISTRY:-ghcr.io}/${SHADOW_IMAGE_NAMESPACE:-buggyblues}/shadow-integration-warbuddy:${SHADOW_INTEGRATIONS_IMAGE_TAG:-latest}
     environment:
       PORT: '4218'
@@ -195,6 +242,7 @@ services:
       - warbuddy-data:/data
 
 volumes:
+  integrations-runtime-data:
   kanban-data:
   skills-data:
   qna-data:

--- a/integrations/kanban/src/manifest.ts
+++ b/integrations/kanban/src/manifest.ts
@@ -9,7 +9,7 @@ export function manifest() {
   const port = Number(process.env.PORT ?? 4201)
   return shadowApp.manifest({
     port,
-    publicBaseUrl: process.env.SHADOW_APP_PUBLIC_BASE_URL,
-    apiBaseUrl: process.env.SHADOW_APP_API_BASE_URL,
+    publicBaseUrl: process.env.KANBAN_PUBLIC_BASE_URL ?? process.env.SHADOW_APP_PUBLIC_BASE_URL,
+    apiBaseUrl: process.env.KANBAN_API_BASE_URL ?? process.env.SHADOW_APP_API_BASE_URL,
   })
 }

--- a/integrations/kanban/src/server.ts
+++ b/integrations/kanban/src/server.ts
@@ -1,4 +1,6 @@
 import 'dotenv/config'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import {
@@ -33,7 +35,10 @@ import { shellPage } from './ui.js'
 
 type KanbanCommandName = ShadowServerAppCommandName<typeof shadowServerAppManifest>
 
-const app = new Hono()
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+
+export const app = new Hono()
 const port = Number(process.env.PORT ?? 4201)
 const commandNames = new Set<string>(
   shadowServerAppManifest.commands.map((command) => command.name),
@@ -155,9 +160,9 @@ function iconSvg() {
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
 app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
-app.get('/assets/cover.png', serveStatic({ root: './public' }))
-app.get('/assets/*', serveStatic({ root: './dist/client' }))
-app.get('/artifacts/*', serveStatic({ root: './data' }))
+app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
+app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
+app.get('/artifacts/*', serveStatic({ root: fromAppRoot('data') }))
 app.get('/shadow/server', (c) => c.html(shellPage()))
 app.get('/shadow/server/*', (c) => c.html(shellPage()))
 app.get('/api/board', (c) => c.json(getBoard()))
@@ -186,6 +191,12 @@ app.post('/api/shadow/commands/:commandName', async (c) => {
   return c.json(result.body, result.status as 200)
 })
 
-serve({ fetch: app.fetch, port })
+export function startStandalone() {
+  serve({ fetch: app.fetch, port })
+  console.log(`Kanban listening on http://localhost:${port}`)
+}
 
-console.log(`Kanban listening on http://localhost:${port}`)
+const entrypoint = process.argv[1]
+if (entrypoint && import.meta.url === pathToFileURL(resolve(entrypoint)).href) {
+  startStandalone()
+}

--- a/integrations/qna/src/manifest.ts
+++ b/integrations/qna/src/manifest.ts
@@ -9,7 +9,7 @@ export function manifest() {
   const port = Number(process.env.PORT ?? 4210)
   return shadowApp.manifest({
     port,
-    publicBaseUrl: process.env.SHADOW_APP_PUBLIC_BASE_URL,
-    apiBaseUrl: process.env.SHADOW_APP_API_BASE_URL,
+    publicBaseUrl: process.env.QNA_PUBLIC_BASE_URL ?? process.env.SHADOW_APP_PUBLIC_BASE_URL,
+    apiBaseUrl: process.env.QNA_API_BASE_URL ?? process.env.SHADOW_APP_API_BASE_URL,
   })
 }

--- a/integrations/qna/src/server.ts
+++ b/integrations/qna/src/server.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { basename, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import type {
@@ -32,7 +33,10 @@ import { shellPage } from './ui.js'
 
 type QnaCommandName = ShadowServerAppCommandName<typeof shadowServerAppManifest>
 
-const app = new Hono()
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+
+export const app = new Hono()
 const port = Number(process.env.PORT ?? 4210)
 const imageMaxBytes = 5 * 1024 * 1024
 const supportedImageTypes = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif'])
@@ -240,8 +244,8 @@ const commands = shadowApp.defineCommands({
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
 app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
-app.get('/assets/cover.png', serveStatic({ root: './public' }))
-app.get('/assets/*', serveStatic({ root: './dist/client' }))
+app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
+app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 app.get('/shadow/server', (c) => c.html(shellPage()))
 app.get('/shadow/server/*', (c) => c.html(shellPage()))
 
@@ -303,6 +307,12 @@ app.post('/api/shadow/commands/:commandName', async (c) => {
   return c.json(result.body, result.status as 200)
 })
 
-serve({ fetch: app.fetch, port })
+export function startStandalone() {
+  serve({ fetch: app.fetch, port })
+  console.log(`Answers listening on http://localhost:${port}`)
+}
 
-console.log(`Answers listening on http://localhost:${port}`)
+const entrypoint = process.argv[1]
+if (entrypoint && import.meta.url === pathToFileURL(resolve(entrypoint)).href) {
+  startStandalone()
+}

--- a/integrations/quiz/src/manifest.ts
+++ b/integrations/quiz/src/manifest.ts
@@ -9,7 +9,7 @@ export function manifest() {
   const port = Number(process.env.PORT ?? 4211)
   return shadowApp.manifest({
     port,
-    publicBaseUrl: process.env.SHADOW_APP_PUBLIC_BASE_URL,
-    apiBaseUrl: process.env.SHADOW_APP_API_BASE_URL,
+    publicBaseUrl: process.env.QUIZ_PUBLIC_BASE_URL ?? process.env.SHADOW_APP_PUBLIC_BASE_URL,
+    apiBaseUrl: process.env.QUIZ_API_BASE_URL ?? process.env.SHADOW_APP_API_BASE_URL,
   })
 }

--- a/integrations/quiz/src/server.ts
+++ b/integrations/quiz/src/server.ts
@@ -1,4 +1,6 @@
 import 'dotenv/config'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import type { ShadowServerAppCommandContext, ShadowServerAppCommandName } from '@shadowob/sdk'
@@ -17,7 +19,10 @@ import { shellPage } from './ui.js'
 
 type QuizCommandName = ShadowServerAppCommandName<typeof shadowServerAppManifest>
 
-const app = new Hono()
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+
+export const app = new Hono()
 const port = Number(process.env.PORT ?? 4211)
 const commandNames = new Set<string>(
   shadowServerAppManifest.commands.map((command) => command.name),
@@ -94,8 +99,8 @@ function iconSvg() {
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
 app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
-app.get('/assets/cover.png', serveStatic({ root: './public' }))
-app.get('/assets/*', serveStatic({ root: './dist/client' }))
+app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
+app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 app.get('/shadow/server', (c) => c.html(shellPage()))
 app.get('/shadow/server/*', (c) => c.html(shellPage()))
 
@@ -123,6 +128,12 @@ app.post('/api/shadow/commands/:commandName', async (c) => {
   return c.json(result.body, result.status as 200)
 })
 
-serve({ fetch: app.fetch, port })
+export function startStandalone() {
+  serve({ fetch: app.fetch, port })
+  console.log(`Quiz listening on http://localhost:${port}`)
+}
 
-console.log(`Quiz listening on http://localhost:${port}`)
+const entrypoint = process.argv[1]
+if (entrypoint && import.meta.url === pathToFileURL(resolve(entrypoint)).href) {
+  startStandalone()
+}

--- a/integrations/resume/src/manifest.ts
+++ b/integrations/resume/src/manifest.ts
@@ -9,7 +9,7 @@ export function manifest() {
   const port = Number(process.env.PORT ?? 4214)
   return shadowApp.manifest({
     port,
-    publicBaseUrl: process.env.SHADOW_APP_PUBLIC_BASE_URL,
-    apiBaseUrl: process.env.SHADOW_APP_API_BASE_URL,
+    publicBaseUrl: process.env.RESUME_PUBLIC_BASE_URL ?? process.env.SHADOW_APP_PUBLIC_BASE_URL,
+    apiBaseUrl: process.env.RESUME_API_BASE_URL ?? process.env.SHADOW_APP_API_BASE_URL,
   })
 }

--- a/integrations/resume/src/server.ts
+++ b/integrations/resume/src/server.ts
@@ -1,4 +1,6 @@
 import 'dotenv/config'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import type { ShadowServerAppCommandContext, ShadowServerAppCommandName } from '@shadowob/sdk'
@@ -18,7 +20,10 @@ import { shellPage } from './ui.js'
 
 type ResumeCommandName = ShadowServerAppCommandName<typeof shadowServerAppManifest>
 
-const app = new Hono()
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+
+export const app = new Hono()
 const port = Number(process.env.PORT ?? 4214)
 const commandNames = new Set<string>(
   shadowServerAppManifest.commands.map((command) => command.name),
@@ -92,8 +97,8 @@ function iconSvg() {
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
 app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
-app.get('/assets/cover.png', serveStatic({ root: './public' }))
-app.get('/assets/*', serveStatic({ root: './dist/client' }))
+app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
+app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 app.get('/shadow/server', (c) => c.html(shellPage()))
 app.get('/shadow/server/*', (c) => c.html(shellPage()))
 
@@ -121,6 +126,12 @@ app.post('/api/shadow/commands/:commandName', async (c) => {
   return c.json(result.body, result.status as 200)
 })
 
-serve({ fetch: app.fetch, port })
+export function startStandalone() {
+  serve({ fetch: app.fetch, port })
+  console.log(`Super Resume listening on http://localhost:${port}`)
+}
 
-console.log(`Super Resume listening on http://localhost:${port}`)
+const entrypoint = process.argv[1]
+if (entrypoint && import.meta.url === pathToFileURL(resolve(entrypoint)).href) {
+  startStandalone()
+}

--- a/integrations/runtime/Dockerfile
+++ b/integrations/runtime/Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable && corepack prepare pnpm@10.19.0 --activate
+
+WORKDIR /repo
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY .npmrc ./
+COPY patches ./patches
+COPY packages/shared/package.json ./packages/shared/
+COPY packages/sdk/package.json ./packages/sdk/
+COPY packages/sdk/bin ./packages/sdk/bin
+COPY integrations/runtime/package.json ./integrations/runtime/
+COPY integrations/kanban/package.json ./integrations/kanban/
+COPY integrations/qna/package.json ./integrations/qna/
+COPY integrations/quiz/package.json ./integrations/quiz/
+COPY integrations/trainer/package.json ./integrations/trainer/
+COPY integrations/resume/package.json ./integrations/resume/
+COPY integrations/skills/package.json ./integrations/skills/
+COPY integrations/warbuddy/package.json ./integrations/warbuddy/
+
+RUN --mount=type=cache,id=shadow-pnpm-store,target=/pnpm/store \
+  pnpm config set store-dir /pnpm/store \
+  && pnpm install \
+    --filter @shadowob/integrations-runtime... \
+    --prod=false \
+    --frozen-lockfile \
+    --ignore-scripts \
+    --package-import-method=copy
+
+COPY packages/shared ./packages/shared
+COPY packages/sdk ./packages/sdk
+COPY integrations/runtime ./integrations/runtime
+COPY integrations/kanban ./integrations/kanban
+COPY integrations/qna ./integrations/qna
+COPY integrations/quiz ./integrations/quiz
+COPY integrations/trainer ./integrations/trainer
+COPY integrations/resume ./integrations/resume
+COPY integrations/skills ./integrations/skills
+COPY integrations/warbuddy ./integrations/warbuddy
+
+RUN pnpm --filter @shadowob/shared build \
+  && pnpm --filter @shadowob/sdk build \
+  && pnpm --filter @shadowob/kanban-app build \
+  && pnpm --filter @shadowob/qna-app build \
+  && pnpm --filter @shadowob/quiz-app build \
+  && pnpm --filter @shadowob/trainer-app build \
+  && pnpm --filter @shadowob/resume-app build \
+  && pnpm --filter @shadowob/skills-app build \
+  && pnpm --filter @shadowob/warbuddy-app build \
+  && pnpm --filter @shadowob/integrations-runtime build
+
+WORKDIR /repo/integrations/runtime
+
+EXPOSE 4200
+
+CMD ["node", "--import", "tsx", "src/server.ts"]

--- a/integrations/runtime/package.json
+++ b/integrations/runtime/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@shadowob/integrations-runtime",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsx watch src/server.ts",
+    "start": "tsx src/server.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.14.1",
+    "@shadowob/kanban-app": "workspace:*",
+    "@shadowob/qna-app": "workspace:*",
+    "@shadowob/quiz-app": "workspace:*",
+    "@shadowob/resume-app": "workspace:*",
+    "@shadowob/skills-app": "workspace:*",
+    "@shadowob/trainer-app": "workspace:*",
+    "@shadowob/warbuddy-app": "workspace:*",
+    "dotenv": "^17.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsx": "^4.19.4",
+    "typescript": "^5.9.3"
+  }
+}

--- a/integrations/runtime/src/server.ts
+++ b/integrations/runtime/src/server.ts
@@ -1,0 +1,231 @@
+import 'dotenv/config'
+import type { IncomingMessage } from 'node:http'
+import type { Socket } from 'node:net'
+import { serve } from '@hono/node-server'
+
+type IntegrationSlug = 'kanban' | 'qna' | 'quiz' | 'trainer' | 'resume' | 'skills' | 'warbuddy'
+
+type HonoLikeApp = {
+  fetch: (request: Request) => Response | Promise<Response>
+}
+
+type UpgradeHandler = (request: IncomingMessage, socket: Socket) => void
+
+type RuntimeIntegration = {
+  slug: IntegrationSlug
+  label: string
+  app: HonoLikeApp
+  hosts: string[]
+  upgrade?: UpgradeHandler
+}
+
+type ResolvedIntegration = {
+  integration: RuntimeIntegration
+  pathPrefix: string | null
+}
+
+const port = Number(process.env.PORT ?? 4200)
+const dataDir = trimTrailingSlash(process.env.INTEGRATIONS_DATA_DIR ?? '/data')
+
+setDefaultEnv('KANBAN_DATA_FILE', `${dataDir}/kanban-board.json`)
+setDefaultEnv('QNA_DATA_FILE', `${dataDir}/qna.json`)
+setDefaultEnv('QNA_UPLOAD_DIR', `${dataDir}/uploads/qna`)
+setDefaultEnv('QUIZ_DATA_FILE', `${dataDir}/quiz.json`)
+setDefaultEnv('TRAINER_DATA_FILE', `${dataDir}/trainer.json`)
+setDefaultEnv('RESUME_DATA_FILE', `${dataDir}/resume.json`)
+setDefaultEnv('SKILLS_DATA_FILE', `${dataDir}/skills-library.json`)
+setDefaultEnv('WARBUDDY_DATA_FILE', `${dataDir}/warbuddy.json`)
+
+const [kanban, qna, quiz, trainer, resume, skills, warbuddy] = await Promise.all([
+  import('../../kanban/src/server.js'),
+  import('../../qna/src/server.js'),
+  import('../../quiz/src/server.js'),
+  import('../../trainer/src/server.js'),
+  import('../../resume/src/server.js'),
+  import('../../skills/src/server.js'),
+  import('../../warbuddy/src/server.js'),
+])
+
+skills.startSkillsBackgroundTasks()
+
+const integrations: RuntimeIntegration[] = [
+  {
+    slug: 'kanban',
+    label: 'Kanban',
+    app: kanban.app,
+    hosts: hostsFor('kanban', ['kanban.localhost', 'kanban-app.localhost']),
+  },
+  {
+    slug: 'qna',
+    label: 'Answers',
+    app: qna.app,
+    hosts: hostsFor('qna', ['qna.localhost', 'qna-app.localhost']),
+  },
+  {
+    slug: 'quiz',
+    label: 'Quiz',
+    app: quiz.app,
+    hosts: hostsFor('quiz', ['quiz.localhost', 'quiz-app.localhost']),
+  },
+  {
+    slug: 'trainer',
+    label: 'Code Trainer',
+    app: trainer.app,
+    hosts: hostsFor('trainer', ['trainer.localhost', 'trainer-app.localhost']),
+  },
+  {
+    slug: 'resume',
+    label: 'Super Resume',
+    app: resume.app,
+    hosts: hostsFor('resume', ['resume.localhost', 'resume-app.localhost']),
+  },
+  {
+    slug: 'skills',
+    label: 'Skills',
+    app: skills.app,
+    hosts: hostsFor('skills', ['skills.localhost', 'skills-app.localhost']),
+  },
+  {
+    slug: 'warbuddy',
+    label: 'WarBuddy',
+    app: warbuddy.app,
+    hosts: hostsFor('warbuddy', ['warbuddy.localhost', 'warbuddy-app.localhost']),
+    upgrade: warbuddy.handleLiveUpgrade,
+  },
+]
+
+const integrationsBySlug = new Map(
+  integrations.map((integration) => [integration.slug, integration]),
+)
+const integrationsByHost = new Map(
+  integrations.flatMap((integration) =>
+    integration.hosts.map((host) => [normalizeHost(host), integration] as const),
+  ),
+)
+
+const server = serve({ fetch: routeRequest, port })
+server.on('upgrade', (request, socket) => {
+  const resolved = resolveIncomingMessage(request)
+  if (!resolved?.integration.upgrade) {
+    socket.destroy()
+    return
+  }
+
+  const originalUrl = request.url
+  if (resolved.pathPrefix)
+    request.url = stripPrefixFromPath(originalUrl ?? '/', resolved.pathPrefix)
+  try {
+    resolved.integration.upgrade(request, socket as Socket)
+  } finally {
+    request.url = originalUrl
+  }
+})
+
+console.log(`Integrations runtime listening on http://localhost:${port}`)
+console.log(
+  `Loaded integrations: ${integrations
+    .map((integration) => `${integration.slug}(${integration.hosts.join(',')})`)
+    .join(' ')}`,
+)
+
+async function routeRequest(request: Request) {
+  const url = new URL(request.url)
+  if (url.pathname === '/healthz') {
+    return jsonResponse(200, { ok: true, integrations: integrations.map((item) => item.slug) })
+  }
+  if (url.pathname === '/__runtime/apps') {
+    return jsonResponse(200, {
+      apps: integrations.map((integration) => ({
+        slug: integration.slug,
+        label: integration.label,
+        hosts: integration.hosts,
+      })),
+    })
+  }
+
+  const resolved = resolveRequest(request)
+  if (!resolved) {
+    return jsonResponse(404, {
+      ok: false,
+      error: 'integration_not_found',
+      hint: 'Set the Host header to a configured integration host or route by /<slug>/...',
+    })
+  }
+
+  const forwardedRequest = resolved.pathPrefix
+    ? stripPrefixFromRequest(request, resolved.pathPrefix)
+    : request
+  return resolved.integration.app.fetch(forwardedRequest)
+}
+
+function resolveRequest(request: Request): ResolvedIntegration | null {
+  const url = new URL(request.url)
+  const hostIntegration = integrationsByHost.get(normalizeHost(request.headers.get('host')))
+  if (hostIntegration) return { integration: hostIntegration, pathPrefix: null }
+
+  const pathPrefix = firstPathSegment(url.pathname)
+  const pathIntegration = pathPrefix ? integrationsBySlug.get(pathPrefix as IntegrationSlug) : null
+  return pathIntegration ? { integration: pathIntegration, pathPrefix } : null
+}
+
+function resolveIncomingMessage(request: IncomingMessage): ResolvedIntegration | null {
+  const hostIntegration = integrationsByHost.get(normalizeHost(request.headers.host))
+  if (hostIntegration) return { integration: hostIntegration, pathPrefix: null }
+
+  const pathPrefix = firstPathSegment(request.url ?? '/')
+  const pathIntegration = pathPrefix ? integrationsBySlug.get(pathPrefix as IntegrationSlug) : null
+  return pathIntegration ? { integration: pathIntegration, pathPrefix } : null
+}
+
+function firstPathSegment(pathname: string) {
+  const segment = pathname.split('/').find(Boolean)
+  return segment && integrationsBySlug.has(segment as IntegrationSlug) ? segment : null
+}
+
+function stripPrefixFromRequest(request: Request, pathPrefix: string) {
+  const url = new URL(request.url)
+  url.pathname = stripPrefixFromPath(url.pathname, pathPrefix)
+  return new Request(url.toString(), request)
+}
+
+function stripPrefixFromPath(pathname: string, pathPrefix: string) {
+  const prefix = `/${pathPrefix}`
+  if (pathname === prefix) return '/'
+  if (pathname.startsWith(`${prefix}/`)) return pathname.slice(prefix.length) || '/'
+  return pathname
+}
+
+function hostsFor(slug: IntegrationSlug, defaults: string[]) {
+  const key = `${slug.toUpperCase()}_HOSTS`
+  return (process.env[key] ?? defaults.join(','))
+    .split(',')
+    .map((item) => normalizeHost(item))
+    .filter(Boolean)
+}
+
+function normalizeHost(value: string | null | undefined) {
+  const host = (value ?? '').trim().toLowerCase()
+  if (!host) return ''
+  if (host.startsWith('[')) {
+    const closing = host.indexOf(']')
+    return closing === -1 ? host : host.slice(1, closing)
+  }
+  return host.split(':')[0] ?? host
+}
+
+function setDefaultEnv(key: string, value: string) {
+  if (!process.env[key]) process.env[key] = value
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/+$/, '')
+}
+
+function jsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  })
+}

--- a/integrations/runtime/tsconfig.json
+++ b/integrations/runtime/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "..",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/integrations/skills/src/manifest.ts
+++ b/integrations/skills/src/manifest.ts
@@ -9,7 +9,7 @@ export function manifest() {
   const port = Number(process.env.PORT ?? 4220)
   return shadowApp.manifest({
     port,
-    publicBaseUrl: process.env.SHADOW_APP_PUBLIC_BASE_URL,
-    apiBaseUrl: process.env.SHADOW_APP_API_BASE_URL,
+    publicBaseUrl: process.env.SKILLS_PUBLIC_BASE_URL ?? process.env.SHADOW_APP_PUBLIC_BASE_URL,
+    apiBaseUrl: process.env.SKILLS_API_BASE_URL ?? process.env.SHADOW_APP_API_BASE_URL,
   })
 }

--- a/integrations/skills/src/server.ts
+++ b/integrations/skills/src/server.ts
@@ -1,4 +1,6 @@
 import 'dotenv/config'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import {
@@ -25,8 +27,12 @@ import { shellPage } from './ui.js'
 
 type SkillsCommandName = ShadowServerAppCommandName<typeof shadowServerAppManifest>
 
-const app = new Hono()
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+
+export const app = new Hono()
 const port = Number(process.env.PORT ?? 4220)
+let skillsBackgroundStarted = false
 const commandNames = new Set<string>(
   shadowServerAppManifest.commands.map((command) => command.name),
 )
@@ -195,8 +201,8 @@ function iconSvg() {
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
 app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
-app.get('/assets/cover.png', serveStatic({ root: './public' }))
-app.get('/assets/*', serveStatic({ root: './dist/client' }))
+app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
+app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 app.get('/shadow/server', (c) => c.html(shellPage()))
 app.get('/shadow/server/*', (c) => c.html(shellPage()))
 app.get('/api/skills', (c) =>
@@ -249,7 +255,19 @@ app.post('/api/shadow/commands/:commandName', async (c) => {
   return c.json(result.body, result.status as 200)
 })
 
-serve({ fetch: app.fetch, port })
-startSkillDirectorySnapshotLoop()
+export function startSkillsBackgroundTasks() {
+  if (skillsBackgroundStarted) return
+  skillsBackgroundStarted = true
+  startSkillDirectorySnapshotLoop()
+}
 
-console.log(`Skills listening on http://localhost:${port}`)
+export function startStandalone() {
+  serve({ fetch: app.fetch, port })
+  startSkillsBackgroundTasks()
+  console.log(`Skills listening on http://localhost:${port}`)
+}
+
+const entrypoint = process.argv[1]
+if (entrypoint && import.meta.url === pathToFileURL(resolve(entrypoint)).href) {
+  startStandalone()
+}

--- a/integrations/trainer/src/manifest.ts
+++ b/integrations/trainer/src/manifest.ts
@@ -9,7 +9,7 @@ export function manifest() {
   const port = Number(process.env.PORT ?? 4213)
   return shadowApp.manifest({
     port,
-    publicBaseUrl: process.env.SHADOW_APP_PUBLIC_BASE_URL,
-    apiBaseUrl: process.env.SHADOW_APP_API_BASE_URL,
+    publicBaseUrl: process.env.TRAINER_PUBLIC_BASE_URL ?? process.env.SHADOW_APP_PUBLIC_BASE_URL,
+    apiBaseUrl: process.env.TRAINER_API_BASE_URL ?? process.env.SHADOW_APP_API_BASE_URL,
   })
 }

--- a/integrations/trainer/src/server.ts
+++ b/integrations/trainer/src/server.ts
@@ -1,4 +1,6 @@
 import 'dotenv/config'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import {
@@ -49,7 +51,10 @@ import { shellPage } from './ui.js'
 
 type TrainerCommandName = ShadowServerAppCommandName<typeof shadowServerAppManifest>
 
-const app = new Hono()
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+
+export const app = new Hono()
 const port = Number(process.env.PORT ?? 4213)
 const commandNames = new Set<string>(
   shadowServerAppManifest.commands.map((command) => command.name),
@@ -696,8 +701,8 @@ async function proxyViteDevAsset(requestUrl: string) {
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
 app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
 app.get('/@fs/*', async (c) => (await proxyViteDevAsset(c.req.url)) ?? c.notFound())
-app.get('/assets/cover.png', serveStatic({ root: './public' }))
-app.get('/assets/*', serveStatic({ root: './dist/client' }))
+app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
+app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 app.get('/shadow/server', (c) => c.html(shellPage()))
 app.get('/shadow/server/*', (c) => c.html(shellPage()))
 
@@ -725,6 +730,12 @@ app.post('/api/shadow/commands/:commandName', async (c) => {
   return c.json(result.body, result.status as 200)
 })
 
-serve({ fetch: app.fetch, port })
+export function startStandalone() {
+  serve({ fetch: app.fetch, port })
+  console.log(`Code Trainer listening on http://localhost:${port}`)
+}
 
-console.log(`Code Trainer listening on http://localhost:${port}`)
+const entrypoint = process.argv[1]
+if (entrypoint && import.meta.url === pathToFileURL(resolve(entrypoint)).href) {
+  startStandalone()
+}

--- a/integrations/warbuddy/src/manifest.ts
+++ b/integrations/warbuddy/src/manifest.ts
@@ -9,7 +9,7 @@ export function manifest() {
   const port = Number(process.env.PORT ?? 4218)
   return shadowApp.manifest({
     port,
-    publicBaseUrl: process.env.SHADOW_APP_PUBLIC_BASE_URL,
-    apiBaseUrl: process.env.SHADOW_APP_API_BASE_URL,
+    publicBaseUrl: process.env.WARBUDDY_PUBLIC_BASE_URL ?? process.env.SHADOW_APP_PUBLIC_BASE_URL,
+    apiBaseUrl: process.env.WARBUDDY_API_BASE_URL ?? process.env.SHADOW_APP_API_BASE_URL,
   })
 }

--- a/integrations/warbuddy/src/oauth.ts
+++ b/integrations/warbuddy/src/oauth.ts
@@ -23,7 +23,11 @@ function trimTrailingSlash(value: string) {
 }
 
 function publicBaseUrl() {
-  return trimTrailingSlash(process.env.SHADOW_APP_PUBLIC_BASE_URL ?? 'http://localhost:4218')
+  return trimTrailingSlash(
+    process.env.WARBUDDY_PUBLIC_BASE_URL ??
+      process.env.SHADOW_APP_PUBLIC_BASE_URL ??
+      'http://localhost:4218',
+  )
 }
 
 function shadowApiBaseUrl() {

--- a/integrations/warbuddy/src/server.ts
+++ b/integrations/warbuddy/src/server.ts
@@ -2,6 +2,8 @@ import 'dotenv/config'
 import { createHash } from 'node:crypto'
 import type { IncomingMessage } from 'node:http'
 import type { Socket } from 'node:net'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import type {
@@ -49,7 +51,10 @@ import { shellPage } from './ui.js'
 
 type WarbuddyCommandName = ShadowServerAppCommandName<typeof shadowServerAppManifest>
 
-const app = new Hono()
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+
+export const app = new Hono()
 const port = Number(process.env.PORT ?? 4218)
 const liveSockets = new Map<string, Map<Socket, LivePeer>>()
 const commandNames = new Set<string>(
@@ -328,10 +333,10 @@ function errorResponse(c: Context, error: unknown) {
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
 app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
-app.get('/assets/cover.png', serveStatic({ root: './public' }))
-app.get('/assets/*', serveStatic({ root: './dist/client' }))
+app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
+app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 if (process.env.WARBUDDY_VITE_DEV_SERVER_URL) {
-  app.get('/src/client/assets/*', serveStatic({ root: '.' }))
+  app.get('/src/client/assets/*', serveStatic({ root: appRoot }))
 }
 app.get('/shadow/server', (c) => c.html(shellPage()))
 app.get('/shadow/server/*', (c) => c.html(shellPage()))
@@ -378,12 +383,18 @@ app.post('/api/shadow/commands/:commandName', async (c) => {
   }
 })
 
-const server = serve({ fetch: app.fetch, port })
-server.on('upgrade', handleLiveUpgrade)
+export function startStandalone() {
+  const server = serve({ fetch: app.fetch, port })
+  server.on('upgrade', handleLiveUpgrade)
+  console.log(`WarBuddy listening on http://localhost:${port}`)
+}
 
-console.log(`WarBuddy listening on http://localhost:${port}`)
+const entrypoint = process.argv[1]
+if (entrypoint && import.meta.url === pathToFileURL(resolve(entrypoint)).href) {
+  startStandalone()
+}
 
-function handleLiveUpgrade(req: IncomingMessage, socket: Socket) {
+export function handleLiveUpgrade(req: IncomingMessage, socket: Socket) {
   const url = new URL(req.url ?? '/', `http://${req.headers.host ?? `localhost:${port}`}`)
   if (!url.pathname.startsWith('/api/live/rooms/')) {
     socket.destroy()

--- a/packages/sdk/__tests__/server-app.test.ts
+++ b/packages/sdk/__tests__/server-app.test.ts
@@ -122,7 +122,10 @@ describe('server app helpers', () => {
                 alt: 'External gallery',
               },
             ],
-            links: [{ label: 'Docs', url: 'https://docs.example.com/demo', type: 'docs' }],
+            links: [
+              { label: 'Home', url: 'http://localhost:4201/shadow/server', type: 'website' },
+              { label: 'Docs', url: 'https://docs.example.com/demo', type: 'docs' },
+            ],
           },
         },
         {
@@ -139,7 +142,10 @@ describe('server app helpers', () => {
           { url: 'https://app.example.com/assets/gallery.png' },
           { url: 'https://cdn.example.com/demo.jpg' },
         ],
-        links: [{ url: 'https://docs.example.com/demo' }],
+        links: [
+          { url: 'https://app.example.com/shadow/server' },
+          { url: 'https://docs.example.com/demo' },
+        ],
       },
       iframe: {
         entry: 'https://app.example.com/server',

--- a/packages/sdk/src/server-app.ts
+++ b/packages/sdk/src/server-app.ts
@@ -771,6 +771,10 @@ export function createShadowServerAppManifest<TManifest extends ShadowServerAppM
             ...item,
             url: rebasePublicAssetUrl(item.url, sourceAssetOrigin, publicBaseUrl),
           })),
+          links: manifest.marketplace.links?.map((item) => ({
+            ...item,
+            url: rebasePublicAssetUrl(item.url, sourceAssetOrigin, publicBaseUrl),
+          })),
         }
       : manifest.marketplace,
     iframe: manifest.iframe

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1450,6 +1450,46 @@ importers:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
 
+  integrations/runtime:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.14.1
+        version: 1.19.13(hono@4.12.17)
+      '@shadowob/kanban-app':
+        specifier: workspace:*
+        version: link:../kanban
+      '@shadowob/qna-app':
+        specifier: workspace:*
+        version: link:../qna
+      '@shadowob/quiz-app':
+        specifier: workspace:*
+        version: link:../quiz
+      '@shadowob/resume-app':
+        specifier: workspace:*
+        version: link:../resume
+      '@shadowob/skills-app':
+        specifier: workspace:*
+        version: link:../skills
+      '@shadowob/trainer-app':
+        specifier: workspace:*
+        version: link:../trainer
+      '@shadowob/warbuddy-app':
+        specifier: workspace:*
+        version: link:../warbuddy
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.4.2
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.6.0
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   integrations/skills:
     dependencies:
       '@hono/node-server':
@@ -20080,7 +20120,7 @@ snapshots:
       '@inquirer/figures': 1.0.15
       '@inquirer/type': 2.0.0
       '@types/mute-stream': 0.0.4
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
@@ -20220,14 +20260,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -20261,7 +20301,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -23465,14 +23505,14 @@ snapshots:
 
   '@slack/logger@4.0.1':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@slack/oauth@3.0.5':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/web-api': 7.15.2
       '@types/jsonwebtoken': 9.0.10
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - debug
@@ -23481,7 +23521,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/web-api': 7.15.2
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
       ws: 8.20.0
@@ -23496,7 +23536,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       '@types/retry': 0.12.0
       axios: 1.16.0
       eventemitter3: 5.0.4
@@ -24038,7 +24078,7 @@ snapshots:
 
   '@types/appdmg@0.5.5':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
     optional: true
 
   '@types/archiver@7.0.0':
@@ -24079,17 +24119,17 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       '@types/responselike': 1.0.3
 
   '@types/canvas-confetti@1.9.0': {}
@@ -24102,15 +24142,15 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.8
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/css-font-loading-module@0.0.12': {}
 
@@ -24263,7 +24303,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -24281,7 +24321,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/hammerjs@2.0.46': {}
 
@@ -24299,7 +24339,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -24322,7 +24362,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/matter-js@0.20.2': {}
 
@@ -24344,11 +24384,11 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/node-forge@1.3.14':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/node@18.19.130':
     dependencies:
@@ -24365,7 +24405,6 @@ snapshots:
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
-    optional: true
 
   '@types/node@24.12.0':
     dependencies:
@@ -24418,11 +24457,11 @@ snapshots:
 
   '@types/readdir-glob@1.1.5':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/retry@0.12.0': {}
 
@@ -24433,11 +24472,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -24446,14 +24485,14 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       '@types/send': 0.17.6
 
   '@types/shimmer@1.2.0': {}
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
 
   '@types/stack-utils@2.0.3': {}
 
@@ -24496,7 +24535,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.6.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.6.3)':
@@ -25792,7 +25831,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -25803,7 +25842,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -26755,7 +26794,7 @@ snapshots:
   engine.io@6.6.5:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2
@@ -28985,7 +29024,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -28995,7 +29034,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -29022,7 +29061,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -29030,7 +29069,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -29047,13 +29086,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -31898,7 +31937,7 @@ snapshots:
 
   protobufjs@8.2.0:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.19.19
       long: 5.3.2
 
   proxy-addr@2.0.7:

--- a/scripts/ops/deploy-integrations-prod.sh
+++ b/scripts/ops/deploy-integrations-prod.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  printf '%s\n' "Usage: $0 --host HOST [--user USER] [--port PORT] [--remote-path PATH] [--image-tag TAG] [--dry-run]"
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+HOST="${PROD_SSH_HOST:-}"
+USER="${PROD_SSH_USER:-root}"
+PORT="${PROD_SSH_PORT:-22}"
+REMOTE_PATH="${PROD_REMOTE_PATH:-/workspace/shadow}"
+IMAGE_REGISTRY="${PROD_IMAGE_REGISTRY:-${SHADOW_IMAGE_REGISTRY:-ghcr.io}}"
+IMAGE_NAMESPACE="${PROD_IMAGE_NAMESPACE:-${SHADOW_IMAGE_NAMESPACE:-buggyblues}}"
+IMAGE_TAG="${INTEGRATIONS_IMAGE_TAG:-${IMAGE_TAG:-latest}}"
+DRY_RUN=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --user)
+      USER="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --remote-path)
+      REMOTE_PATH="$2"
+      shift 2
+      ;;
+    --image-registry)
+      IMAGE_REGISTRY="$2"
+      shift 2
+      ;;
+    --image-namespace)
+      IMAGE_NAMESPACE="$2"
+      shift 2
+      ;;
+    --image-tag)
+      IMAGE_TAG="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$HOST" ]; then
+  printf 'Missing deploy host. Pass --host or set PROD_SSH_HOST.\n' >&2
+  exit 2
+fi
+
+bash "$REPO_ROOT/scripts/ops/verify-prod-no-build.sh"
+
+TARGET="${USER}@${HOST}"
+SSH_COMMON=(
+  -o ConnectTimeout="${PROD_SSH_CONNECT_TIMEOUT:-20}"
+  -o ConnectionAttempts="${PROD_SSH_CONNECTION_ATTEMPTS:-3}"
+  -o ServerAliveInterval=30
+  -o ServerAliveCountMax=4
+  -o StrictHostKeyChecking=accept-new
+)
+SSH_CMD=(ssh "${SSH_COMMON[@]}")
+SCP_CMD=(scp "${SSH_COMMON[@]}")
+SSH_RETRIES="${PROD_SSH_RETRIES:-3}"
+SSH_RETRY_DELAY="${PROD_SSH_RETRY_DELAY:-10}"
+
+if [ "$PORT" != "22" ]; then
+  SSH_CMD+=(-p "$PORT")
+  SCP_CMD+=(-P "$PORT")
+fi
+
+KEY_PATH="${PROD_SSH_KEY_PATH:-${SSH_KEY_PATH:-}}"
+if [ -n "$KEY_PATH" ]; then
+  SSH_CMD+=(-i "$KEY_PATH")
+  SCP_CMD+=(-i "$KEY_PATH")
+fi
+
+if [ -n "${SSHPASS:-}" ] && [ -z "$KEY_PATH" ]; then
+  if ! command -v sshpass >/dev/null 2>&1; then
+    printf 'SSHPASS is set, but sshpass is not installed.\n' >&2
+    exit 127
+  fi
+  SSH_CMD=(sshpass -e "${SSH_CMD[@]}")
+  SCP_CMD=(sshpass -e "${SCP_CMD[@]}")
+fi
+
+quote() {
+  printf '%q' "$1"
+}
+
+retry_cmd() {
+  attempt=1
+
+  while :; do
+    if "$@"; then
+      return 0
+    else
+      status="$?"
+    fi
+
+    if [ "$attempt" -ge "$SSH_RETRIES" ]; then
+      return "$status"
+    fi
+
+    printf 'Command failed with exit %s; retrying in %ss (%s/%s).\n' "$status" "$SSH_RETRY_DELAY" "$attempt" "$SSH_RETRIES" >&2
+    sleep "$SSH_RETRY_DELAY"
+    attempt=$((attempt + 1))
+  done
+}
+
+remote_run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '[dry-run] ssh %s %s\n' "$TARGET" "$*"
+    return 0
+  fi
+
+  retry_cmd "${SSH_CMD[@]}" "$TARGET" "$@"
+}
+
+remote_path_q="$(quote "$REMOTE_PATH")"
+
+printf 'Deploy target: %s@<host>:%s\n' "$USER" "$REMOTE_PATH"
+printf 'Integrations tag: %s\n' "$IMAGE_TAG"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '[dry-run] would copy integrations compose file to %s\n' "$TARGET"
+else
+  remote_run "mkdir -p ${remote_path_q}/integrations"
+  retry_cmd "${SCP_CMD[@]}" \
+    "$REPO_ROOT/integrations/docker-compose.prod.yaml" \
+    "$TARGET:$REMOTE_PATH/integrations/docker-compose.prod.yaml"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '[dry-run] would deploy integrations on %s\n' "$TARGET"
+  exit 0
+fi
+
+"${SSH_CMD[@]}" "$TARGET" \
+  "REMOTE_PATH=$(quote "$REMOTE_PATH") IMAGE_REGISTRY=$(quote "$IMAGE_REGISTRY") IMAGE_NAMESPACE=$(quote "$IMAGE_NAMESPACE") IMAGE_TAG=$(quote "$IMAGE_TAG") bash -s" <<'REMOTE'
+set -euo pipefail
+
+cd "$REMOTE_PATH"
+
+compose() {
+  if docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose "$@"
+  else
+    printf 'docker compose or docker-compose is required on the remote host.\n' >&2
+    return 127
+  fi
+}
+
+upsert_env() {
+  key="$1"
+  value="$2"
+  file=".env"
+  tmp="$(mktemp)"
+
+  if [ ! -f "$file" ]; then
+    printf 'Missing %s/%s. Create it before deployment.\n' "$REMOTE_PATH" "$file" >&2
+    exit 1
+  fi
+
+  awk -v key="$key" -v value="$value" '
+    BEGIN { replaced = 0 }
+    $0 ~ "^" key "=" {
+      print key "=" value
+      replaced = 1
+      next
+    }
+    { print }
+    END {
+      if (replaced == 0) {
+        print key "=" value
+      }
+    }
+  ' "$file" > "$tmp"
+
+  cat "$tmp" > "$file"
+  rm -f "$tmp"
+}
+
+upsert_env SHADOW_IMAGE_REGISTRY "$IMAGE_REGISTRY"
+upsert_env SHADOW_IMAGE_NAMESPACE "$IMAGE_NAMESPACE"
+upsert_env SHADOW_INTEGRATIONS_IMAGE_TAG "$IMAGE_TAG"
+
+compose --env-file .env -f integrations/docker-compose.prod.yaml pull integrations-runtime
+compose --env-file .env -f integrations/docker-compose.prod.yaml up -d --remove-orphans --no-build integrations-runtime
+
+docker image prune -f
+
+compose --env-file .env -f integrations/docker-compose.prod.yaml ps integrations-runtime
+REMOTE

--- a/scripts/ops/verify-prod-no-build.sh
+++ b/scripts/ops/verify-prod-no-build.sh
@@ -19,8 +19,10 @@ done
 
 for file in \
   "$REPO_ROOT/scripts/ops/deploy-prod.sh" \
+  "$REPO_ROOT/scripts/ops/deploy-integrations-prod.sh" \
   "$REPO_ROOT/scripts/ops/migrate-prod-data.sh" \
-  "$REPO_ROOT/.github/workflows/deploy-production.yml"
+  "$REPO_ROOT/.github/workflows/deploy-production.yml" \
+  "$REPO_ROOT/.github/workflows/deploy-integrations-production.yml"
 do
   if grep -nE '(^|[[:space:]])--build($|[[:space:]])|docker[[:space:]]+build($|[[:space:]])|docker-compose[[:space:]]+build($|[[:space:]])|docker[[:space:]]+compose[[:space:]]+build($|[[:space:]])' "$file" >&2; then
     printf 'Production deploy path must not request image builds: %s\n' "${file#$REPO_ROOT/}" >&2


### PR DESCRIPTION
## Summary
- add a combined shadow-integrations runtime for lightweight integrations
- add publish and production deploy workflows for the integrations runtime
- deploy production integrations with pull/up --no-build and document Nginx/DNS requirements

## Verification
- pnpm -C integrations/runtime typecheck
- pnpm -C packages/sdk typecheck
- pnpm -C packages/sdk test -- server-app
- bash scripts/ops/verify-prod-no-build.sh
- docker compose -f integrations/docker-compose.prod.yaml config --quiet
- production smoke: integrations runtime, HTTPS manifests, SPA shells, cache headers, WarBuddy upgrade path