### PR TITLE
[codex] Enable default Buddy collaboration and polish Inbox UX

### DIFF
--- a/apps/cloud/__tests__/runtimes/runtime-package-smoke.test.ts
+++ b/apps/cloud/__tests__/runtimes/runtime-package-smoke.test.ts
@@ -92,8 +92,13 @@ describe('runner runtime package smoke checks', () => {
     const shadowCliSkill = runtimeFiles(pkg.configData)[
       '/home/shadow/.openclaw/skills/shadowob/SKILL.md'
     ]
+    const serverAppSkill = runtimeFiles(pkg.configData)[
+      '/home/shadow/.openclaw/skills/shadow-server-app/SKILL.md'
+    ]
     expect(shadowCliSkill).toContain('shadowob')
     expectShadowCliInboxRouting(shadowCliSkill)
+    expect(serverAppSkill).toContain('shadowob app discover')
+    expect(serverAppSkill).toContain('shadowob app call')
     expect(pkg.configData['SOUL.md']).toContain('shadowob inbox list')
     expect(pkg.configData['SOUL.md']).toContain('shadowob inbox enqueue')
     expect(pkg.configData['SOUL.md']).toContain('not statically bound to one server')
@@ -122,9 +127,37 @@ describe('runner runtime package smoke checks', () => {
     expect(pkg.configData['config.json']).toBeUndefined()
     expect(JSON.parse(pkg.configData['runtime-extensions.json'] ?? '{}').openclaw).toBeUndefined()
     expect(() => parseToml(files['/home/shadow/.cc-connect/config.toml'] ?? '')).not.toThrow()
+    const ccConnectConfig = parseToml(files['/home/shadow/.cc-connect/config.toml'] ?? '') as {
+      projects?: Array<{ agent?: { options?: { system_prompt?: string } } }>
+    }
+    expect(ccConnectConfig.projects?.[0]?.agent?.options?.system_prompt).toContain(
+      'shadowob app discover',
+    )
+    expect(ccConnectConfig.projects?.[0]?.agent?.options?.system_prompt).toContain(
+      'Shadow Buddy collaboration rules',
+    )
     expect(files['/workspace/AGENTS.md']).toContain(`${runtime} smoke`)
+    expect(files['/workspace/SOUL.md']).toContain('shadowob app discover')
     expect(files['/workspace/.agents/skills/shadowob/SKILL.md']).toContain('shadowob')
     expectShadowCliInboxRouting(files['/workspace/.agents/skills/shadowob/SKILL.md'])
+    expect(files['/workspace/.agents/skills/shadow-server-app/SKILL.md']).toContain(
+      'shadowob app call',
+    )
+    if (runtime === 'claude-code') {
+      expect(files['/workspace/.claude/skills/shadow-server-app/SKILL.md']).toContain(
+        'shadowob app discover',
+      )
+    }
+    if (runtime === 'codex') {
+      expect(files['/home/shadow/.codex/skills/shadow-server-app/SKILL.md']).toContain(
+        'shadowob app discover',
+      )
+    }
+    if (runtime === 'opencode') {
+      expect(files['/workspace/.opencode/skills/shadow-server-app/SKILL.md']).toContain(
+        'shadowob app discover',
+      )
+    }
     const slashCommands = JSON.parse(files['/etc/shadowob/slash-commands.json'] ?? '[]') as Array<{
       name: string
       packId: string
@@ -220,6 +253,7 @@ describe('runner runtime package smoke checks', () => {
     expect(files['/workspace/.agents/skills/shadow-server-app/SKILL.md']).toContain(
       'shadowob app call',
     )
+    expect(files['/workspace/SOUL.md']).toContain('shadowob app discover')
     expect(files['/home/shadow/.hermes/.env']).toContain('SHADOWOB_TOKEN=${SHADOW_TOKEN_BUDDY_1}')
     expect(files['/home/shadow/.hermes/.env']).toContain('HERMES_YOLO_MODE=true')
     expect(JSON.stringify(pkg.configData)).not.toContain(SHADOW_TOKEN)

--- a/apps/cloud/src/config/openclaw-builder.ts
+++ b/apps/cloud/src/config/openclaw-builder.ts
@@ -788,6 +788,24 @@ function appendPromptSection(existing: string | undefined, addition: string): st
   return `${trimmedExisting}\n\n---\n\n${trimmedAddition}`
 }
 
+export function collectPluginBuildPrompts(
+  agent: AgentDeployment,
+  config: CloudConfig,
+  cwd?: string,
+  env?: RuntimeEnv,
+): string {
+  let prompt = ''
+  forEachEnabledPlugin(agent, config, cwd, env, ({ pluginDef, context }) => {
+    for (const fn of pluginDef._hooks.buildPrompt) {
+      const addition = fn(context)
+      if (addition) {
+        prompt = appendPromptSection(prompt, addition)
+      }
+    }
+  })
+  return prompt
+}
+
 function applyPluginPromptPipeline(
   agent: AgentDeployment,
   config: CloudConfig,
@@ -795,14 +813,10 @@ function applyPluginPromptPipeline(
   cwd?: string,
   env?: RuntimeEnv,
 ): void {
-  forEachEnabledPlugin(agent, config, cwd, env, ({ pluginDef, context }) => {
-    for (const fn of pluginDef._hooks.buildPrompt) {
-      const addition = fn(context)
-      if (addition) {
-        agentEntry.instructions = appendPromptSection(agentEntry.instructions, addition)
-      }
-    }
-  })
+  const prompt = collectPluginBuildPrompts(agent, config, cwd, env)
+  if (prompt) {
+    agentEntry.instructions = appendPromptSection(agentEntry.instructions, prompt)
+  }
 }
 
 function applyRuntimeContext(

--- a/apps/cloud/src/infra/runtime-package.test.ts
+++ b/apps/cloud/src/infra/runtime-package.test.ts
@@ -123,6 +123,12 @@ describe('buildAgentRuntimePackage OpenClaw compatibility', () => {
     const files = runtimeFiles(pkg)
     expect(files['/home/shadow/.openclaw/skills/shadowob/SKILL.md']).toBe(shadowobCliSkill())
     expectShadowCliInboxRouting(files['/home/shadow/.openclaw/skills/shadowob/SKILL.md'] ?? '')
+    expect(files['/home/shadow/.openclaw/skills/shadow-server-app/SKILL.md']).toContain(
+      'shadowob app discover',
+    )
+    expect(files['/workspace/.agents/skills/shadow-server-app/SKILL.md']).toContain(
+      'shadowob app call',
+    )
     expectShadowCliAuth(files)
     expect(JSON.parse(files['/etc/shadowob/slash-commands.json'] ?? '[]')).toEqual(
       expect.arrayContaining([
@@ -164,11 +170,32 @@ describe('buildAgentRuntimePackage native runner adapters', () => {
     expect(ccConnectConfig).toContain('token = "${SHADOW_TOKEN_BUDDY_1}"')
     expect(ccConnectConfig).toContain('server_url = "${SHADOW_SERVER_URL}"')
     expect(ccConnectConfig).toContain('slash_commands_path = "${SHADOW_SLASH_COMMANDS_PATH}"')
+    expect(ccConnectConfig).toContain('shadowob app discover')
+    expect(ccConnectConfig).toContain('shadowob app call')
     expect(() => parseToml(ccConnectConfig ?? '')).not.toThrow()
 
     const files = runtimeFiles(pkg)
+    expect(files['/workspace/SOUL.md']).toContain('shadowob app discover')
     expect(files['/workspace/.agents/skills/shadowob/SKILL.md']).toBe(shadowobCliSkill())
     expectShadowCliInboxRouting(files['/workspace/.agents/skills/shadowob/SKILL.md'] ?? '')
+    expect(files['/workspace/.agents/skills/shadow-server-app/SKILL.md']).toContain(
+      'shadowob app call',
+    )
+    if (runtime === 'claude-code') {
+      expect(files['/workspace/.claude/skills/shadow-server-app/SKILL.md']).toContain(
+        'shadowob app discover',
+      )
+    }
+    if (runtime === 'codex') {
+      expect(files['/home/shadow/.codex/skills/shadow-server-app/SKILL.md']).toContain(
+        'shadowob app discover',
+      )
+    }
+    if (runtime === 'opencode') {
+      expect(files['/workspace/.opencode/skills/shadow-server-app/SKILL.md']).toContain(
+        'shadowob app discover',
+      )
+    }
     expectShadowCliAuth(files)
     const runtimeExtensions = JSON.parse(pkg.configData['runtime-extensions.json'] ?? '{}')
     expect(runtimeExtensions.openclaw).toBeUndefined()
@@ -279,6 +306,13 @@ describe('buildAgentRuntimePackage native runner adapters', () => {
     expect(Object.keys(files).some((path) => path.includes('/plugins/shadowob/'))).toBe(false)
     expect(files['/home/shadow/.hermes/skills/shadowob/SKILL.md']).toBe(shadowobCliSkill())
     expectShadowCliInboxRouting(files['/home/shadow/.hermes/skills/shadowob/SKILL.md'] ?? '')
+    expect(files['/home/shadow/.hermes/skills/shadow-server-app/SKILL.md']).toContain(
+      'shadowob app discover',
+    )
+    expect(files['/workspace/.agents/skills/shadow-server-app/SKILL.md']).toContain(
+      'shadowob app call',
+    )
+    expect(files['/workspace/SOUL.md']).toContain('shadowob app discover')
     expectShadowCliAuth(files)
     expect(JSON.parse(files['/etc/shadowob/slash-commands.json'] ?? '[]')).toEqual(
       expect.arrayContaining([

--- a/apps/cloud/src/infra/runtime-package.ts
+++ b/apps/cloud/src/infra/runtime-package.ts
@@ -1,5 +1,6 @@
 import {
   collectPluginBuildEnvVars,
+  collectPluginBuildPrompts,
   collectPluginRuntimeEnvOmitKeys,
   collectPluginRuntimeExtensions,
 } from '../config/openclaw-builder.js'
@@ -120,6 +121,24 @@ function runtimePackageEnvDefaults(options: {
   return env
 }
 
+function agentWithAdditionalSystemPrompt(
+  agent: AgentDeployment,
+  additionalPrompt: string,
+): AgentDeployment {
+  const trimmed = additionalPrompt.trim()
+  if (!trimmed) return agent
+
+  const identity = agent.identity ?? {}
+  const existingPrompt = identity.systemPrompt?.trim()
+  return {
+    ...agent,
+    identity: {
+      ...identity,
+      systemPrompt: existingPrompt ? `${existingPrompt}\n\n---\n\n${trimmed}` : trimmed,
+    },
+  }
+}
+
 export function buildAgentRuntimePackage(options: {
   agent: AgentDeployment
   config: CloudConfig
@@ -137,6 +156,13 @@ export function buildAgentRuntimePackage(options: {
   }
   const runtimeEnvOmitKeys = collectPluginRuntimeEnvOmitKeys(agent, config, cwd, runtimeEnv)
   const runtimeExtensions = collectPluginRuntimeExtensions(agent, config, cwd, runtimeEnv)
+  const runtimeAgent =
+    runtime.runtimeKind === 'openclaw'
+      ? agent
+      : agentWithAdditionalSystemPrompt(
+          agent,
+          collectPluginBuildPrompts(agent, config, cwd, runtimeEnv),
+        )
 
   const mergedEnv: Record<string, string> = {
     ...collectPluginBuildEnvVars(agent, config, cwd, runtimeEnv),
@@ -154,7 +180,7 @@ export function buildAgentRuntimePackage(options: {
   )
 
   const runtimeArtifacts = runtime.buildPackage({
-    agent,
+    agent: runtimeAgent,
     config,
     cwd,
     runtimeEnv,

--- a/apps/cloud/src/runtimes/cc-connect-package.ts
+++ b/apps/cloud/src/runtimes/cc-connect-package.ts
@@ -8,6 +8,7 @@ import type {
 import {
   addShadowobCliAuth,
   addShadowobSkill,
+  addShadowServerAppSkill,
   buildIdentityWorkspaceFiles,
   CC_CONNECT_CONFIG_PATH,
   envPlaceholder,
@@ -36,8 +37,32 @@ export interface CcConnectPackageOptions {
   shadowSlashCommands?: unknown[]
 }
 
+const BUDDY_COLLABORATION_SYSTEM_PROMPT = [
+  'Shadow Buddy collaboration rules:',
+  '- Treat a Buddy collaboration as a bounded IM conversation, not an open-ended work session.',
+  '- Speak only when you add a distinct useful point. If another Buddy already covered it, stay brief or stay silent.',
+  '- If you only agree, use a structured Shadow reaction action when available; otherwise stay silent instead of posting acknowledgement text.',
+  '- Later collaboration turns may be routed into a Shadow thread by the platform. Do not announce thread routing yourself.',
+  '- Match the density of the triggering message. Short chat gets a short reply; long analysis requires an explicit user pull.',
+  '- Do not run tools, create memories, create skills, write files, promote tasks, or run demos unless a human explicitly asks for current action.',
+  '- Keep runtime logs, tool progress, memory updates, skill views, and self-improvement reviews private. Do not post them as chat messages.',
+  '- If the user says to stop, stay quiet, not implement, or just discuss, stop the action chain immediately.',
+].join('\n')
+
 function opencodeModelRef(providerId: string, model: string): string {
   return model.startsWith(`${providerId}/`) ? model : `${providerId}/${model}`
+}
+
+function agentSystemPrompt(agent: AgentDeployment): string | undefined {
+  const prompt = [
+    agent.identity?.personality,
+    agent.identity?.systemPrompt,
+    BUDDY_COLLABORATION_SYSTEM_PROMPT,
+  ]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join('\n\n')
+    .trim()
+  return prompt || undefined
 }
 
 function buildCcConnectConfig(options: {
@@ -53,6 +78,8 @@ function buildCcConnectConfig(options: {
   const baseAgentOptions: TomlTable = {
     work_dir: WORKSPACE_DIR,
   }
+  const systemPrompt = agentSystemPrompt(agent)
+  if (systemPrompt) baseAgentOptions.system_prompt = systemPrompt
   const model = modelName(agent)
   const effort = reasoningEffort(agent)
   if (model) baseAgentOptions.model = model
@@ -150,6 +177,7 @@ function buildCcConnectRuntimeFiles(options: {
     ...(options.nativeFiles ?? {}),
   }
   addShadowobSkill(files, 'cc-connect', agent.runtime)
+  addShadowServerAppSkill(files, 'cc-connect', agent.runtime)
   addShadowobCliAuth(files, options.runtimeExtensions)
   appendTemplateRoutineFiles(files, options.config, agent, 'cc-connect', options.runtimeExtensions)
   return files

--- a/apps/cloud/src/runtimes/openclaw.ts
+++ b/apps/cloud/src/runtimes/openclaw.ts
@@ -13,6 +13,7 @@ import { type RuntimeAdapter, registerRuntime } from './index.js'
 import {
   addShadowobCliAuth,
   addShadowobSkill,
+  addShadowServerAppSkill,
   hasRuntimeExtensions,
   json,
   OPENCLAW_SKILLS_DIR,
@@ -67,6 +68,7 @@ const openclawAdapter: RuntimeAdapter = {
       [SHADOW_SLASH_COMMANDS_PATH]: json(openClawSlashCommands),
     }
     addShadowobSkill(runtimeFiles, 'openclaw', context.agent.runtime)
+    addShadowServerAppSkill(runtimeFiles, 'openclaw', context.agent.runtime)
     addShadowobCliAuth(runtimeFiles, context.runtimeExtensions)
     appendTemplateRoutineFiles(
       runtimeFiles,

--- a/apps/mobile/app/(main)/servers/[serverSlug]/channels/[channelId].tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/channels/[channelId].tsx
@@ -144,7 +144,7 @@ type PendingChatFile = {
   transcriptSource?: 'client' | 'runtime'
 }
 
-type TaskDraftPriority = 'low' | 'normal' | 'high' | 'urgent'
+type TaskDraftPriority = 'low' | 'normal' | 'medium' | 'high'
 
 function taskDraftToInput(value: string) {
   const lines = value
@@ -687,7 +687,6 @@ export default function ChannelViewScreen() {
   const channel = bootstrap?.channel ?? channelFallback
   const isDirectChannel = channel?.kind === 'dm' || channel?.serverId === null
   const isInboxChannel = channel?.topic?.startsWith('shadow:buddy-inbox:') ?? false
-  const isInboxTaskMode = isInboxChannel && inboxViewMode === 'tasks'
   const { data: accessFallback } = useQuery({
     queryKey: ['channel-access', channelId],
     queryFn: () =>
@@ -1146,10 +1145,9 @@ export default function ChannelViewScreen() {
   const timelineBaseMessages = useMemo(() => {
     return buildBuddyInboxViewMessages(messages, {
       isInboxChannel,
-      mode: inboxViewMode,
       taskFilter: inboxTaskFilter,
     })
-  }, [inboxTaskFilter, inboxViewMode, isInboxChannel, messages])
+  }, [inboxTaskFilter, isInboxChannel, messages])
 
   const buildThreadName = useCallback(
     (message: Message) => {
@@ -2798,7 +2796,7 @@ export default function ChannelViewScreen() {
             channelId={channelId!}
             serverSlug={serverSlug}
             allMessages={messages}
-            taskReplies={isInboxTaskMode ? taskRepliesByMessageId.get(item.data.id) : undefined}
+            taskReplies={isInboxChannel ? taskRepliesByMessageId.get(item.data.id) : undefined}
             isGrouped={isGrouped}
             selectionMode={selectionMode}
             isSelected={selectedMessageIds.has(item.data.id)}
@@ -2821,7 +2819,7 @@ export default function ChannelViewScreen() {
       threadsByParentId,
       messages,
       latestMessageId,
-      isInboxTaskMode,
+      isInboxChannel,
       taskRepliesByMessageId,
       timeline,
       highlightMessageId,
@@ -2991,25 +2989,21 @@ export default function ChannelViewScreen() {
       ) : timeline.length === 0 ? (
         <Pressable style={styles.emptyState} onPress={Keyboard.dismiss}>
           <EmptyState
-            icon={isInboxChannel ? (isInboxTaskMode ? ListTodo : MessageSquare) : Hash}
+            icon={isInboxChannel ? ListTodo : Hash}
             title={
               isInboxChannel
-                ? isInboxTaskMode
-                  ? inboxTaskFilter === 'all'
-                    ? t('inbox.empty.allTitle')
-                    : t('inbox.empty.filterTitle')
-                  : t('inbox.empty.chatTitle')
+                ? inboxTaskFilter === 'all'
+                  ? t('inbox.empty.allTitle')
+                  : t('inbox.empty.filterTitle')
                 : t('chat.welcomeChannel', {
                     channelName: channel?.name ?? t('chat.channelFallback'),
                   })
             }
             description={
               isInboxChannel
-                ? isInboxTaskMode
-                  ? inboxTaskFilter === 'all'
-                    ? t('inbox.empty.allHint')
-                    : t('inbox.empty.filterHint')
-                  : t('inbox.empty.chatHint')
+                ? inboxTaskFilter === 'all'
+                  ? t('inbox.empty.allHint')
+                  : t('inbox.empty.filterHint')
                 : t('chat.welcomeStart')
             }
           />

--- a/apps/mobile/src/components/chat/chat-composer.tsx
+++ b/apps/mobile/src/components/chat/chat-composer.tsx
@@ -356,8 +356,8 @@ interface ChatComposerProps {
   onInboxTaskFilterChange?: (filter: BuddyInboxTaskFilter) => void
   taskDraft?: string
   onTaskDraftChange?: (text: string) => void
-  taskPriority?: 'low' | 'normal' | 'high' | 'urgent'
-  onTaskPriorityChange?: (priority: 'low' | 'normal' | 'high' | 'urgent') => void
+  taskPriority?: 'low' | 'normal' | 'medium' | 'high'
+  onTaskPriorityChange?: (priority: 'low' | 'normal' | 'medium' | 'high') => void
   taskTags?: string
   onTaskTagsChange?: (text: string) => void
   creatingTask?: boolean
@@ -438,9 +438,9 @@ const RECORDING_PREVIEW_PEAKS = [
   22, 36, 18, 44, 72, 30, 86, 58, 28, 64, 46, 24, 52, 34, 26, 42, 28, 36, 24, 32, 26, 30,
 ]
 
-type TaskDraftPriority = 'low' | 'normal' | 'high' | 'urgent'
+type TaskDraftPriority = 'low' | 'normal' | 'medium' | 'high'
 
-const taskPriorityOptions: TaskDraftPriority[] = ['normal', 'high', 'urgent', 'low']
+const taskPriorityOptions: TaskDraftPriority[] = ['low', 'normal', 'medium', 'high']
 
 function getTaskDraftTitle(value: string) {
   return value
@@ -815,9 +815,9 @@ export const ChatComposer = memo(function ChatComposer({
               )
             })}
           </View>
-          {isInboxTaskMode && onInboxTaskFilterChange && (
+          {onInboxTaskFilterChange && (
             <View style={[styles.inboxSegment, { backgroundColor: colors.inputBackground }]}>
-              {(['all', 'open', 'done'] as const).map((filter) => {
+              {(['all', 'done', 'open'] as const).map((filter) => {
                 const selected = inboxTaskFilter === filter
                 return (
                   <Pressable
@@ -892,6 +892,14 @@ export const ChatComposer = memo(function ChatComposer({
           >
             {taskPriorityOptions.map((priority) => {
               const selected = taskPriority === priority
+              const priorityColor =
+                priority === 'high'
+                  ? colors.error
+                  : priority === 'medium'
+                    ? colors.warning
+                    : priority === 'normal'
+                      ? colors.success
+                      : colors.textMuted
               return (
                 <Pressable
                   key={priority}
@@ -907,7 +915,7 @@ export const ChatComposer = memo(function ChatComposer({
                   <Text
                     style={[
                       styles.taskPriorityButtonText,
-                      { color: selected ? colors.primary : colors.textMuted },
+                      { color: selected ? priorityColor : colors.textMuted },
                     ]}
                   >
                     {t(`inbox.task.priority.${priority}`)}

--- a/apps/mobile/src/components/chat/message-bubble.tsx
+++ b/apps/mobile/src/components/chat/message-bubble.tsx
@@ -639,13 +639,13 @@ function TaskCardMobile({
           : colors.primary
   const priority = card.priority ?? 'normal'
   const priorityColor =
-    priority === 'urgent'
+    priority === 'high'
       ? colors.error
-      : priority === 'high'
+      : priority === 'medium'
         ? colors.warning
-        : priority === 'low'
-          ? colors.textMuted
-          : colors.primary
+        : priority === 'normal'
+          ? colors.success
+          : colors.textMuted
   const assigneeLabel = card.assignee?.label ?? t('inbox.unassigned')
   const tags = useMemo(() => (card.tags ?? []).map(taskTagLabel).filter(Boolean), [card.tags])
   const app = useMemo(() => taskSourceMeta(card), [card])

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -550,8 +550,8 @@
       "priority": {
         "low": "Low",
         "normal": "Normal",
-        "high": "High",
-        "urgent": "Urgent"
+        "medium": "Medium",
+        "high": "High"
       }
     },
     "action": {

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -550,8 +550,8 @@
       "priority": {
         "low": "低",
         "normal": "通常",
-        "high": "高",
-        "urgent": "緊急"
+        "medium": "中",
+        "high": "高"
       }
     },
     "action": {

--- a/apps/mobile/src/i18n/locales/ko.json
+++ b/apps/mobile/src/i18n/locales/ko.json
@@ -550,8 +550,8 @@
       "priority": {
         "low": "낮음",
         "normal": "보통",
-        "high": "높음",
-        "urgent": "긴급"
+        "medium": "중간",
+        "high": "높음"
       }
     },
     "action": {

--- a/apps/mobile/src/i18n/locales/zh-CN.json
+++ b/apps/mobile/src/i18n/locales/zh-CN.json
@@ -547,10 +547,10 @@
       "sendReply": "发送回复",
       "replyFailed": "发送回复失败",
       "priority": {
-        "low": "低优",
-        "normal": "普通",
-        "high": "高优",
-        "urgent": "紧急"
+        "low": "低",
+        "normal": "一般",
+        "medium": "中",
+        "high": "高"
       }
     },
     "action": {

--- a/apps/mobile/src/i18n/locales/zh-TW.json
+++ b/apps/mobile/src/i18n/locales/zh-TW.json
@@ -548,10 +548,10 @@
       "sendReply": "傳送回覆",
       "replyFailed": "傳送回覆失敗",
       "priority": {
-        "low": "低優",
-        "normal": "普通",
-        "high": "高優",
-        "urgent": "緊急"
+        "low": "低",
+        "normal": "一般",
+        "medium": "中",
+        "high": "高"
       }
     },
     "action": {

--- a/apps/server/__tests__/channel-slash-commands.test.ts
+++ b/apps/server/__tests__/channel-slash-commands.test.ts
@@ -293,6 +293,61 @@ describe('channel Buddy reply policy routes', () => {
     ])
   })
 
+  it('defaults custom Buddy policies to collaborative chat enabled', async () => {
+    const agentPolicyService = {
+      upsertPolicies: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const agentService = {
+      getById: vi.fn().mockResolvedValue({
+        id: 'agent-1',
+        userId: 'bot-user-1',
+        ownerId: 'owner-1',
+      }),
+    }
+    const channelService = {
+      getById: vi.fn().mockResolvedValue({ id: 'channel-1', kind: 'server', serverId: 'server-1' }),
+    }
+    const rentalService = {
+      canUseAgent: vi.fn().mockResolvedValue({ canUse: true, role: 'tenant' }),
+    }
+
+    const app = createChannelHandler(
+      createMockContainer({
+        agentPolicyService,
+        agentService,
+        channelService,
+        rentalService,
+      }),
+    )
+
+    const res = await app.request('/channels/channel-1/agents/agent-1/policy', {
+      method: 'PUT',
+      headers: { ...authHeaders('tenant-1'), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'custom',
+        config: {
+          mentionOnly: true,
+        },
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(agentPolicyService.upsertPolicies).toHaveBeenCalledWith('agent-1', [
+      {
+        serverId: 'server-1',
+        channelId: 'channel-1',
+        listen: true,
+        reply: true,
+        mentionOnly: true,
+        config: {
+          mentionOnly: true,
+          replyToBuddy: true,
+          maxBuddyTurns: 4,
+        },
+      },
+    ])
+  })
+
   it('rejects policy updates from users who are not the Buddy owner or tenant', async () => {
     const agentPolicyService = {
       upsertPolicies: vi.fn(),
@@ -369,7 +424,7 @@ describe('channel Buddy reply policy routes', () => {
       listen: true,
       reply: false,
       mentionOnly: true,
-      config: { replyToBuddy: true },
+      config: { replyToBuddy: true, maxBuddyTurns: 4 },
     })
   })
 })

--- a/apps/server/src/db/migrations/0097_buddy_inbox_task_priority_levels.sql
+++ b/apps/server/src/db/migrations/0097_buddy_inbox_task_priority_levels.sql
@@ -1,0 +1,1 @@
+-- buddy inbox task priority metadata level contract

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -680,6 +680,13 @@
       "when": 1780997429000,
       "tag": "0096_server_app_integrations_server_app_key_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 97,
+      "version": "7",
+      "when": 1781040686000,
+      "tag": "0097_buddy_inbox_task_priority_levels",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/messages.ts
+++ b/apps/server/src/db/schema/messages.ts
@@ -195,7 +195,7 @@ export interface TaskMessageCardMetadata {
   title: string
   body?: string
   status: MessageCardStatus
-  priority?: 'low' | 'normal' | 'high' | 'urgent'
+  priority?: 'low' | 'normal' | 'medium' | 'high'
   tags?: TaskMessageCardTagMetadata[]
   app?: MessageCardAppMetadata
   assignee?: {

--- a/apps/server/src/handlers/buddy-inbox.handler.ts
+++ b/apps/server/src/handlers/buddy-inbox.handler.ts
@@ -81,7 +81,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const enqueueTaskSchema = z.object({
   title: z.string().min(1).max(180),
   body: z.string().max(8000).optional(),
-  priority: z.enum(['low', 'normal', 'high', 'urgent']).optional(),
+  priority: z.enum(['low', 'normal', 'medium', 'high']).optional(),
   tags: z
     .array(
       z.union([
@@ -138,7 +138,7 @@ const promoteMessageSchema = z.object({
   serverId: z.string().min(1),
   agentId: z.string().uuid(),
   title: z.string().min(1).max(180).optional(),
-  priority: z.enum(['low', 'normal', 'high', 'urgent']).optional(),
+  priority: z.enum(['low', 'normal', 'medium', 'high']).optional(),
 })
 
 const admissionModeSchema = z.enum(['allow', 'deny', 'first_time', 'every_time'])

--- a/apps/server/src/handlers/channel.handler.ts
+++ b/apps/server/src/handlers/channel.handler.ts
@@ -1145,11 +1145,12 @@ export function createChannelHandler(container: AppContainer) {
           if (body.config?.keywords?.length) {
             config.keywords = body.config.keywords
           }
-          if (typeof body.config?.replyToBuddy === 'boolean') {
-            config.replyToBuddy = body.config.replyToBuddy
-          }
-          if (typeof body.config?.maxBuddyTurns === 'number') {
-            config.maxBuddyTurns = body.config.maxBuddyTurns
+          if (body.config?.replyToBuddy === false) {
+            config.replyToBuddy = false
+          } else {
+            config.replyToBuddy = true
+            config.maxBuddyTurns =
+              typeof body.config?.maxBuddyTurns === 'number' ? body.config.maxBuddyTurns : 4
           }
           if (body.config?.buddyBlacklist?.length) {
             config.buddyBlacklist = body.config.buddyBlacklist
@@ -1223,7 +1224,7 @@ export function createChannelHandler(container: AppContainer) {
         mentionOnly: channelPolicy.mentionOnly,
         listen: channelPolicy.listen,
         reply: channelPolicy.reply,
-        config: channelPolicy.config ?? {},
+        config: { replyToBuddy: true, maxBuddyTurns: 4, ...(channelPolicy.config ?? {}) },
       })
     }
 
@@ -1232,7 +1233,7 @@ export function createChannelHandler(container: AppContainer) {
       mentionOnly: serverDefault?.mentionOnly ?? true,
       listen: serverDefault?.listen ?? true,
       reply: serverDefault?.reply ?? true,
-      config: serverDefault?.config ?? {},
+      config: { replyToBuddy: true, maxBuddyTurns: 4, ...(serverDefault?.config ?? {}) },
     })
   })
 

--- a/apps/server/src/services/agent-policy.service.ts
+++ b/apps/server/src/services/agent-policy.service.ts
@@ -36,6 +36,11 @@ const AGENT_POLICY_CONFIG_KEYS = new Set([
   'inboxAdmissionPending',
 ])
 
+const DEFAULT_BUDDY_COLLABORATION_CONFIG = {
+  replyToBuddy: true,
+  maxBuddyTurns: 4,
+} as const
+
 function stringArray(value: unknown, key: string): string[] | undefined {
   if (value === undefined) return undefined
   if (!Array.isArray(value) || value.length > 50) {
@@ -262,6 +267,7 @@ export class AgentPolicyService {
       reply: base?.reply ?? true,
       mentionOnly: base?.mentionOnly ?? true,
       config: {
+        ...DEFAULT_BUDDY_COLLABORATION_CONFIG,
         ...(((base?.config as Record<string, unknown> | undefined) ?? {}) as Record<
           string,
           unknown

--- a/apps/server/src/services/app-integration.service.ts
+++ b/apps/server/src/services/app-integration.service.ts
@@ -396,7 +396,7 @@ type InboxTaskOutbox = ShadowServerAppInboxTaskOutbox
 type ChannelMessageOutbox = ShadowServerAppChannelMessageOutbox
 
 const RESTRICTED_DATA_CLASSES = new Set(['financial', 'secret', 'cloud-secret'])
-const TASK_PRIORITIES = new Set(['low', 'normal', 'high', 'urgent'])
+const TASK_PRIORITIES = new Set(['low', 'normal', 'medium', 'high'])
 
 function optionalString(value: unknown) {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
@@ -457,12 +457,13 @@ function parseInboxTaskOutbox(value: unknown): InboxTaskOutbox | null {
   const title = optionalString(value.title)
   if (!title) return null
   const priority = optionalString(value.priority)
+  if (priority && !TASK_PRIORITIES.has(priority)) {
+    throw new Error('Invalid App inbox task priority')
+  }
   return {
     title,
     ...(optionalString(value.body) ? { body: optionalString(value.body) } : {}),
-    ...(priority && TASK_PRIORITIES.has(priority)
-      ? { priority: priority as InboxTaskOutbox['priority'] }
-      : {}),
+    ...(priority ? { priority: priority as InboxTaskOutbox['priority'] } : {}),
     ...(optionalString(value.agentId) ? { agentId: optionalString(value.agentId) } : {}),
     ...(optionalString(value.agentUserId)
       ? { agentUserId: optionalString(value.agentUserId) }

--- a/apps/server/src/services/buddy-inbox.service.ts
+++ b/apps/server/src/services/buddy-inbox.service.ts
@@ -31,7 +31,7 @@ import type { PolicyService } from './policy.service'
 import type { ServerService } from './server.service'
 
 type ServerMemberRole = 'owner' | 'admin' | 'member'
-type TaskPriority = 'low' | 'normal' | 'high' | 'urgent'
+type TaskPriority = 'low' | 'normal' | 'medium' | 'high'
 
 type EnqueueTaskInput = {
   title: string

--- a/apps/server/src/validators/message.schema.ts
+++ b/apps/server/src/validators/message.schema.ts
@@ -294,7 +294,7 @@ const taskMessageCardSchema = z
     title: z.string().min(1).max(180),
     body: z.string().max(8000).optional(),
     status: messageCardStatusSchema,
-    priority: z.enum(['low', 'normal', 'high', 'urgent']).optional(),
+    priority: z.enum(['low', 'normal', 'medium', 'high']).optional(),
     tags: z.array(taskMessageCardTagSchema).max(12).optional(),
     app: messageCardAppSchema.optional(),
     assignee: z

--- a/apps/web/src/components/channel/channel-sidebar.tsx
+++ b/apps/web/src/components/channel/channel-sidebar.tsx
@@ -957,6 +957,10 @@ export function ChannelSidebar({
 
   const handleSelectChannel = useCallback(
     (channel: Channel) => {
+      if (onSelectChannel) {
+        onSelectChannel(channel)
+        return
+      }
       const serverId = server?.id ?? activeServerId
       setActiveChannel(channel.id)
       if (serverId && channel.isMember !== false) {
@@ -1004,10 +1008,6 @@ export function ChannelSidebar({
         updateLastAccessed(channel.id)
       })
       setMobileView('chat')
-      if (onSelectChannel) {
-        onSelectChannel(channel)
-        return
-      }
       // Navigate to channel URL using channel ID
       navigate({
         to: '/servers/$serverSlug/channels/$channelId',
@@ -1030,6 +1030,11 @@ export function ChannelSidebar({
 
   const handleJoinVoiceChannel = useCallback(
     async (channel: Channel) => {
+      if (onSelectChannel) {
+        handleSelectChannel(channel)
+        return
+      }
+
       if (channel.isMember === false) {
         const result = await fetchApi<{
           status: 'approved' | 'pending' | 'rejected'
@@ -1061,6 +1066,7 @@ export function ChannelSidebar({
       connectedVoiceChannel?.id,
       handleSelectChannel,
       joinVoiceChannel,
+      onSelectChannel,
       queryClient,
       serverChannelKeys,
       serverSlug,
@@ -1483,6 +1489,11 @@ export function ChannelSidebar({
             type="button"
             data-channel-item
             onClick={async () => {
+              if (onSelectChannel) {
+                handleSelectChannel(ch)
+                return
+              }
+
               if (ch.isMember === false) {
                 const result = await fetchApi<{
                   status: 'approved' | 'pending' | 'rejected'

--- a/apps/web/src/components/chat/chat-area.tsx
+++ b/apps/web/src/components/chat/chat-area.tsx
@@ -32,7 +32,6 @@ import {
   Copy,
   Hash,
   Inbox,
-  ListFilter,
   Loader2,
   LockKeyhole,
   LogIn,
@@ -587,6 +586,14 @@ export function ChatArea({
     directPeer?.isBot && privateBuddyUserIds.has(directPeer.id),
   )
   const isInboxChannel = channel?.topic?.startsWith('shadow:buddy-inbox:') ?? false
+  const activeChannelSwitcherOption = useMemo(
+    () => channelSwitcher?.channels.find((item) => item.id === activeChannelId) ?? null,
+    [activeChannelId, channelSwitcher],
+  )
+  const isCopilotInboxChannel =
+    activeChannelSwitcherOption !== null &&
+    getChannelSwitcherSection(activeChannelSwitcherOption) === 'inbox'
+  const usesInboxTaskView = isInboxChannel || isCopilotInboxChannel
   const inboxAgentId = isInboxChannel ? parseBuddyInboxAgentId(channel?.topic) : null
   const { data: inboxServerMembers = [] } = useQuery({
     queryKey: ['members', activeServerId, 'inbox-buddy', inboxAgentId],
@@ -618,8 +625,7 @@ export function ChatArea({
     : inboxBuddy
       ? inboxBuddyName
       : (channel?.name ?? '...')
-  const isInboxTaskMode = isInboxChannel && inboxViewMode === 'tasks'
-  const visibleChannelTopic = isInboxChannel ? null : channel?.topic
+  const visibleChannelTopic = usesInboxTaskView ? null : channel?.topic
   const normalizedSearchQuery = debouncedSearchQuery.trim()
   const syncChannelMutationResult = useCallback(
     (updatedChannel: Channel) => {
@@ -799,11 +805,10 @@ export function ChatArea({
 
   const timelineMessages = useMemo(() => {
     return buildBuddyInboxViewMessages(messages, {
-      isInboxChannel,
-      mode: inboxViewMode,
+      isInboxChannel: usesInboxTaskView,
       taskFilter: inboxTaskFilter,
     })
-  }, [inboxTaskFilter, inboxViewMode, isInboxChannel, messages])
+  }, [inboxTaskFilter, messages, usesInboxTaskView])
 
   // O(1) message lookup map — avoids O(n) .find() for replyToMessage
   const messageMap = useMemo(() => {
@@ -1831,7 +1836,7 @@ export function ChatArea({
           replyToMessage={
             item.data.replyToId ? (messageMap.get(item.data.replyToId) ?? null) : null
           }
-          taskReplies={isInboxTaskMode ? taskRepliesByMessageId.get(item.data.id) : undefined}
+          taskReplies={usesInboxTaskView ? taskRepliesByMessageId.get(item.data.id) : undefined}
           selectionMode={selectionMode}
           isSelected={selectedMessageIds.has(item.data.id)}
           selectionAnchorId={selectionAnchorId}
@@ -2046,37 +2051,32 @@ export function ChatArea({
           )}
           {/* Right side: mobile QR + members toggle + notification bell */}
           <div className="ml-auto flex shrink-0 items-center gap-1.5">
-            {isInboxTaskMode && (
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 rounded-full"
-                    title={t('inbox.filter.label')}
-                    aria-label={t('inbox.filter.label')}
-                  >
-                    <ListFilter size={18} />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent align="end" className="w-40 p-1.5">
-                  {(['all', 'open', 'done'] as const).map((filter) => (
+            {usesInboxTaskView && (
+              <div
+                className="hidden h-8 items-center gap-3 border-b border-border-subtle/70 px-1 sm:flex"
+                role="tablist"
+                aria-label={t('inbox.filter.label')}
+              >
+                {(['all', 'done', 'open'] as const).map((filter) => {
+                  const selected = inboxTaskFilter === filter
+                  return (
                     <button
                       key={filter}
                       type="button"
+                      role="tab"
+                      aria-selected={selected}
                       onClick={() => setInboxTaskFilter(filter)}
                       className={cn(
-                        'flex h-9 w-full items-center rounded-lg px-2 text-left text-sm font-bold transition',
-                        inboxTaskFilter === filter
-                          ? 'bg-primary/15 text-primary'
-                          : 'text-text-secondary hover:bg-bg-tertiary/70 hover:text-text-primary',
+                        'relative h-8 px-0.5 text-xs font-black text-text-muted transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35',
+                        'after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-full after:bg-transparent after:transition',
+                        selected ? 'text-primary after:bg-primary' : 'hover:text-text-primary',
                       )}
                     >
                       {t(`inbox.filter.${filter}`)}
                     </button>
-                  ))}
-                </PopoverContent>
-              </Popover>
+                  )
+                })}
+              </div>
             )}
             <Button
               variant="ghost"
@@ -2221,12 +2221,8 @@ export function ChatArea({
               <span className="animate-pulse">{t('chat.loading', 'Loading...')}</span>
             </div>
           ) : timelineMessages.length === 0 && systemEvents.length === 0 ? (
-            isInboxChannel ? (
-              <InboxEmptyState
-                mode={inboxViewMode}
-                filter={inboxTaskFilter}
-                hasMessages={messages.length > 0}
-              />
+            usesInboxTaskView ? (
+              <InboxEmptyState filter={inboxTaskFilter} hasMessages={messages.length > 0} />
             ) : (
               <EmptyChannelState
                 channelName={channel?.name}
@@ -2373,7 +2369,7 @@ export function ChatArea({
             messageMetadata={messageMetadata}
             externalFiles={droppedFiles}
             onExternalFilesConsumed={() => setDroppedFiles([])}
-            enableTaskCards={isInboxChannel}
+            enableTaskCards={usesInboxTaskView}
             inboxViewMode={inboxViewMode}
             onInboxViewModeChange={setInboxViewMode}
           />
@@ -2603,17 +2599,14 @@ function HighlightedSearchText({ content, query }: { content: string; query: str
 }
 
 function InboxEmptyState({
-  mode,
   filter,
   hasMessages,
 }: {
-  mode: BuddyInboxViewMode
   filter: BuddyInboxTaskFilter
   hasMessages: boolean
 }) {
   const { t } = useTranslation()
-  const isChatMode = mode === 'chat'
-  const isFilteredEmpty = !isChatMode && hasMessages && filter !== 'all'
+  const isFilteredEmpty = hasMessages && filter !== 'all'
 
   return (
     <div className="flex h-full flex-col items-center justify-center px-4 text-center text-text-muted">
@@ -2621,18 +2614,10 @@ function InboxEmptyState({
         <Inbox size={24} strokeWidth={2.4} />
       </div>
       <p className="mb-2 text-lg font-black text-text-primary">
-        {isChatMode
-          ? t('inbox.empty.chatTitle')
-          : isFilteredEmpty
-            ? t('inbox.empty.filterTitle')
-            : t('inbox.empty.allTitle')}
+        {isFilteredEmpty ? t('inbox.empty.filterTitle') : t('inbox.empty.allTitle')}
       </p>
       <p className="max-w-md text-sm font-semibold leading-6 text-text-muted">
-        {isChatMode
-          ? t('inbox.empty.chatHint')
-          : isFilteredEmpty
-            ? t('inbox.empty.filterHint')
-            : t('inbox.empty.allHint')}
+        {isFilteredEmpty ? t('inbox.empty.filterHint') : t('inbox.empty.allHint')}
       </p>
     </div>
   )

--- a/apps/web/src/components/chat/message-bubble/task-card.tsx
+++ b/apps/web/src/components/chat/message-bubble/task-card.tsx
@@ -311,17 +311,21 @@ function TaskCardView({
       ? t('inbox.task.todoProgress', { done: doneTodos, total: todoItems.length })
       : t('inbox.task.noProgress')
   const priorityDot =
-    priority === 'urgent' || priority === 'high'
+    priority === 'high'
       ? 'bg-[#FF2A55] shadow-[0_0_6px_rgba(255,42,85,0.8)]'
-      : priority === 'low'
-        ? 'bg-white/40'
-        : 'bg-[#00F3FF] shadow-[0_0_6px_rgba(0,243,255,0.7)]'
+      : priority === 'medium'
+        ? 'bg-[#FFB020] shadow-[0_0_6px_rgba(255,176,32,0.75)]'
+        : priority === 'normal'
+          ? 'bg-[#00E676] shadow-[0_0_6px_rgba(0,230,118,0.7)]'
+          : 'bg-white/45'
   const priorityTone =
-    priority === 'urgent' || priority === 'high'
+    priority === 'high'
       ? 'text-[#FF2A55]/90 hover:text-[#FF2A55] hover:drop-shadow-[0_0_8px_rgba(255,42,85,0.4)]'
-      : priority === 'low'
-        ? 'text-white/50 hover:text-white/70'
-        : 'text-[#00F3FF]/90 hover:text-[#00F3FF] hover:drop-shadow-[0_0_8px_rgba(0,243,255,0.35)]'
+      : priority === 'medium'
+        ? 'text-[#FFB020]/90 hover:text-[#FFB020] hover:drop-shadow-[0_0_8px_rgba(255,176,32,0.35)]'
+        : priority === 'normal'
+          ? 'text-[#00E676]/90 hover:text-[#00E676] hover:drop-shadow-[0_0_8px_rgba(0,230,118,0.35)]'
+          : 'text-white/50 hover:text-white/70'
   const statusIsDanger =
     card.status === 'failed' || card.status === 'canceled' || card.status === 'transferred'
   const statusDot = statusIsDanger ? 'bg-[#FF2A55]' : 'bg-[#00E676]'

--- a/apps/web/src/components/chat/message-input.tsx
+++ b/apps/web/src/components/chat/message-input.tsx
@@ -7,25 +7,14 @@ import type {
   TaskMessageCardTag,
 } from '@shadowob/shared'
 import { assignMentionRanges, canonicalMentionToken } from '@shadowob/shared'
-import {
-  Button,
-  cn,
-  InputValley,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@shadowob/ui'
+import { Button, cn, InputValley, Popover, PopoverContent, PopoverTrigger } from '@shadowob/ui'
 import { type InfiniteData, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   AppWindow,
   ArrowUp,
   AtSign,
   Check,
+  ChevronDown,
   Command as CommandIcon,
   FileText,
   FolderOpen,
@@ -33,6 +22,7 @@ import {
   Image as ImageIcon,
   ListTodo,
   Loader2,
+  type LucideIcon,
   MessageSquare,
   Mic,
   Plus,
@@ -289,9 +279,136 @@ function mentionsForContent(content: string, mentions: MessageMention[]): Messag
   return assignMentionRanges(content, mentions).slice(0, 20)
 }
 
-type TaskDraftPriority = 'low' | 'normal' | 'high' | 'urgent'
+type TaskDraftPriority = 'low' | 'normal' | 'medium' | 'high'
 
-const taskPriorityOptions: TaskDraftPriority[] = ['normal', 'high', 'urgent', 'low']
+const taskPriorityOptions: TaskDraftPriority[] = ['low', 'normal', 'medium', 'high']
+
+function taskPriorityDotClass(priority: TaskDraftPriority) {
+  if (priority === 'high') {
+    return 'bg-[#FF2A55] shadow-[0_0_6px_rgba(255,42,85,0.8)]'
+  }
+  if (priority === 'medium') {
+    return 'bg-[#FFB020] shadow-[0_0_6px_rgba(255,176,32,0.75)]'
+  }
+  if (priority === 'normal') {
+    return 'bg-[#00E676] shadow-[0_0_6px_rgba(0,230,118,0.7)]'
+  }
+  return 'bg-white/45'
+}
+
+function taskPriorityLabelClass(priority: TaskDraftPriority) {
+  if (priority === 'high') return 'text-[#FF2A55]'
+  if (priority === 'medium') return 'text-[#FFB020]'
+  if (priority === 'normal') return 'text-[#00E676]'
+  return 'text-white/55'
+}
+
+function taskPrioritySelectedClass(priority: TaskDraftPriority) {
+  if (priority === 'high') {
+    return 'bg-[#FF2A55]/12 text-[#FF2A55]'
+  }
+  if (priority === 'medium') return 'bg-[#FFB020]/12 text-[#FFB020]'
+  if (priority === 'normal') return 'bg-[#00E676]/12 text-[#00E676]'
+  if (priority === 'low') return 'bg-white/8 text-white/65'
+  return 'bg-primary/15 text-primary'
+}
+
+interface InlineSwitcherOption<TValue extends string> {
+  value: TValue
+  label: string
+  icon?: LucideIcon
+  dotClassName?: string
+  labelClassName?: string
+  selectedClassName?: string
+}
+
+function InlineOptionSwitcher<TValue extends string>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  align = 'start',
+  triggerClassName,
+  contentClassName,
+}: {
+  value: TValue
+  options: InlineSwitcherOption<TValue>[]
+  onChange: (value: TValue) => void
+  ariaLabel: string
+  align?: 'start' | 'center' | 'end'
+  triggerClassName?: string
+  contentClassName?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const selected = options.find((option) => option.value === value) ?? options[0]
+  if (!selected) return null
+
+  const SelectedIcon = selected.icon
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          className={cn(
+            'inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg px-2 text-sm font-semibold text-text-secondary transition hover:bg-bg-tertiary/45 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 sm:h-9',
+            triggerClassName,
+          )}
+        >
+          {selected.dotClassName ? (
+            <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', selected.dotClassName)} />
+          ) : (
+            SelectedIcon && <SelectedIcon size={16} strokeWidth={2.1} className="shrink-0" />
+          )}
+          <span className={cn('min-w-0 truncate text-left', selected.labelClassName)}>
+            {selected.label}
+          </span>
+          <ChevronDown size={14} strokeWidth={2.2} className="shrink-0 opacity-70" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align={align}
+        sideOffset={6}
+        className={cn('!w-fit min-w-[7rem] rounded-2xl p-1.5', contentClassName)}
+      >
+        <div className="grid gap-1">
+          {options.map((option) => {
+            const selectedOption = option.value === value
+            const OptionIcon = option.icon
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  onChange(option.value)
+                  setOpen(false)
+                }}
+                className={cn(
+                  'flex h-9 w-full items-center justify-start gap-2 rounded-lg px-2 text-left text-sm font-bold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35',
+                  selectedOption
+                    ? (option.selectedClassName ?? 'bg-primary/15 text-primary')
+                    : cn(
+                        'text-text-secondary hover:bg-bg-tertiary/70 hover:text-text-primary',
+                        option.labelClassName,
+                      ),
+                )}
+              >
+                {option.dotClassName ? (
+                  <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', option.dotClassName)} />
+                ) : (
+                  OptionIcon && <OptionIcon size={15} strokeWidth={2.2} className="shrink-0" />
+                )}
+                <span className="min-w-0 truncate">{option.label}</span>
+                {selectedOption && <Check size={14} strokeWidth={2.4} className="shrink-0" />}
+              </button>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
 const taskTagPresetOptions = ['research', 'script', 'render', 'qa', 'publish'] as const
 
 function taskDraftToInput(value: string): { title: string; body?: string } {
@@ -440,8 +557,29 @@ export function MessageInput({
   const showInboxComposerControls =
     enableTaskCards && Boolean(inboxViewMode && onInboxViewModeChange)
   const isInboxTaskComposer = showInboxComposerControls && inboxViewMode === 'tasks'
+  const activeComposerPlaceholder = isInboxTaskComposer
+    ? t('inbox.task.quickPlaceholder')
+    : composerPlaceholder
   const taskTitleInput = taskDraftToInput(taskDraft)
   const selectedTaskTags = useMemo(() => taskTagsToValues(taskTags), [taskTags])
+  const inboxModeOptions = useMemo<InlineSwitcherOption<BuddyInboxViewMode>[]>(
+    () => [
+      { value: 'chat', label: t('inbox.mode.chat'), icon: MessageSquare },
+      { value: 'tasks', label: t('inbox.mode.tasks'), icon: ListTodo },
+    ],
+    [t],
+  )
+  const taskPrioritySwitcherOptions = useMemo<InlineSwitcherOption<TaskDraftPriority>[]>(
+    () =>
+      taskPriorityOptions.map((priority) => ({
+        value: priority,
+        label: t(`inbox.task.priority.${priority}`),
+        dotClassName: taskPriorityDotClass(priority),
+        labelClassName: taskPriorityLabelClass(priority),
+        selectedClassName: taskPrioritySelectedClass(priority),
+      })),
+    [t],
+  )
 
   const toggleTaskTagPreset = useCallback((tag: string) => {
     setTaskTags((current) => {
@@ -921,7 +1059,11 @@ export function MessageInput({
       setDictationListening(false)
       requestAnimationFrame(() => {
         if (isInboxTaskComposer) {
-          taskTextareaRef.current?.focus()
+          const el = taskTextareaRef.current
+          if (el) {
+            el.style.height = 'auto'
+            el.focus()
+          }
           return
         }
         textareaRef.current?.focus()
@@ -1804,6 +1946,15 @@ export function MessageInput({
     scheduleSave(value)
   }
 
+  const handleTaskInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value
+    setTaskDraft(value)
+
+    const el = e.target
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`
+  }
+
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
     if (!files) return
@@ -1893,24 +2044,14 @@ export function MessageInput({
       >
         {isInboxTaskComposer && (
           <div className="mb-1 grid gap-2 border-b border-border-subtle/70 p-2 pb-3">
-            <Select
+            <InlineOptionSwitcher
               value={taskPriority}
-              onValueChange={(priority) => setTaskPriority(priority as TaskDraftPriority)}
-            >
-              <SelectTrigger
-                className="h-10 rounded-xl border-border-subtle bg-bg-secondary/65 text-xs font-black text-text-primary shadow-none"
-                aria-label={t('inbox.task.priorityLabel')}
-              >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent position="popper" sideOffset={6}>
-                {taskPriorityOptions.map((priority) => (
-                  <SelectItem key={priority} value={priority}>
-                    {t(`inbox.task.priority.${priority}`)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              onChange={setTaskPriority}
+              options={taskPrioritySwitcherOptions}
+              ariaLabel={t('inbox.task.priorityLabel')}
+              triggerClassName="h-10 w-full justify-start border border-border-subtle bg-bg-secondary/65 px-3 text-xs font-black text-text-primary hover:bg-bg-secondary/85"
+              contentClassName="min-w-[7rem]"
+            />
 
             <Popover open={showTaskTagsMenu} onOpenChange={setShowTaskTagsMenu}>
               <PopoverTrigger asChild>
@@ -2052,7 +2193,7 @@ export function MessageInput({
   return (
     <section
       className="relative z-20 px-4 pb-4 mobile-safe-bottom"
-      aria-label={composerPlaceholder}
+      aria-label={activeComposerPlaceholder}
       onDrop={handleDrop}
       onDragOver={handleDragOver}
     >
@@ -2330,241 +2471,109 @@ export function MessageInput({
       ) : (
         <InputValley
           className={cn(
-            isInboxTaskComposer
-              ? 'grid min-h-[168px] gap-3 px-5 py-4 sm:min-h-[172px] sm:rounded-[34px] sm:px-6 sm:py-5'
-              : 'grid gap-2 px-3 py-2 sm:px-4',
+            'grid gap-2 px-3 py-2 sm:px-4',
             replyToId || pendingFiles.length > 0 || selectedCommerceCards.length > 0
-              ? isInboxTaskComposer
-                ? 'rounded-b-[30px]'
-                : 'rounded-b-[20px]'
-              : isInboxTaskComposer
-                ? 'rounded-[34px]'
-                : 'rounded-[20px]',
+              ? 'rounded-b-[20px]'
+              : 'rounded-[20px]',
           )}
-          style={
-            isInboxTaskComposer
-              ? {
-                  background: 'color-mix(in srgb, var(--color-bg-secondary) 88%, transparent)',
-                  border:
-                    '1px solid color-mix(in srgb, var(--color-border-subtle) 78%, transparent)',
-                  boxShadow: 'none',
-                }
-              : undefined
-          }
         >
-          {isInboxTaskComposer ? (
-            <>
-              {showInboxComposerControls && (
-                <Select
-                  value={inboxViewMode}
-                  onValueChange={(mode) => {
-                    onInboxViewModeChange?.(mode as BuddyInboxViewMode)
-                    setShowAttachMenu(false)
-                    setShowEmojiPicker(false)
-                    setShowTaskTagsMenu(false)
-                  }}
-                >
-                  <SelectTrigger
-                    className="h-8 w-fit rounded-none border-0 bg-transparent px-0 py-0 text-[22px] font-medium leading-none text-text-primary shadow-none hover:text-text-primary focus:ring-0 sm:text-2xl"
-                    aria-label={t('inbox.mode.label')}
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent position="popper" sideOffset={6}>
-                    {(['chat', 'tasks'] as const).map((mode) => {
-                      const Icon = mode === 'chat' ? MessageSquare : ListTodo
-                      return (
-                        <SelectItem key={mode} value={mode}>
-                          <span className="inline-flex items-center gap-2">
-                            <Icon size={14} />
-                            {t(`inbox.mode.${mode}`)}
-                          </span>
-                        </SelectItem>
-                      )
-                    })}
-                  </SelectContent>
-                </Select>
-              )}
-
-              <textarea
-                ref={taskTextareaRef}
-                value={taskDraft}
-                onChange={(event) => setTaskDraft(event.target.value)}
-                onKeyDown={(event) => {
-                  if (
-                    event.key === 'Enter' &&
-                    (event.metaKey || event.ctrlKey) &&
-                    !event.nativeEvent.isComposing
-                  ) {
-                    event.preventDefault()
-                    void createTaskCard()
-                  }
-                }}
-                onPaste={handlePaste}
-                placeholder={t('inbox.task.quickPlaceholder')}
-                rows={4}
-                wrap="soft"
-                autoFocus
-                className="min-h-[52px] max-h-[50vh] w-full resize-none overflow-hidden bg-transparent px-0 py-0 text-[20px] font-medium leading-8 text-text-primary outline-none placeholder:text-text-muted sm:min-h-[56px] sm:text-[22px]"
-              />
-
-              <div className="flex items-center justify-between gap-3">
-                <div className="relative shrink-0">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className={cn(
-                      'h-11 w-11 rounded-full text-text-primary hover:bg-bg-tertiary/55',
-                      showAttachMenu && 'bg-bg-tertiary/70 text-primary',
-                    )}
-                    onClick={() => setShowAttachMenu((open) => !open)}
-                    title={t('chat.addMenu')}
-                    aria-label={t('chat.addMenu')}
-                  >
-                    <Plus size={28} strokeWidth={1.8} />
-                  </Button>
-                  {showAttachMenu && renderAttachMenu()}
-                </div>
-
-                <div className="flex min-w-0 items-center gap-2 sm:gap-3">
-                  <Select
-                    value={taskPriority}
-                    onValueChange={(priority) => setTaskPriority(priority as TaskDraftPriority)}
-                  >
-                    <SelectTrigger
-                      className="h-10 w-[5.75rem] shrink-0 rounded-full border-0 bg-transparent px-2 text-base font-medium text-text-secondary shadow-none hover:bg-bg-tertiary/45 hover:text-text-primary focus:ring-0 sm:w-[6.25rem]"
-                      aria-label={t('inbox.task.priorityLabel')}
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent position="popper" sideOffset={6}>
-                      {taskPriorityOptions.map((priority) => (
-                        <SelectItem key={priority} value={priority}>
-                          {t(`inbox.task.priority.${priority}`)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className={cn(
-                      'h-11 w-11 shrink-0 rounded-full text-text-primary hover:bg-bg-tertiary/55',
-                      dictationListening && 'bg-primary/12 text-primary',
-                    )}
-                    onClick={toggleDictation}
-                    title={
-                      dictationListening ? t('chat.voiceStopDictation') : t('chat.voiceDictate')
-                    }
-                    aria-label={
-                      dictationListening ? t('chat.voiceStopDictation') : t('chat.voiceDictate')
-                    }
-                    aria-pressed={dictationListening}
-                    disabled={uploading || voiceRecording}
-                  >
-                    <Mic size={24} strokeWidth={1.9} />
-                  </Button>
-
-                  <Button
-                    size="icon"
-                    className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border-none bg-white text-[#050505] shadow-none transition-all duration-200 hover:bg-white/90 disabled:bg-white/35 disabled:text-[#050505]/45"
-                    onClick={() => void createTaskCard()}
-                    title={t('inbox.task.create')}
-                    aria-label={t('inbox.task.create')}
-                    disabled={!taskTitleInput.title || creatingTask || dictationListening}
-                  >
-                    {creatingTask ? (
-                      <Loader2 size={22} className="animate-spin" />
-                    ) : (
-                      <ArrowUp size={30} strokeWidth={2.6} />
-                    )}
-                  </Button>
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="flex items-end gap-1.5 sm:gap-2">
-              <div className="relative mb-[2px] shrink-0 self-end sm:mb-[3px]">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className={cn(
-                    'h-8 w-8 sm:h-9 sm:w-9',
-                    showAttachMenu && 'bg-primary/10 text-primary',
-                  )}
-                  onClick={() => setShowAttachMenu((open) => !open)}
-                  title={t('chat.addMenu')}
-                  aria-label={t('chat.addMenu')}
-                >
-                  <Plus size={18} />
-                </Button>
-                {showAttachMenu && renderAttachMenu()}
-              </div>
-
-              {showInboxComposerControls && (
-                <Select
-                  value={inboxViewMode}
-                  onValueChange={(mode) => {
-                    onInboxViewModeChange?.(mode as BuddyInboxViewMode)
-                    setShowAttachMenu(false)
-                    setShowEmojiPicker(false)
-                    setShowTaskTagsMenu(false)
-                  }}
-                >
-                  <SelectTrigger
-                    className="mb-[2px] h-8 w-[7.25rem] shrink-0 rounded-full border-border-subtle bg-bg-secondary/65 px-3 text-xs font-black text-text-primary shadow-none sm:mb-[3px] sm:h-9"
-                    aria-label={t('inbox.mode.label')}
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent position="popper" sideOffset={6}>
-                    {(['chat', 'tasks'] as const).map((mode) => {
-                      const Icon = mode === 'chat' ? MessageSquare : ListTodo
-                      return (
-                        <SelectItem key={mode} value={mode}>
-                          <span className="inline-flex items-center gap-2">
-                            <Icon size={14} />
-                            {t(`inbox.mode.${mode}`)}
-                          </span>
-                        </SelectItem>
-                      )
-                    })}
-                  </SelectContent>
-                </Select>
-              )}
-
-              <textarea
-                ref={textareaRef}
-                value={content}
-                onChange={handleInput}
-                onKeyDown={handleKeyDown}
-                onPaste={handlePaste}
-                placeholder={composerPlaceholder}
-                rows={1}
-                wrap={content ? 'soft' : 'off'}
-                autoFocus
-                className="max-h-[50vh] min-h-[24px] min-w-0 flex-1 resize-none overflow-hidden bg-transparent py-[6px] text-[15px] leading-[24px] text-text-primary outline-none placeholder:text-text-muted sm:py-[7px]"
-              />
-
+          <div className="flex items-end gap-1.5 sm:gap-2">
+            <div className="relative mb-[2px] shrink-0 self-end sm:mb-[3px]">
               <Button
                 variant="ghost"
                 size="icon"
                 className={cn(
-                  'mb-[2px] h-8 w-8 shrink-0 self-end sm:mb-[3px] sm:h-9 sm:w-9',
-                  dictationListening && 'bg-primary/12 text-primary',
+                  'h-8 w-8 sm:h-9 sm:w-9',
+                  showAttachMenu && 'bg-primary/10 text-primary',
                 )}
-                onClick={toggleDictation}
-                title={dictationListening ? t('chat.voiceStopDictation') : t('chat.voiceDictate')}
-                aria-label={
-                  dictationListening ? t('chat.voiceStopDictation') : t('chat.voiceDictate')
-                }
-                aria-pressed={dictationListening}
-                disabled={uploading || voiceRecording}
+                onClick={() => setShowAttachMenu((open) => !open)}
+                title={t('chat.addMenu')}
+                aria-label={t('chat.addMenu')}
               >
-                <Mic size={18} />
+                <Plus size={18} />
               </Button>
+              {showAttachMenu && renderAttachMenu()}
+            </div>
 
+            {showInboxComposerControls && (
+              <InlineOptionSwitcher
+                value={inboxViewMode ?? 'chat'}
+                onChange={(mode) => {
+                  onInboxViewModeChange?.(mode)
+                  setShowAttachMenu(false)
+                  setShowEmojiPicker(false)
+                  setShowTaskTagsMenu(false)
+                  requestAnimationFrame(() => {
+                    if (mode === 'tasks') {
+                      taskTextareaRef.current?.focus()
+                      return
+                    }
+                    textareaRef.current?.focus()
+                  })
+                }}
+                options={inboxModeOptions}
+                ariaLabel={t('inbox.mode.label')}
+                triggerClassName="mb-[2px] min-w-[4.75rem] self-end px-1.5 text-xs font-black text-text-primary sm:mb-[3px]"
+              />
+            )}
+
+            <textarea
+              ref={isInboxTaskComposer ? taskTextareaRef : textareaRef}
+              value={isInboxTaskComposer ? taskDraft : content}
+              onChange={isInboxTaskComposer ? handleTaskInput : handleInput}
+              onKeyDown={
+                isInboxTaskComposer
+                  ? (event) => {
+                      if (
+                        event.key === 'Enter' &&
+                        (event.metaKey || event.ctrlKey) &&
+                        !event.nativeEvent.isComposing
+                      ) {
+                        event.preventDefault()
+                        void createTaskCard()
+                      }
+                    }
+                  : handleKeyDown
+              }
+              onPaste={handlePaste}
+              placeholder={activeComposerPlaceholder}
+              rows={1}
+              wrap={(isInboxTaskComposer ? taskDraft : content) ? 'soft' : 'off'}
+              autoFocus
+              className="max-h-[50vh] min-h-[24px] min-w-0 flex-1 resize-none overflow-hidden bg-transparent py-[6px] text-[15px] leading-[24px] text-text-primary outline-none placeholder:text-text-muted sm:py-[7px]"
+            />
+
+            {isInboxTaskComposer && (
+              <InlineOptionSwitcher
+                value={taskPriority}
+                onChange={setTaskPriority}
+                options={taskPrioritySwitcherOptions}
+                ariaLabel={t('inbox.task.priorityLabel')}
+                align="end"
+                triggerClassName="mb-[2px] min-w-[4.75rem] self-end px-1.5 text-xs font-black text-text-primary sm:mb-[3px]"
+                contentClassName="min-w-[7rem]"
+              />
+            )}
+
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                'mb-[2px] h-8 w-8 shrink-0 self-end sm:mb-[3px] sm:h-9 sm:w-9',
+                dictationListening && 'bg-primary/12 text-primary',
+              )}
+              onClick={toggleDictation}
+              title={dictationListening ? t('chat.voiceStopDictation') : t('chat.voiceDictate')}
+              aria-label={
+                dictationListening ? t('chat.voiceStopDictation') : t('chat.voiceDictate')
+              }
+              aria-pressed={dictationListening}
+              disabled={uploading || voiceRecording}
+            >
+              <Mic size={18} />
+            </Button>
+
+            {!isInboxTaskComposer && (
               <div className="relative mb-[2px] shrink-0 self-end sm:mb-[3px]">
                 <Button
                   variant="ghost"
@@ -2586,26 +2595,36 @@ export function MessageInput({
                   />
                 )}
               </div>
+            )}
 
-              <Button
-                size="icon"
-                className="mb-0.5 flex h-9 w-9 shrink-0 items-center justify-center self-end rounded-full border-none bg-primary text-white shadow-none transition-all duration-300 hover:bg-primary-strong disabled:opacity-30"
-                onClick={handleSend}
-                title={t('chat.sendMessage')}
-                aria-label={t('chat.sendMessage')}
-                disabled={
-                  (!content.trim() &&
-                    pendingFiles.length === 0 &&
-                    selectedCommerceCards.length === 0) ||
-                  uploading ||
-                  voiceRecording ||
-                  dictationListening
-                }
-              >
-                <Send size={16} className="text-white" />
-              </Button>
-            </div>
-          )}
+            <Button
+              size="icon"
+              className="mb-0.5 flex h-9 w-9 shrink-0 items-center justify-center self-end rounded-full border-none bg-primary text-white shadow-none transition-all duration-300 hover:bg-primary-strong disabled:opacity-30"
+              onClick={isInboxTaskComposer ? () => void createTaskCard() : handleSend}
+              title={isInboxTaskComposer ? t('inbox.task.create') : t('chat.sendMessage')}
+              aria-label={isInboxTaskComposer ? t('inbox.task.create') : t('chat.sendMessage')}
+              disabled={
+                isInboxTaskComposer
+                  ? !taskTitleInput.title ||
+                    creatingTask ||
+                    uploading ||
+                    voiceRecording ||
+                    dictationListening
+                  : (!content.trim() &&
+                      pendingFiles.length === 0 &&
+                      selectedCommerceCards.length === 0) ||
+                    uploading ||
+                    voiceRecording ||
+                    dictationListening
+              }
+            >
+              {isInboxTaskComposer && creatingTask ? (
+                <Loader2 size={17} className="animate-spin text-white" />
+              ) : (
+                <ArrowUp size={18} strokeWidth={2.5} className="text-white" />
+              )}
+            </Button>
+          </div>
         </InputValley>
       )}
 

--- a/apps/web/src/components/member/member-list.tsx
+++ b/apps/web/src/components/member/member-list.tsx
@@ -714,8 +714,8 @@ function BuddyContextMenu({
   const [customKeywords, setCustomKeywords] = useState('')
   const [customMentionOnly, setCustomMentionOnly] = useState(false)
   // Buddy interaction settings
-  const [customReplyToBuddy, setCustomReplyToBuddy] = useState(false)
-  const [customMaxBuddyTurns, setCustomMaxBuddyTurns] = useState(3)
+  const [customReplyToBuddy, setCustomReplyToBuddy] = useState(true)
+  const [customMaxBuddyTurns, setCustomMaxBuddyTurns] = useState(4)
   const [customSmartReply, setCustomSmartReply] = useState(true)
   const [userPickerOpen, setUserPickerOpen] = useState(false)
   const [userPickerSearch, setUserPickerSearch] = useState('')
@@ -745,7 +745,8 @@ function BuddyContextMenu({
   })
 
   const policyConfig = (currentPolicy?.config ?? {}) as BuddyPolicyConfig
-  const collaborationEnabled = policyConfig.replyToBuddy === true
+  const collaborationEnabled = policyConfig.replyToBuddy !== false
+  const collaborationExplicitlyDisabled = policyConfig.replyToBuddy === false
   const hasCustomRules = Boolean(
     policyConfig.replyToUsers?.length ||
       policyConfig.keywords?.length ||
@@ -762,7 +763,7 @@ function BuddyContextMenu({
   const updateTriggerMode = (triggerMode: ReplyTriggerMode) => {
     if (!activeChannelId || !agent) return
     const mode =
-      collaborationEnabled || hasCustomRules
+      triggerMode !== 'disabled' && (collaborationExplicitlyDisabled || hasCustomRules)
         ? 'custom'
         : triggerMode === 'disabled'
           ? 'disabled'
@@ -780,9 +781,9 @@ function BuddyContextMenu({
             ...(collaborationEnabled
               ? {
                   replyToBuddy: true,
-                  maxBuddyTurns: policyConfig.maxBuddyTurns ?? 3,
+                  maxBuddyTurns: policyConfig.maxBuddyTurns ?? 4,
                 }
-              : {}),
+              : { replyToBuddy: false }),
             ...(policyConfig.smartReply === false ? { smartReply: false } : {}),
           }
         : undefined
@@ -804,17 +805,7 @@ function BuddyContextMenu({
     const nextEnabled = !collaborationEnabled
     const triggerMode =
       currentTriggerMode === 'disabled' && nextEnabled ? 'mentionOnly' : currentTriggerMode
-    const nextHasCustomRules = Boolean(
-      policyConfig.replyToUsers?.length ||
-        policyConfig.keywords?.length ||
-        policyConfig.smartReply === false,
-    )
-    const mode =
-      triggerMode === 'disabled' && !nextEnabled
-        ? 'disabled'
-        : nextEnabled || nextHasCustomRules
-          ? 'custom'
-          : triggerMode
+    const mode = triggerMode === 'disabled' && !nextEnabled ? 'disabled' : 'custom'
     const config =
       mode === 'custom'
         ? {
@@ -826,9 +817,9 @@ function BuddyContextMenu({
             ...(nextEnabled
               ? {
                   replyToBuddy: true,
-                  maxBuddyTurns: policyConfig.maxBuddyTurns ?? 3,
+                  maxBuddyTurns: policyConfig.maxBuddyTurns ?? 4,
                 }
-              : {}),
+              : { replyToBuddy: false }),
             ...(policyConfig.smartReply === false ? { smartReply: false } : {}),
           }
         : undefined
@@ -1030,8 +1021,8 @@ function BuddyContextMenu({
                       setCustomReplyToUsers(cfg?.replyToUsers ?? [])
                       setCustomKeywords(cfg?.keywords?.join('\n') ?? '')
                       setCustomMentionOnly(cfg?.mentionOnly ?? false)
-                      setCustomReplyToBuddy(cfg?.replyToBuddy ?? false)
-                      setCustomMaxBuddyTurns(cfg?.maxBuddyTurns ?? 3)
+                      setCustomReplyToBuddy(cfg?.replyToBuddy !== false)
+                      setCustomMaxBuddyTurns(cfg?.maxBuddyTurns ?? 4)
                       setCustomSmartReply(cfg?.smartReply ?? true)
                       setCustomPolicyOpen(true)
                       setPolicyOpen(false)
@@ -1369,7 +1360,7 @@ function BuddyContextMenu({
                         ...(customMentionOnly ? { mentionOnly: true } : {}),
                         ...(customReplyToBuddy
                           ? { replyToBuddy: true, maxBuddyTurns: customMaxBuddyTurns }
-                          : {}),
+                          : { replyToBuddy: false }),
                         ...(customSmartReply !== true ? { smartReply: false } : {}),
                       },
                     },

--- a/apps/web/src/lib/locales/en.json
+++ b/apps/web/src/lib/locales/en.json
@@ -872,6 +872,12 @@
     "noInstalled": "No Apps installed yet.",
     "selectApp": "Select an App",
     "selectFromSidebar": "Choose an installed App from the left, or add a new one.",
+    "channelModeTitle": "Choose how to open",
+    "channelModeDesc": "Open {{channelName}} directly, or collaborate with the current App?",
+    "channelModeOpenChannel": "Open channel",
+    "channelModeOpenChannelDesc": "Leave the App page and view the channel chat.",
+    "channelModeCollaborate": "Enter collaboration mode",
+    "channelModeCollaborateDesc": "Open the channel beside the App so Buddy can work with the context.",
     "install": "Install App",
     "privateUrlError": "This App URL points to a local or private network and cannot be installed in this environment.",
     "uninstallConfirmTitle": "Uninstall App",
@@ -3811,8 +3817,8 @@
       "priority": {
         "low": "Low",
         "normal": "Normal",
-        "high": "High",
-        "urgent": "Urgent"
+        "medium": "Medium",
+        "high": "High"
       },
       "status": {
         "queued": "Queued",

--- a/apps/web/src/lib/locales/ja.json
+++ b/apps/web/src/lib/locales/ja.json
@@ -674,6 +674,12 @@
     "noInstalled": "アプリはまだインストールされていません。",
     "selectApp": "アプリを選択",
     "selectFromSidebar": "左からインストール済みアプリを選ぶか、新しいアプリを追加してください。",
+    "channelModeTitle": "開き方を選択",
+    "channelModeDesc": "{{channelName}} を直接開くか、現在のアプリと共同作業しますか？",
+    "channelModeOpenChannel": "チャンネルを開く",
+    "channelModeOpenChannelDesc": "アプリページを離れて、チャンネルチャットを表示します。",
+    "channelModeCollaborate": "共同作業モードに入る",
+    "channelModeCollaborateDesc": "アプリの横にチャンネルを開き、Buddy が文脈を持って作業できるようにします。",
     "install": "アプリをインストール",
     "privateUrlError": "このアプリ URL はローカルまたはプライベートネットワークを指しているため、この環境ではインストールできません。",
     "uninstallConfirmTitle": "アプリをアンインストール",
@@ -3808,8 +3814,8 @@
       "priority": {
         "low": "低",
         "normal": "通常",
-        "high": "高",
-        "urgent": "緊急"
+        "medium": "中",
+        "high": "高"
       },
       "status": {
         "queued": "待機中",

--- a/apps/web/src/lib/locales/ko.json
+++ b/apps/web/src/lib/locales/ko.json
@@ -674,6 +674,12 @@
     "noInstalled": "설치된 앱이 아직 없습니다.",
     "selectApp": "앱 선택",
     "selectFromSidebar": "왼쪽에서 설치된 앱을 선택하거나 새 앱을 추가하세요.",
+    "channelModeTitle": "열기 방식 선택",
+    "channelModeDesc": "{{channelName}} 채널로 바로 들어갈까요, 아니면 현재 앱과 함께 협업할까요?",
+    "channelModeOpenChannel": "채널로 이동",
+    "channelModeOpenChannelDesc": "앱 페이지를 떠나 채널 채팅을 바로 봅니다.",
+    "channelModeCollaborate": "협업 모드로 들어가기",
+    "channelModeCollaborateDesc": "앱 옆에 채널을 열어 Buddy가 맥락을 가지고 협업하게 합니다.",
     "install": "앱 설치",
     "privateUrlError": "이 앱 URL은 로컬 또는 사설 네트워크를 가리키므로 현재 환경에서 설치할 수 없습니다.",
     "uninstallConfirmTitle": "앱 제거",
@@ -3808,8 +3814,8 @@
       "priority": {
         "low": "낮음",
         "normal": "보통",
-        "high": "높음",
-        "urgent": "긴급"
+        "medium": "중간",
+        "high": "높음"
       },
       "status": {
         "queued": "대기 중",

--- a/apps/web/src/lib/locales/zh-CN.json
+++ b/apps/web/src/lib/locales/zh-CN.json
@@ -872,6 +872,12 @@
     "noInstalled": "还没有安装应用。",
     "selectApp": "选择一个应用",
     "selectFromSidebar": "从左侧选择已安装应用，或添加新应用。",
+    "channelModeTitle": "选择打开方式",
+    "channelModeDesc": "要直接进入 {{channelName}}，还是让它和当前应用一起协作？",
+    "channelModeOpenChannel": "进入频道",
+    "channelModeOpenChannelDesc": "离开应用页面，直接查看频道聊天。",
+    "channelModeCollaborate": "进入协作模式",
+    "channelModeCollaborateDesc": "把频道打开在应用旁边，让 Buddy 带着上下文协作。",
     "install": "安装应用",
     "privateUrlError": "这个应用地址指向本地或私有网络，当前环境不允许安装。",
     "uninstallConfirmTitle": "卸载应用",
@@ -3809,10 +3815,10 @@
       "complete": "完成",
       "fail": "失败",
       "priority": {
-        "low": "低优",
-        "normal": "普通",
-        "high": "高优",
-        "urgent": "紧急"
+        "low": "低",
+        "normal": "一般",
+        "medium": "中",
+        "high": "高"
       },
       "status": {
         "queued": "排队中",

--- a/apps/web/src/lib/locales/zh-TW.json
+++ b/apps/web/src/lib/locales/zh-TW.json
@@ -674,6 +674,12 @@
     "noInstalled": "還沒有安裝應用。",
     "selectApp": "選擇一個應用",
     "selectFromSidebar": "從左側選擇已安裝應用，或加入新應用。",
+    "channelModeTitle": "選擇開啟方式",
+    "channelModeDesc": "要直接進入 {{channelName}}，還是讓它和目前應用一起協作？",
+    "channelModeOpenChannel": "進入頻道",
+    "channelModeOpenChannelDesc": "離開應用頁面，直接查看頻道聊天。",
+    "channelModeCollaborate": "進入協作模式",
+    "channelModeCollaborateDesc": "把頻道開在應用旁邊，讓 Buddy 帶著上下文協作。",
     "install": "安裝應用",
     "privateUrlError": "這個應用位址指向本機或私有網路，目前環境不允許安裝。",
     "uninstallConfirmTitle": "卸載應用",
@@ -3806,10 +3812,10 @@
       "complete": "完成",
       "fail": "失敗",
       "priority": {
-        "low": "低優",
-        "normal": "普通",
-        "high": "高優",
-        "urgent": "緊急"
+        "low": "低",
+        "normal": "一般",
+        "medium": "中",
+        "high": "高"
       },
       "status": {
         "queued": "排隊中",

--- a/apps/web/src/pages/server.tsx
+++ b/apps/web/src/pages/server.tsx
@@ -1,7 +1,7 @@
-import { GlassPanel } from '@shadowob/ui'
+import { GlassPanel, Modal, ModalBody, ModalContent, ModalHeader } from '@shadowob/ui'
 import { type InfiniteData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Outlet, useLocation, useNavigate, useParams, useSearch } from '@tanstack/react-router'
-import { Loader2 } from 'lucide-react'
+import { Loader2, MessageSquare, Users } from 'lucide-react'
 import {
   type PointerEvent,
   useCallback,
@@ -64,6 +64,12 @@ interface ChannelMeta {
   serverId: string
   type?: string
   isArchived?: boolean
+}
+
+interface PendingAppChannelMode {
+  id: string
+  name: string
+  type?: string
 }
 
 interface ChannelAccessMeta {
@@ -242,6 +248,9 @@ export function ServerLayout() {
   const openCopilotChannel = useUIStore((state) => state.openCopilotChannel)
   const closeCopilotChannel = useUIStore((state) => state.closeCopilotChannel)
   const [bootstrapSeededChannelId, setBootstrapSeededChannelId] = useState<string | null>(null)
+  const [pendingAppChannelMode, setPendingAppChannelMode] = useState<PendingAppChannelMode | null>(
+    null,
+  )
   const [stableServerMeta, setStableServerMeta] = useState<ServerMeta | null>(null)
   const copilotResize = useCopilotPanelResize()
 
@@ -684,9 +693,39 @@ export function ServerLayout() {
     })
   }
 
-  const openChannelInCopilot = (channel: { id: string }) => {
-    openCopilotChannel(serverSlug, channel.id)
-    navigateServerAppCopilot(channel.id)
+  const openChannelModePrompt = (channel: PendingAppChannelMode) => {
+    setPendingAppChannelMode({
+      id: channel.id,
+      name: channel.name,
+      type: channel.type,
+    })
+  }
+
+  const closeChannelModePrompt = () => {
+    setPendingAppChannelMode(null)
+  }
+
+  const enterPendingChannel = () => {
+    if (!pendingAppChannelMode) return
+
+    const nextChannelId = pendingAppChannelMode.id
+    setPendingAppChannelMode(null)
+    closeCopilotChannel()
+    setMobileView('chat')
+    navigate({
+      to: '/servers/$serverSlug/channels/$channelId',
+      params: { serverSlug: routeServerSlug, channelId: nextChannelId },
+    })
+  }
+
+  const enterPendingChannelCopilot = () => {
+    if (!pendingAppChannelMode) return
+
+    const nextChannelId = pendingAppChannelMode.id
+    setPendingAppChannelMode(null)
+    setMobileView('chat')
+    openCopilotChannel(serverSlug, nextChannelId)
+    navigateServerAppCopilot(nextChannelId)
   }
 
   const closeCopilot = () => {
@@ -716,7 +755,7 @@ export function ServerLayout() {
             deferInitialQueries={Boolean(
               channelId && !serverMeta && bootstrapSeededChannelId !== channelId,
             )}
-            onSelectChannel={isServerAppsRoute ? openChannelInCopilot : undefined}
+            onSelectChannel={isServerAppsRoute ? openChannelModePrompt : undefined}
           />
         </div>
       )}
@@ -810,6 +849,59 @@ export function ServerLayout() {
           <Outlet />
         )}
       </div>
+
+      <Modal open={pendingAppChannelMode !== null} onClose={closeChannelModePrompt}>
+        {pendingAppChannelMode && (
+          <ModalContent maxWidth="max-w-[460px]" aria-label={t('serverApps.channelModeTitle')}>
+            <ModalHeader
+              icon={<Users size={20} />}
+              title={t('serverApps.channelModeTitle')}
+              subtitle={t('serverApps.channelModeDesc', {
+                channelName: pendingAppChannelMode.name,
+              })}
+              hideCloseButton
+            />
+            <ModalBody className="space-y-3 py-5">
+              <button
+                type="button"
+                onClick={enterPendingChannel}
+                className="group flex w-full items-center gap-3 rounded-2xl border border-border-subtle/70 bg-white/[0.04] p-4 text-left transition hover:border-primary/35 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 active:scale-[0.99]"
+              >
+                <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-border-subtle/70 bg-bg-secondary/60 text-text-muted transition group-hover:border-primary/30 group-hover:text-primary">
+                  <MessageSquare size={19} />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-black text-text-primary">
+                    {t('serverApps.channelModeOpenChannel')}
+                  </span>
+                  <span className="mt-1 block text-xs font-semibold leading-5 text-text-muted">
+                    {t('serverApps.channelModeOpenChannelDesc')}
+                  </span>
+                </span>
+              </button>
+
+              <button
+                autoFocus
+                type="button"
+                onClick={enterPendingChannelCopilot}
+                className="group flex w-full items-center gap-3 rounded-2xl border border-primary/25 bg-primary/10 p-4 text-left transition hover:border-primary/55 hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 active:scale-[0.99]"
+              >
+                <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/15 text-primary shadow-[0_14px_30px_rgba(0,198,209,0.12)]">
+                  <Users size={19} />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-black text-text-primary">
+                    {t('serverApps.channelModeCollaborate')}
+                  </span>
+                  <span className="mt-1 block text-xs font-semibold leading-5 text-text-muted">
+                    {t('serverApps.channelModeCollaborateDesc')}
+                  </span>
+                </span>
+              </button>
+            </ModalBody>
+          </ModalContent>
+        )}
+      </Modal>
     </div>
   )
 }

--- a/docs/development/multi-buddy-channel-collaboration.zh-CN.md
+++ b/docs/development/multi-buddy-channel-collaboration.zh-CN.md
@@ -36,7 +36,7 @@
 
 ## 设计原则
 
-- 默认人类主导: Buddy 默认响应人类消息或明确 @，Buddy 间协作必须显式开启。
+- 默认人类主导: Buddy 默认响应人类消息或明确 @，协作对话默认开启，但 Buddy 间继续发言仍必须带协作 metadata 并通过 claim。
 - 一个 root 一个协作: 同一条 root 消息只创建一条协作记录，所有 Buddy 都围绕它 claim 发言权。
 - 平台分配发言权: runtime 不能只靠本地规则决定接话，必须先向平台 claim。
 - 主频道少噪声: 主频道放请求、短声明、最终结果；多轮、工具日志和中间状态优先进入 thread 或状态条。
@@ -162,6 +162,69 @@ type ClaimBuddyReplyResult =
       reason: "busy" | "duplicate" | "policy_denied" | "limit_reached" | "stopped";
     };
 ```
+
+## 回复规则细则
+
+适用范围: 公开频道里的自动 Buddy 回复。DM、Inbox task card、runtime 生命周期事件、工具进度、memory 更新、skill view/search/write、gateway shutdown 不进入这张表；它们要么走各自的任务协议，要么默认静默。
+
+### 触发矩阵
+
+| 触发者 | @ 场景 | 候选 Buddy | claim 模式 | 服务端仲裁 | 投递目标 | 体验预期 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 人类 | 不 @ Buddy | 频道策略允许“回复人类消息”的 Buddy | `initial`，`rootMessageId=message.id` | `mentionedBuddyIds=[]`，同一 root 首轮最多 1 个 Buddy claim 成功 | 默认 `main` | 普通聊天最多一个 Buddy 短答，不扩散成群聊。 |
+| 人类 | 单 @ 当前 Buddy | 被 @ 的 Buddy | `initial` | 只有被点名 Buddy 可以成功；其它 Buddy 返回 `policy_denied` 或本地静默 | 默认 `main` | 单点名就是单 Buddy 回复，覆盖普通“回复全部/仅 @/禁用自动回复”的差异。 |
+| 人类 | 单 @ 其它 Buddy | 当前 Buddy 不是候选 | 不 claim | 本地静默或服务端 `policy_denied` | 无 | 不发送“我不回答”确认文本。 |
+| 人类 | 多 @，包含当前 Buddy | 所有被 @ 的 Buddy | `initial` | 初始 claim 上限等于被点名 Buddy 数；未被点名 Buddy 拒绝 | 默认 root `thread` | 主频道只保留 root，多 Buddy 首轮起进入 thread。 |
+| 人类 | 多 @，不包含当前 Buddy | 当前 Buddy 不是候选 | 不 claim | 本地静默或服务端 `policy_denied` | 无 | 不蹭答、不补充、不解释。 |
+| Buddy | 带 `metadata.collaboration` | 未显式设置 `replyToBuddy=false` 且允许列表通过的 Buddy | `conversation`，复用原 `rootMessageId` | 达到 `maxTurns`、stopped、expired、重复 claim 时拒绝 | 复用协作 `thread`，无 thread 时按服务端返回 | 后续轮次只补一个新点；同意则 reaction 或静默。 |
+| Buddy | 不带 `metadata.collaboration` | 无 | 不 claim | 本地静默 | 无 | 普通 Buddy 发言不会自动触发另一个 Buddy。 |
+
+### 自定义策略优先级
+
+从上到下短路，越靠上优先级越高:
+
+| 优先级 | 规则 | 结果 |
+| --- | --- | --- |
+| 1 | 消息来自自己、已发送 echo、重复 delivery、被 `allow_from` 拦截 | 静默，不 claim。 |
+| 2 | runtime 私有事件、工具/进度/memory/skill/log、task card 协议消息 | 不作为公开自动回复触发；task card 走 Inbox/任务协议。 |
+| 3 | 人类明确 @ 当前 Buddy | 当前 Buddy 成为候选，即使频道是“仅 @”或普通自动回复关闭。 |
+| 4 | 人类明确 @ 其它 Buddy 且没有 @ 当前 Buddy | 当前 Buddy 静默。 |
+| 5 | `mentionOnly=true` 且没有 @ 当前 Buddy | 静默。 |
+| 6 | `reply=false` 且没有 @ 当前 Buddy | 静默。 |
+| 7 | Buddy 触发但 `replyToBuddy=false` | 静默。 |
+| 8 | Buddy 触发且命中 `buddyBlacklist`，或设置了 `buddyWhitelist` 但不在其中 | 静默。 |
+| 9 | 仍是候选的 Buddy 调用 `POST /api/buddy-collaborations/claim` | 只有 `ok:true` 才发给 runtime；失败原因不公开解释。 |
+
+约束:
+
+- 本地策略只负责“是否有资格 claim”；最终“谁能说、说第几轮、发到 main 还是 thread”只由 claim 结果决定。
+- Runtime 收到 claim 上下文后只拥有一轮公开发言权，不拥有自动跑工具、写文件、记忆、自我改进或继续发多条消息的权限。
+- 所有公开回复都必须把 `metadata.collaboration` 带回消息；thread/replyTo 也必须使用 claim 返回值，不能由 runtime 正文猜测。
+- 人类新 root 消息优先于旧协作；如果用户说停止、安静、不实现、先讨论，相关 Buddy 立即停止动作链。
+
+### 当前实现状态（2026-06-10）
+
+| Runtime | 初始人类消息 | Buddy 触发 | 协作上下文 | Thread/metadata 投递 |
+| --- | --- | --- | --- | --- |
+| OpenClaw ShadowOB | 已调整为不 @、单 @、多 @ 都先走 `claim(initial)`；单 @/多 @ 排他由 structured mentions 和服务端共同约束。 | 只处理带协作 metadata 且策略允许的 Buddy 消息。 | `bodyForAgent` 注入短协作规范。 | 已按 claim target/replyTo 写回。 |
+| Hermes ShadowOB plugin | 已调整为所有通过本地 preflight 的人类消息都走 `claim(initial)`。 | 只处理带协作 metadata 且策略允许的 Buddy 消息。 | `channel_prompt` 注入同一组规范。 | 已按 claim target/replyTo 写回。 |
+| cc-connect ShadowOB fork | 已调整为人类消息走 `claim(initial)`，明确 @ 可覆盖普通自动回复关闭。 | metadata 合法且未显式 `replyToBuddy=false` 时走 `claim(conversation)`。 | ShadowOB platform 给 agent `ExtraContent`，Cloud cc-connect 包默认拼接协作 system prompt。 | fork 已补齐 `metadata.collaboration`、`threadId`、`replyToId` 回写。 |
+
+### Runtime 模块边界
+
+每个 runtime 只允许保留三类本地模块，不能再把协作规则散落在消息处理大函数里:
+
+| 模块 | 职责 | 禁止 |
+| --- | --- | --- |
+| 本地 preflight | 过滤自己消息、echo、`allow_from`、`listen/reply/mentionOnly`、明确 @ 排他、Buddy 白黑名单、task card 旁路。 | 决定谁最终能说、改写 turn、猜测 thread。 |
+| Buddy collaboration claim adapter | 根据 preflight 结果构造 `initial` 或 `conversation` claim，校验 Buddy 消息必须有 `metadata.collaboration`，标准化 `collaboration/replyToId/target/threadId`。 | 在本地实现多 @ 分配、重复 claim、最大轮次、过期、停止。 |
+| delivery context | 把 claim 返回的 `metadata.collaboration`、`replyToId`、`threadId` 带回公开消息、表单、按钮和附件。 | 从自然语言正文推断 reaction/thread/reply target，或把 runtime 私有日志作为公开消息。 |
+
+落地文件:
+
+- OpenClaw: `packages/openclaw-shadowob/src/monitor/preflight.ts` + `packages/openclaw-shadowob/src/monitor/buddy-collaboration.ts` + delivery helpers。
+- Hermes: `packages/connector/hermes-shadowob-plugin/buddy_collaboration.py` + adapter 当前协作 context。
+- cc-connect fork: `platform/shadowob/collaboration.go` + `replyContext`/send helpers。
 
 规则:
 

--- a/integrations/kanban/shadow-app.local.json
+++ b/integrations/kanban/shadow-app.local.json
@@ -121,7 +121,7 @@
             }
           },
           "priority": {
-            "enum": ["low", "medium", "high", "urgent"]
+            "enum": ["low", "normal", "medium", "high"]
           },
           "progress": {
             "type": "number",
@@ -188,7 +188,7 @@
             }
           },
           "priority": {
-            "enum": ["low", "medium", "high", "urgent"]
+            "enum": ["low", "normal", "medium", "high"]
           },
           "progress": {
             "type": "number",
@@ -296,7 +296,7 @@
             "maxLength": 8000
           },
           "priority": {
-            "enum": ["low", "normal", "high", "urgent"]
+            "enum": ["low", "normal", "medium", "high"]
           },
           "tags": {
             "type": "array",

--- a/integrations/kanban/src/client/api.ts
+++ b/integrations/kanban/src/client/api.ts
@@ -147,8 +147,8 @@ export async function sendCoordinatorRequest(input: {
 }
 
 function cardDispatchPriority(priority: BoardCard['priority']) {
-  if (priority === 'urgent') return 'urgent'
   if (priority === 'high') return 'high'
+  if (priority === 'medium') return 'medium'
   if (priority === 'low') return 'low'
   return 'normal'
 }

--- a/integrations/kanban/src/outbox.ts
+++ b/integrations/kanban/src/outbox.ts
@@ -8,7 +8,7 @@ import type { BoardCard, BoardPerson, CardDispatchInput } from './types.js'
 const buddyPrefix = 'buddy:'
 
 function inboxTaskPriority(value: string | undefined) {
-  if (value === 'urgent' || value === 'high' || value === 'low') return value
+  if (value === 'low' || value === 'normal' || value === 'medium' || value === 'high') return value
   return 'normal'
 }
 

--- a/integrations/kanban/src/shadow-app.generated.ts
+++ b/integrations/kanban/src/shadow-app.generated.ts
@@ -128,7 +128,7 @@ export const shadowServerAppManifest = {
             },
           },
           priority: {
-            enum: ['low', 'medium', 'high', 'urgent'],
+            enum: ['low', 'normal', 'medium', 'high'],
           },
           progress: {
             type: 'number',
@@ -196,7 +196,7 @@ export const shadowServerAppManifest = {
             },
           },
           priority: {
-            enum: ['low', 'medium', 'high', 'urgent'],
+            enum: ['low', 'normal', 'medium', 'high'],
           },
           progress: {
             type: 'number',
@@ -306,7 +306,7 @@ export const shadowServerAppManifest = {
             maxLength: 8000,
           },
           priority: {
-            enum: ['low', 'normal', 'high', 'urgent'],
+            enum: ['low', 'normal', 'medium', 'high'],
           },
           tags: {
             type: 'array',

--- a/integrations/kanban/src/types.ts
+++ b/integrations/kanban/src/types.ts
@@ -94,7 +94,7 @@ export interface IssueCreateStepInput {
   artifactKind?: string
   prompt?: string
   dependsOn?: string[]
-  priority?: 'low' | 'medium' | 'high' | 'urgent'
+  priority?: 'low' | 'normal' | 'medium' | 'high'
   labels?: string[]
 }
 
@@ -126,7 +126,7 @@ export interface BoardCard {
   prompt?: string
   labels: string[]
   assignees: BoardPerson[]
-  priority?: 'low' | 'medium' | 'high' | 'urgent'
+  priority?: 'low' | 'normal' | 'medium' | 'high'
   status?: IssueStepStatus
   progress?: number
   issueStep?: BoardIssueStepCard
@@ -162,7 +162,7 @@ export interface CardCreateInput {
   prompt?: string
   label?: string
   labels?: string[]
-  priority?: 'low' | 'medium' | 'high' | 'urgent'
+  priority?: 'low' | 'normal' | 'medium' | 'high'
   progress?: number
   status?: IssueStepStatus
   assignee?: BoardPerson | string | null
@@ -176,7 +176,7 @@ export interface CardUpdateInput {
   description?: string
   prompt?: string
   labels?: string[]
-  priority?: 'low' | 'medium' | 'high' | 'urgent'
+  priority?: 'low' | 'normal' | 'medium' | 'high'
   progress?: number
   status?: IssueStepStatus
 }
@@ -233,7 +233,7 @@ export interface CardDispatchInput {
   assigneeAvatarUrl?: string | null
   title?: string
   body?: string
-  priority?: 'low' | 'normal' | 'high' | 'urgent'
+  priority?: 'low' | 'normal' | 'medium' | 'high'
   tags?: Array<string | { id?: string; label: string; color?: string }>
   idempotencyKey?: string
   requirements?: Record<string, unknown> | null

--- a/integrations/trainer/src/server.ts
+++ b/integrations/trainer/src/server.ts
@@ -284,9 +284,9 @@ function reviewFocusInstruction(submission: CodeSubmission, locale: TaskLocale) 
     : 'Focus on sandbox correctness: run cases, identify correctness gaps, and explain the core invariant.'
 }
 
-function reviewTaskPriority(submission: CodeSubmission): 'urgent' | 'high' {
+function reviewTaskPriority(submission: CodeSubmission): 'medium' | 'high' {
   const focus = submission.reviewRequest?.reviewFocus
-  return focus === 'debug' || focus === 'interview' ? 'urgent' : 'high'
+  return focus === 'debug' || focus === 'interview' ? 'high' : 'medium'
 }
 
 function reviewTaskAssigneeLabel(reviewRequest: NonNullable<CodeSubmission['reviewRequest']>) {

--- a/packages/cli/src/commands/inbox.ts
+++ b/packages/cli/src/commands/inbox.ts
@@ -107,7 +107,7 @@ export function createInboxCommand(): Command {
     .description('Enqueue a new task card into a Buddy Inbox')
     .requiredOption('--title <title>', 'Task title')
     .option('--body <text>', 'Task body')
-    .option('--priority <priority>', 'low|normal|high|urgent')
+    .option('--priority <priority>', 'low|normal|medium|high')
     .option('--tag <tag...>', 'Task tag; can be repeated or comma-separated')
     .option('--idempotency-key <key>', 'Idempotency key')
     .option('--server <server>', 'Server ID or slug; required with --agent')
@@ -124,7 +124,7 @@ export function createInboxCommand(): Command {
       async (options: {
         title: string
         body?: string
-        priority?: 'low' | 'normal' | 'high' | 'urgent'
+        priority?: 'low' | 'normal' | 'medium' | 'high'
         tag?: string[]
         idempotencyKey?: string
         server?: string
@@ -451,7 +451,7 @@ export function createInboxCommand(): Command {
     .requiredOption('--server <server>', 'Server ID or slug')
     .requiredOption('--agent <agent-id>', 'Buddy agent ID')
     .option('--title <title>', 'Task title override')
-    .option('--priority <priority>', 'low|normal|high|urgent')
+    .option('--priority <priority>', 'low|normal|medium|high')
     .option('--profile <name>', 'Profile to use')
     .option('--json', 'Output as JSON')
     .action(
@@ -461,7 +461,7 @@ export function createInboxCommand(): Command {
           server: string
           agent: string
           title?: string
-          priority?: 'low' | 'normal' | 'high' | 'urgent'
+          priority?: 'low' | 'normal' | 'medium' | 'high'
           profile?: string
           json?: boolean
         },

--- a/packages/connector/hermes-shadowob-plugin/adapter.py
+++ b/packages/connector/hermes-shadowob-plugin/adapter.py
@@ -61,8 +61,10 @@ except Exception:  # pragma: no cover - lets local static checks import this fil
         return None
 
 try:
+    from .buddy_collaboration import claim_buddy_collaboration_for_runtime, message_buddy_collaboration
     from .shadow_sdk import ShadowApiError, ShadowAsyncClient, ShadowSocketClient, parse_bool, split_csv
 except Exception:  # pragma: no cover - Hermes may load adapter.py as a loose module.
+    from buddy_collaboration import claim_buddy_collaboration_for_runtime, message_buddy_collaboration  # type: ignore
     from shadow_sdk import ShadowApiError, ShadowAsyncClient, ShadowSocketClient, parse_bool, split_csv  # type: ignore
 
 logger = logging.getLogger(__name__)
@@ -74,6 +76,10 @@ CURRENT_INBOUND_SHADOW_MESSAGE: contextvars.ContextVar[dict[str, Any] | None] = 
 )
 CURRENT_BUDDY_COLLABORATION: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
     "shadowob_current_buddy_collaboration",
+    default=None,
+)
+CURRENT_BUDDY_COLLABORATION_REPLY_TO_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "shadowob_current_buddy_collaboration_reply_to_id",
     default=None,
 )
 CURRENT_SHADOW_TOOL_EFFECTS: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
@@ -264,6 +270,7 @@ def _metadata_channel_id(metadata: dict[str, Any] | None) -> str | None:
 
 
 def _metadata_reply_to(metadata: dict[str, Any] | None, fallback: str | None = None) -> str | None:
+    fallback = fallback or CURRENT_BUDDY_COLLABORATION_REPLY_TO_ID.get()
     if not metadata:
         return fallback
     for key in ("reply_to_message_id", "replyToId", "reply_to", "shadow_reply_to_id"):
@@ -314,18 +321,7 @@ def _metadata_payload(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
 
 
 def _message_buddy_collaboration(message: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(message, dict):
-        return None
-    metadata = message.get("metadata")
-    if not isinstance(metadata, dict):
-        return None
-    collaboration = metadata.get("collaboration")
-    if isinstance(collaboration, dict):
-        return collaboration
-    custom = metadata.get("custom")
-    if isinstance(custom, dict) and isinstance(custom.get("collaboration"), dict):
-        return custom["collaboration"]
-    return None
+    return message_buddy_collaboration(message)
 
 
 def _message_buddy_mention_ids(message: dict[str, Any] | None) -> set[str]:
@@ -2450,9 +2446,9 @@ class ShadowOBAdapter(BasePlatformAdapter):
         if self._buddy_user_id and author_id == self._buddy_user_id:
             logger.debug("[Shadow] skipping own message %s", message_id)
             return
-        reply_to_buddy = parse_bool(policy_config.get("replyToBuddy"), False)
+        reply_to_buddy = parse_bool(policy_config.get("replyToBuddy"), True)
         if is_author_buddy:
-            if not (self._reply_to_buddies or reply_to_buddy or task_card):
+            if not (reply_to_buddy or task_card):
                 logger.debug("[Shadow] skipping Buddy-authored message %s", message_id)
                 return
             sender_ids = {str(item) for item in (author_id, author.get("id")) if item}
@@ -2505,69 +2501,47 @@ class ShadowOBAdapter(BasePlatformAdapter):
                 logger.debug("[Shadow] mention-only skipped message %s", message_id)
                 return
         buddy_collaboration: dict[str, Any] | None = None
-        if (
-            not is_author_buddy
-            and not task_card
-            and self.client is not None
-            and self._agent_id
-            and _message_has_multiple_buddy_mentions(message)
-        ):
-            try:
-                claim = await self.client.claim_buddy_reply(
-                    channel_id=channel_id,
-                    root_message_id=message_id,
-                    buddy_id=self._agent_id,
-                    reply_to_message_id=message_id,
-                    max_turns=_policy_int(policy_config, "maxBuddyTurns", 4),
-                    mode="initial",
-                )
-            except Exception as exc:
-                logger.debug("[Shadow] initial collaboration claim failed for message %s: %s", message_id, exc)
-                return
-            if not isinstance(claim, dict) or not claim.get("ok"):
-                reason = claim.get("reason") if isinstance(claim, dict) else "failed"
-                logger.debug("[Shadow] initial collaboration claim skipped message %s: %s", message_id, reason)
-                return
-            metadata = claim.get("metadata")
-            if isinstance(metadata, dict) and isinstance(metadata.get("collaboration"), dict):
-                buddy_collaboration = metadata["collaboration"]
-        if is_processing_buddy_message and not task_card and self.client is not None and self._agent_id:
-            collaboration_meta = _message_buddy_collaboration(message)
-            if not isinstance(collaboration_meta, dict):
-                logger.debug(
-                    "[Shadow] collaboration skipped for Buddy message %s: missing collaboration claim",
-                    message_id,
-                )
-                return
-            root_message_id = (
-                collaboration_meta.get("rootMessageId")
+        buddy_collaboration_reply_to_id: str | None = None
+        if self.client is not None:
+            collaboration_claim = await claim_buddy_collaboration_for_runtime(
+                client=self.client,
+                message=message,
+                channel_id=channel_id,
+                agent_id=self._agent_id,
+                max_turns=_policy_int(policy_config, "maxBuddyTurns", 4),
+                is_processing_buddy_message=is_processing_buddy_message,
+                has_task_card=bool(task_card),
             )
-            if not root_message_id:
-                logger.debug(
-                    "[Shadow] collaboration skipped for Buddy message %s: missing rootMessageId",
-                    message_id,
-                )
+            if not collaboration_claim.get("ok"):
+                mode = str(collaboration_claim.get("mode") or "")
+                reason = str(collaboration_claim.get("reason") or "failed")
+                error = collaboration_claim.get("error")
+                if error is not None:
+                    if mode == "initial":
+                        logger.debug(
+                            "[Shadow] initial collaboration claim failed for message %s: %s",
+                            message_id,
+                            error,
+                        )
+                    else:
+                        logger.debug("[Shadow] collaboration claim failed for message %s: %s", message_id, error)
+                elif reason == "missing_collaboration":
+                    logger.debug(
+                        "[Shadow] collaboration skipped for Buddy message %s: missing collaboration claim",
+                        message_id,
+                    )
+                elif mode == "initial":
+                    logger.debug("[Shadow] initial collaboration claim skipped message %s: %s", message_id, reason)
+                else:
+                    logger.debug("[Shadow] collaboration claim skipped message %s: %s", message_id, reason)
                 return
-            root_message_id = str(root_message_id)
-            try:
-                claim = await self.client.claim_buddy_reply(
-                    channel_id=channel_id,
-                    root_message_id=root_message_id,
-                    buddy_id=self._agent_id,
-                    reply_to_message_id=message_id,
-                    max_turns=_policy_int(policy_config, "maxBuddyTurns", 4),
-                    mode="conversation",
-                )
-            except Exception as exc:
-                logger.debug("[Shadow] collaboration claim failed for message %s: %s", message_id, exc)
-                return
-            if not isinstance(claim, dict) or not claim.get("ok"):
-                reason = claim.get("reason") if isinstance(claim, dict) else "failed"
-                logger.debug("[Shadow] collaboration claim skipped message %s: %s", message_id, reason)
-                return
-            metadata = claim.get("metadata")
-            if isinstance(metadata, dict) and isinstance(metadata.get("collaboration"), dict):
-                buddy_collaboration = metadata["collaboration"]
+            if collaboration_claim.get("claimed"):
+                collaboration = collaboration_claim.get("collaboration")
+                if isinstance(collaboration, dict):
+                    buddy_collaboration = collaboration
+                reply_to_id = collaboration_claim.get("reply_to_id")
+                if reply_to_id:
+                    buddy_collaboration_reply_to_id = str(reply_to_id)
         text = _text_without_self_mention(text, self._buddy_username)
         if await self._handle_shadow_control_command(
             text,
@@ -2585,6 +2559,9 @@ class ShadowOBAdapter(BasePlatformAdapter):
             if command.get("interaction") and not args.strip() and not passthrough:
                 token = CURRENT_INBOUND_SHADOW_MESSAGE.set(message)
                 collaboration_token = CURRENT_BUDDY_COLLABORATION.set(buddy_collaboration)
+                collaboration_reply_to_token = CURRENT_BUDDY_COLLABORATION_REPLY_TO_ID.set(
+                    buddy_collaboration_reply_to_id
+                )
                 try:
                     sent = await self._send_slash_interactive_prompt(
                         slash_match,
@@ -2593,6 +2570,7 @@ class ShadowOBAdapter(BasePlatformAdapter):
                         thread_id=thread_id,
                     )
                 finally:
+                    CURRENT_BUDDY_COLLABORATION_REPLY_TO_ID.reset(collaboration_reply_to_token)
                     CURRENT_BUDDY_COLLABORATION.reset(collaboration_token)
                     CURRENT_INBOUND_SHADOW_MESSAGE.reset(token)
                 if sent:
@@ -2671,6 +2649,9 @@ class ShadowOBAdapter(BasePlatformAdapter):
         task_card_id = _card_id(task_card) if task_card else None
         token = CURRENT_INBOUND_SHADOW_MESSAGE.set(message)
         collaboration_token = CURRENT_BUDDY_COLLABORATION.set(buddy_collaboration)
+        collaboration_reply_to_token = CURRENT_BUDDY_COLLABORATION_REPLY_TO_ID.set(
+            buddy_collaboration_reply_to_id
+        )
         tool_effects_token = CURRENT_SHADOW_TOOL_EFFECTS.set({})
         try:
             try:
@@ -2682,6 +2663,7 @@ class ShadowOBAdapter(BasePlatformAdapter):
                 await self._complete_task_card(message_id, task_card_id)
         finally:
             CURRENT_SHADOW_TOOL_EFFECTS.reset(tool_effects_token)
+            CURRENT_BUDDY_COLLABORATION_REPLY_TO_ID.reset(collaboration_reply_to_token)
             CURRENT_BUDDY_COLLABORATION.reset(collaboration_token)
             CURRENT_INBOUND_SHADOW_MESSAGE.reset(token)
 

--- a/packages/connector/hermes-shadowob-plugin/buddy_collaboration.py
+++ b/packages/connector/hermes-shadowob-plugin/buddy_collaboration.py
@@ -1,0 +1,96 @@
+"""Buddy collaboration claim adapter for the ShadowOB Hermes runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def message_buddy_collaboration(message: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(message, dict):
+        return None
+    metadata = message.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    collaboration = metadata.get("collaboration")
+    if isinstance(collaboration, dict):
+        return collaboration
+    custom = metadata.get("custom")
+    if isinstance(custom, dict) and isinstance(custom.get("collaboration"), dict):
+        return custom["collaboration"]
+    return None
+
+
+def _claim_context(claim: dict[str, Any], *, root_message_id: str, buddy_id: str) -> dict[str, Any]:
+    metadata = claim.get("metadata")
+    collaboration = metadata.get("collaboration") if isinstance(metadata, dict) else None
+    if not isinstance(collaboration, dict):
+        collaboration = {
+            "id": claim.get("collaborationId"),
+            "rootMessageId": root_message_id,
+            "buddyId": buddy_id,
+            "turn": claim.get("turn"),
+            "target": claim.get("target"),
+        }
+        if claim.get("threadId"):
+            collaboration["threadId"] = claim.get("threadId")
+    return {
+        "ok": True,
+        "claimed": True,
+        "collaboration": collaboration,
+        "reply_to_id": claim.get("replyToId"),
+        "target": claim.get("target"),
+        "thread_id": claim.get("threadId"),
+    }
+
+
+async def claim_buddy_collaboration_for_runtime(
+    *,
+    client: Any,
+    message: dict[str, Any],
+    channel_id: str,
+    agent_id: str | None,
+    max_turns: int,
+    is_processing_buddy_message: bool,
+    has_task_card: bool,
+) -> dict[str, Any]:
+    message_id = str(message.get("id") or "")
+    if not agent_id or has_task_card:
+        return {"ok": True, "claimed": False}
+
+    if not is_processing_buddy_message:
+        try:
+            claim = await client.claim_buddy_reply(
+                channel_id=channel_id,
+                root_message_id=message_id,
+                buddy_id=agent_id,
+                reply_to_message_id=message_id,
+                max_turns=max_turns,
+                mode="initial",
+            )
+        except Exception as exc:  # pragma: no cover - exercised through adapter logs.
+            return {"ok": False, "mode": "initial", "reason": "failed", "error": exc}
+        if not isinstance(claim, dict) or not claim.get("ok"):
+            reason = claim.get("reason") if isinstance(claim, dict) else "failed"
+            return {"ok": False, "mode": "initial", "reason": reason}
+        return {**_claim_context(claim, root_message_id=message_id, buddy_id=agent_id), "mode": "initial"}
+
+    collaboration = message_buddy_collaboration(message)
+    if not isinstance(collaboration, dict) or not collaboration.get("rootMessageId"):
+        return {"ok": False, "mode": "conversation", "reason": "missing_collaboration"}
+
+    root_message_id = str(collaboration.get("rootMessageId"))
+    try:
+        claim = await client.claim_buddy_reply(
+            channel_id=channel_id,
+            root_message_id=root_message_id,
+            buddy_id=agent_id,
+            reply_to_message_id=message_id,
+            max_turns=max_turns,
+            mode="conversation",
+        )
+    except Exception as exc:  # pragma: no cover - exercised through adapter logs.
+        return {"ok": False, "mode": "conversation", "reason": "failed", "error": exc}
+    if not isinstance(claim, dict) or not claim.get("ok"):
+        reason = claim.get("reason") if isinstance(claim, dict) else "failed"
+        return {"ok": False, "mode": "conversation", "reason": reason}
+    return {**_claim_context(claim, root_message_id=root_message_id, buddy_id=agent_id), "mode": "conversation"}

--- a/packages/connector/hermes-shadowob-plugin/tests/test_adapter_env.py
+++ b/packages/connector/hermes-shadowob-plugin/tests/test_adapter_env.py
@@ -9,6 +9,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 import adapter
+import buddy_collaboration
 from shadow_sdk import ShadowAsyncClient
 
 
@@ -257,6 +258,145 @@ def test_format_buddy_collaboration_prompt_injects_runtime_rules():
     assert 'Never post them as channel messages' in prompt
 
 
+def test_buddy_collaboration_claims_initial_human_turn():
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        async def claim_buddy_reply(self, **kwargs):
+            self.calls.append(kwargs)
+            return {
+                'ok': True,
+                'collaborationId': 'collab-1',
+                'turn': 1,
+                'replyToId': 'root-1',
+                'target': 'main',
+                'metadata': {
+                    'collaboration': {
+                        'id': 'collab-1',
+                        'rootMessageId': kwargs['root_message_id'],
+                        'buddyId': kwargs['buddy_id'],
+                        'turn': 1,
+                        'target': 'main',
+                    }
+                },
+            }
+
+    client = FakeClient()
+    result = asyncio.run(
+        buddy_collaboration.claim_buddy_collaboration_for_runtime(
+            client=client,
+            message={'id': 'root-1'},
+            channel_id='channel-1',
+            agent_id='buddy-1',
+            max_turns=3,
+            is_processing_buddy_message=False,
+            has_task_card=False,
+        )
+    )
+
+    assert client.calls == [
+        {
+            'channel_id': 'channel-1',
+            'root_message_id': 'root-1',
+            'buddy_id': 'buddy-1',
+            'reply_to_message_id': 'root-1',
+            'max_turns': 3,
+            'mode': 'initial',
+        }
+    ]
+    assert result['ok'] is True
+    assert result['claimed'] is True
+    assert result['reply_to_id'] == 'root-1'
+    assert result['collaboration']['rootMessageId'] == 'root-1'
+
+
+def test_buddy_collaboration_skips_buddy_message_without_metadata():
+    class FakeClient:
+        async def claim_buddy_reply(self, **kwargs):
+            raise AssertionError('claim should not be called')
+
+    result = asyncio.run(
+        buddy_collaboration.claim_buddy_collaboration_for_runtime(
+            client=FakeClient(),
+            message={'id': 'buddy-msg-1', 'metadata': {}},
+            channel_id='channel-1',
+            agent_id='buddy-1',
+            max_turns=4,
+            is_processing_buddy_message=True,
+            has_task_card=False,
+        )
+    )
+
+    assert result == {'ok': False, 'mode': 'conversation', 'reason': 'missing_collaboration'}
+
+
+def test_buddy_collaboration_claims_conversation_turn_from_root_metadata():
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        async def claim_buddy_reply(self, **kwargs):
+            self.calls.append(kwargs)
+            return {
+                'ok': True,
+                'collaborationId': 'collab-1',
+                'turn': 2,
+                'replyToId': 'buddy-msg-1',
+                'target': 'thread',
+                'threadId': 'thread-1',
+                'metadata': {
+                    'collaboration': {
+                        'id': 'collab-1',
+                        'rootMessageId': kwargs['root_message_id'],
+                        'buddyId': kwargs['buddy_id'],
+                        'turn': 2,
+                        'target': 'thread',
+                        'threadId': 'thread-1',
+                    }
+                },
+            }
+
+    client = FakeClient()
+    result = asyncio.run(
+        buddy_collaboration.claim_buddy_collaboration_for_runtime(
+            client=client,
+            message={
+                'id': 'buddy-msg-1',
+                'metadata': {
+                    'collaboration': {
+                        'id': 'collab-1',
+                        'rootMessageId': 'root-1',
+                        'buddyId': 'buddy-2',
+                        'turn': 1,
+                    }
+                },
+            },
+            channel_id='channel-1',
+            agent_id='buddy-1',
+            max_turns=2,
+            is_processing_buddy_message=True,
+            has_task_card=False,
+        )
+    )
+
+    assert client.calls == [
+        {
+            'channel_id': 'channel-1',
+            'root_message_id': 'root-1',
+            'buddy_id': 'buddy-1',
+            'reply_to_message_id': 'buddy-msg-1',
+            'max_turns': 2,
+            'mode': 'conversation',
+        }
+    ]
+    assert result['ok'] is True
+    assert result['claimed'] is True
+    assert result['target'] == 'thread'
+    assert result['thread_id'] == 'thread-1'
+    assert result['reply_to_id'] == 'buddy-msg-1'
+
+
 def test_metadata_payload_flattens_custom_shadow_fields():
     collaboration = {
         'id': 'collab-1',
@@ -352,6 +492,53 @@ def test_platform_send_routes_collaboration_target_to_thread():
             '补一个不同角度',
             {
                 'reply_to_id': 'message-1',
+                'metadata': {
+                    'collaboration': collaboration,
+                },
+            },
+        )
+    ]
+
+
+def test_platform_send_uses_collaboration_reply_target_fallback():
+    class FakeClient:
+        def __init__(self):
+            self.sent = []
+
+        async def send_message(self, channel_id, content, **kwargs):
+            self.sent.append((channel_id, content, kwargs))
+            return {'id': 'message-1'}
+
+    instance = adapter.ShadowOBAdapter.__new__(adapter.ShadowOBAdapter)
+    instance.client = FakeClient()
+    instance._resolve_outbound_channel = lambda chat_id, metadata: ('channel-1', None)
+
+    async def set_activity(channel_id, status):
+        return None
+
+    instance._set_activity = set_activity
+    collaboration = {
+        'id': 'collab-1',
+        'rootMessageId': 'root-1',
+        'buddyId': 'agent-1',
+        'turn': 1,
+        'target': 'main',
+    }
+    collaboration_token = adapter.CURRENT_BUDDY_COLLABORATION.set(collaboration)
+    reply_to_token = adapter.CURRENT_BUDDY_COLLABORATION_REPLY_TO_ID.set('claim-reply-target')
+    try:
+        result = asyncio.run(instance.send('channel-1', '收到'))
+    finally:
+        adapter.CURRENT_BUDDY_COLLABORATION_REPLY_TO_ID.reset(reply_to_token)
+        adapter.CURRENT_BUDDY_COLLABORATION.reset(collaboration_token)
+
+    assert result.success is True
+    assert instance.client.sent == [
+        (
+            'channel-1',
+            '收到',
+            {
+                'reply_to_id': 'claim-reply-target',
                 'metadata': {
                     'collaboration': collaboration,
                 },
@@ -526,6 +713,83 @@ def test_task_card_failure_is_terminal():
             'note': 'boom',
         }
     ]
+
+
+def test_hermes_buddy_message_defaults_to_collaboration_claim(monkeypatch):
+    calls = []
+
+    async def fake_claim(**kwargs):
+        calls.append(kwargs)
+        return {'ok': False, 'mode': 'conversation', 'reason': 'missing_collaboration'}
+
+    monkeypatch.setattr(adapter, 'claim_buddy_collaboration_for_runtime', fake_claim)
+    instance = adapter.ShadowOBAdapter.__new__(adapter.ShadowOBAdapter)
+    instance.client = object()
+    instance._processed_set = set()
+    instance._remember_processed = lambda message_id: None
+    instance._channel_ids = []
+    instance._channel_cache = {}
+    instance._channel_policies = {'channel-1': {'listen': True, 'reply': True, 'config': {}}}
+    instance._buddy_user_id = 'bot-1'
+    instance._buddy_username = 'buddy'
+    instance._agent_id = 'buddy-1'
+    instance._mention_only = False
+    instance._message_mentions_self = lambda message: False
+    instance._set_runtime_current_channel = lambda *args, **kwargs: None
+    instance._set_runtime_home_channel = lambda *args, **kwargs: None
+
+    asyncio.run(
+        instance._handle_shadow_message(
+            {
+                'id': 'buddy-msg-1',
+                'channelId': 'channel-1',
+                'authorId': 'buddy-user-2',
+                'content': 'One more point.',
+                'author': {'id': 'buddy-user-2', 'username': 'other-buddy', 'isBot': True},
+            },
+            source='test',
+        )
+    )
+
+    assert len(calls) == 1
+    assert calls[0]['is_processing_buddy_message'] is True
+    assert calls[0]['agent_id'] == 'buddy-1'
+
+
+def test_hermes_buddy_message_honors_explicit_reply_to_buddy_false(monkeypatch):
+    async def fake_claim(**kwargs):
+        raise AssertionError('claim should not be called')
+
+    monkeypatch.setattr(adapter, 'claim_buddy_collaboration_for_runtime', fake_claim)
+    instance = adapter.ShadowOBAdapter.__new__(adapter.ShadowOBAdapter)
+    instance.client = object()
+    instance._processed_set = set()
+    instance._remember_processed = lambda message_id: None
+    instance._channel_ids = []
+    instance._channel_cache = {}
+    instance._channel_policies = {
+        'channel-1': {'listen': True, 'reply': True, 'config': {'replyToBuddy': False}}
+    }
+    instance._buddy_user_id = 'bot-1'
+    instance._buddy_username = 'buddy'
+    instance._agent_id = 'buddy-1'
+    instance._mention_only = False
+    instance._message_mentions_self = lambda message: False
+    instance._set_runtime_current_channel = lambda *args, **kwargs: None
+    instance._set_runtime_home_channel = lambda *args, **kwargs: None
+
+    asyncio.run(
+        instance._handle_shadow_message(
+            {
+                'id': 'buddy-msg-1',
+                'channelId': 'channel-1',
+                'authorId': 'buddy-user-2',
+                'content': 'One more point.',
+                'author': {'id': 'buddy-user-2', 'username': 'other-buddy', 'isBot': True},
+            },
+            source='test',
+        )
+    )
 
 
 def test_shadow_client_claim_buddy_reply_forwards_claim_mode():

--- a/packages/openclaw-shadowob/__tests__/buddy-collaboration.test.ts
+++ b/packages/openclaw-shadowob/__tests__/buddy-collaboration.test.ts
@@ -1,0 +1,163 @@
+import type { ShadowMessage } from '@shadowob/sdk'
+import { describe, expect, it, vi } from 'vitest'
+import { claimBuddyCollaborationForRuntime } from '../src/monitor/buddy-collaboration.js'
+
+function message(input: Partial<ShadowMessage>): ShadowMessage {
+  return {
+    id: 'msg-1',
+    content: 'hello',
+    channelId: 'channel-1',
+    authorId: 'user-1',
+    createdAt: '2026-06-10T00:00:00.000Z',
+    updatedAt: '2026-06-10T00:00:00.000Z',
+    ...input,
+  } as ShadowMessage
+}
+
+function okClaim(input: {
+  rootMessageId: string
+  buddyId: string
+  turn: number
+  target?: 'main' | 'thread'
+  threadId?: string
+}) {
+  const target = input.target ?? 'main'
+  return {
+    ok: true as const,
+    collaborationId: 'collab-1',
+    turn: input.turn,
+    replyToId: 'reply-to-1',
+    target,
+    ...(input.threadId ? { threadId: input.threadId } : {}),
+    suggestedTextLimit: target === 'main' ? 160 : 360,
+    replyDensity: 'short' as const,
+    metadata: {
+      collaboration: {
+        id: 'collab-1',
+        rootMessageId: input.rootMessageId,
+        buddyId: input.buddyId,
+        turn: input.turn,
+        target,
+        ...(input.threadId ? { threadId: input.threadId } : {}),
+        suggestedTextLimit: target === 'main' ? 160 : 360,
+        replyDensity: 'short' as const,
+      },
+    },
+  }
+}
+
+describe('OpenClaw Buddy collaboration claim adapter', () => {
+  it('claims initial turns for human messages that pass preflight', async () => {
+    const claimBuddyReply = vi.fn(async (input) =>
+      okClaim({ rootMessageId: input.rootMessageId, buddyId: input.buddyId, turn: 1 }),
+    )
+
+    const result = await claimBuddyCollaborationForRuntime({
+      client: { claimBuddyReply },
+      message: message({ id: 'root-1' }),
+      channelId: 'channel-1',
+      agentId: 'buddy-1',
+      maxTurns: 3,
+      isProcessingBuddyMessage: false,
+      hasRuntimeTaskCard: false,
+    })
+
+    expect(claimBuddyReply).toHaveBeenCalledWith({
+      channelId: 'channel-1',
+      rootMessageId: 'root-1',
+      buddyId: 'buddy-1',
+      replyToMessageId: 'root-1',
+      maxTurns: 3,
+      mode: 'initial',
+    })
+    expect(result).toMatchObject({
+      ok: true,
+      claimed: true,
+      replyToId: 'reply-to-1',
+      target: 'main',
+      collaboration: {
+        id: 'collab-1',
+        rootMessageId: 'root-1',
+        buddyId: 'buddy-1',
+        turn: 1,
+      },
+    })
+  })
+
+  it('skips Buddy messages that do not carry collaboration metadata', async () => {
+    const claimBuddyReply = vi.fn()
+
+    const result = await claimBuddyCollaborationForRuntime({
+      client: { claimBuddyReply },
+      message: message({
+        id: 'buddy-msg-1',
+        authorId: 'buddy-user-2',
+        author: { id: 'buddy-user-2', username: 'other-buddy', isBot: true },
+      }),
+      channelId: 'channel-1',
+      agentId: 'buddy-1',
+      isProcessingBuddyMessage: true,
+      hasRuntimeTaskCard: false,
+    })
+
+    expect(claimBuddyReply).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      ok: false,
+      mode: 'conversation',
+      reason: 'missing_collaboration',
+    })
+  })
+
+  it('claims conversation turns using the original collaboration root', async () => {
+    const claimBuddyReply = vi.fn(async (input) =>
+      okClaim({
+        rootMessageId: input.rootMessageId,
+        buddyId: input.buddyId,
+        turn: 2,
+        target: 'thread',
+        threadId: 'thread-1',
+      }),
+    )
+
+    const result = await claimBuddyCollaborationForRuntime({
+      client: { claimBuddyReply },
+      message: message({
+        id: 'buddy-msg-1',
+        authorId: 'buddy-user-2',
+        author: { id: 'buddy-user-2', username: 'other-buddy', isBot: true },
+        metadata: {
+          collaboration: {
+            id: 'collab-1',
+            rootMessageId: 'root-1',
+            buddyId: 'buddy-2',
+            turn: 1,
+          },
+        },
+      }),
+      channelId: 'channel-1',
+      agentId: 'buddy-1',
+      maxTurns: 2,
+      isProcessingBuddyMessage: true,
+      hasRuntimeTaskCard: false,
+    })
+
+    expect(claimBuddyReply).toHaveBeenCalledWith({
+      channelId: 'channel-1',
+      rootMessageId: 'root-1',
+      buddyId: 'buddy-1',
+      replyToMessageId: 'buddy-msg-1',
+      maxTurns: 2,
+      mode: 'conversation',
+    })
+    expect(result).toMatchObject({
+      ok: true,
+      claimed: true,
+      target: 'thread',
+      threadId: 'thread-1',
+      collaboration: {
+        rootMessageId: 'root-1',
+        turn: 2,
+      },
+    })
+  })
+})

--- a/packages/openclaw-shadowob/__tests__/mentions.test.ts
+++ b/packages/openclaw-shadowob/__tests__/mentions.test.ts
@@ -271,7 +271,7 @@ describe('Shadow OpenClaw mentions', () => {
     if (!result.ok) expect(result.reason).toContain('Policy blocks reply')
   })
 
-  it('skips ordinary Buddy messages unless replyToBuddy is enabled', () => {
+  it('processes Buddy messages by default so the claim adapter can enforce collaboration metadata', () => {
     const result = evaluateShadowMessagePreflight({
       message: baseMessage({
         authorId: 'buddy-user-2',
@@ -284,6 +284,28 @@ describe('Shadow OpenClaw mentions', () => {
       buddyUserId: 'bot-1',
       buddyUsername: 'workspace-buddy',
       channelPolicies: new Map([['channel-1', { listen: true, reply: true, config: {} }]] as never),
+      runtime: { log: vi.fn(), error: vi.fn() },
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.isProcessingBuddyMessage).toBe(true)
+  })
+
+  it('skips Buddy messages when replyToBuddy is explicitly disabled', () => {
+    const result = evaluateShadowMessagePreflight({
+      message: baseMessage({
+        authorId: 'buddy-user-2',
+        author: {
+          id: 'agent-2',
+          username: 'other-buddy',
+          isBot: true,
+        },
+      } as Partial<ShadowMessage>),
+      buddyUserId: 'bot-1',
+      buddyUsername: 'workspace-buddy',
+      channelPolicies: new Map([
+        ['channel-1', { listen: true, reply: true, config: { replyToBuddy: false } }],
+      ] as never),
       runtime: { log: vi.fn(), error: vi.fn() },
     })
 
@@ -415,7 +437,10 @@ describe('Shadow OpenClaw mentions', () => {
       buddyUserId: 'bot-1',
       buddyUsername: 'workspace-buddy',
       channelPolicies: new Map([
-        ['channel-1', { listen: true, reply: true, mentionOnly: true, config: {} }],
+        [
+          'channel-1',
+          { listen: true, reply: true, mentionOnly: true, config: { replyToBuddy: false } },
+        ],
       ] as never),
       runtime,
     })
@@ -549,7 +574,10 @@ describe('Shadow OpenClaw mentions', () => {
       buddyId: 'agent-1',
       buddyUsername: 'workspace-buddy',
       channelPolicies: new Map([
-        ['channel-1', { listen: true, reply: true, mentionOnly: true, config: {} }],
+        [
+          'channel-1',
+          { listen: true, reply: true, mentionOnly: true, config: { replyToBuddy: false } },
+        ],
       ] as never),
       runtime: { log: vi.fn(), error: vi.fn() },
     })

--- a/packages/openclaw-shadowob/__tests__/plugin.test.ts
+++ b/packages/openclaw-shadowob/__tests__/plugin.test.ts
@@ -471,7 +471,14 @@ describe('Slash Commands', () => {
           }),
         }),
       )
-      expect(claimBuddyReply).not.toHaveBeenCalled()
+      expect(claimBuddyReply).toHaveBeenCalledWith({
+        channelId: 'ch-1',
+        rootMessageId: 'msg-1',
+        buddyId: 'strategy-buddy',
+        replyToMessageId: 'msg-1',
+        maxTurns: undefined,
+        mode: 'initial',
+      })
       vi.runOnlyPendingTimers()
     } finally {
       vi.useRealTimers()

--- a/packages/openclaw-shadowob/src/monitor/buddy-collaboration.ts
+++ b/packages/openclaw-shadowob/src/monitor/buddy-collaboration.ts
@@ -1,0 +1,110 @@
+import type {
+  ShadowBuddyReplyClaimInput,
+  ShadowBuddyReplyClaimResult,
+  ShadowMessage,
+} from '@shadowob/sdk'
+import type { BuddyCollaborationMetadata } from '../types.js'
+
+export type BuddyCollaborationClaimClient = {
+  claimBuddyReply(input: ShadowBuddyReplyClaimInput): Promise<ShadowBuddyReplyClaimResult>
+}
+
+export type BuddyCollaborationClaimContext = {
+  collaboration: BuddyCollaborationMetadata
+  replyToId: string
+  target: 'main' | 'thread'
+  threadId?: string
+}
+
+export type BuddyCollaborationRuntimeClaimResult =
+  | {
+      ok: true
+      claimed: false
+    }
+  | ({
+      ok: true
+      claimed: true
+    } & BuddyCollaborationClaimContext)
+  | {
+      ok: false
+      mode: 'initial' | 'conversation'
+      reason: string
+      error?: unknown
+    }
+
+function messageCollaboration(message: ShadowMessage): BuddyCollaborationMetadata | undefined {
+  return message.metadata?.collaboration as BuddyCollaborationMetadata | undefined
+}
+
+function claimContext(
+  claim: Extract<ShadowBuddyReplyClaimResult, { ok: true }>,
+): BuddyCollaborationClaimContext {
+  return {
+    collaboration: claim.metadata.collaboration,
+    replyToId: claim.replyToId,
+    target: claim.target,
+    ...(claim.threadId ? { threadId: claim.threadId } : {}),
+  }
+}
+
+export async function claimBuddyCollaborationForRuntime(params: {
+  client: BuddyCollaborationClaimClient
+  message: ShadowMessage
+  channelId: string
+  agentId: string | null | undefined
+  maxTurns?: number
+  isProcessingBuddyMessage: boolean
+  hasRuntimeTaskCard: boolean
+}): Promise<BuddyCollaborationRuntimeClaimResult> {
+  const {
+    client,
+    message,
+    channelId,
+    agentId,
+    maxTurns,
+    isProcessingBuddyMessage,
+    hasRuntimeTaskCard,
+  } = params
+  if (!agentId || hasRuntimeTaskCard) return { ok: true, claimed: false }
+
+  if (!isProcessingBuddyMessage) {
+    try {
+      const claim = await client.claimBuddyReply({
+        channelId,
+        rootMessageId: message.id,
+        buddyId: agentId,
+        replyToMessageId: message.id,
+        maxTurns,
+        mode: 'initial',
+      })
+      if (!claim.ok) {
+        return { ok: false, mode: 'initial', reason: claim.reason }
+      }
+      return { ok: true, claimed: true, ...claimContext(claim) }
+    } catch (error) {
+      return { ok: false, mode: 'initial', reason: 'failed', error }
+    }
+  }
+
+  const collaboration = messageCollaboration(message)
+  if (!collaboration?.rootMessageId) {
+    return { ok: false, mode: 'conversation', reason: 'missing_collaboration' }
+  }
+
+  try {
+    const claim = await client.claimBuddyReply({
+      channelId,
+      rootMessageId: collaboration.rootMessageId,
+      buddyId: agentId,
+      replyToMessageId: message.id,
+      maxTurns,
+      mode: 'conversation',
+    })
+    if (!claim.ok) {
+      return { ok: false, mode: 'conversation', reason: claim.reason }
+    }
+    return { ok: true, claimed: true, ...claimContext(claim) }
+  } catch (error) {
+    return { ok: false, mode: 'conversation', reason: 'failed', error }
+  }
+}

--- a/packages/openclaw-shadowob/src/monitor/channel-message.ts
+++ b/packages/openclaw-shadowob/src/monitor/channel-message.ts
@@ -13,7 +13,6 @@ import type { OpenClawConfig, PluginRuntime } from 'openclaw/plugin-sdk/core'
 import {
   formatShadowMentionsForAgent,
   getShadowMessageMentions,
-  hasMultipleBuddyMentions,
   mentionContextFields,
   mentionsTargetServerApp,
   mentionTargetsBuddy,
@@ -25,6 +24,7 @@ import type {
   ShadowRuntimeLogger,
   ShadowSlashCommand,
 } from '../types.js'
+import { claimBuddyCollaborationForRuntime } from './buddy-collaboration.js'
 import {
   buddyCollaborationContextFields,
   formatBuddyCollaborationContext,
@@ -675,73 +675,54 @@ export async function processShadowMessage(params: {
   }
 
   const structuredMentions = getShadowMessageMentions(message)
-  const triggerCollaboration = message.metadata?.collaboration
   let collaboration: BuddyCollaborationMetadata | undefined
   let collaborationReplyToId: string | undefined
   let collaborationTarget: 'main' | 'thread' = 'main'
   let collaborationThreadId: string | undefined
-  if (
-    !preflight.isProcessingBuddyMessage &&
-    !runtimeTaskCard &&
-    agentId &&
-    hasMultipleBuddyMentions(structuredMentions)
-  ) {
-    const claim = await mediaClient
-      .claimBuddyReply({
-        channelId,
-        rootMessageId: message.id,
-        buddyId: agentId,
-        replyToMessageId: message.id,
-        maxTurns: preflight.policyConfig?.maxBuddyTurns,
-        mode: 'initial',
-      })
-      .catch((err) => {
+  const collaborationClaim = await claimBuddyCollaborationForRuntime({
+    client: mediaClient,
+    message,
+    channelId,
+    agentId,
+    maxTurns: preflight.policyConfig?.maxBuddyTurns,
+    isProcessingBuddyMessage: preflight.isProcessingBuddyMessage,
+    hasRuntimeTaskCard: Boolean(runtimeTaskCard),
+  })
+  if (!collaborationClaim.ok) {
+    if (collaborationClaim.error) {
+      if (collaborationClaim.mode === 'initial') {
         runtime.error?.(
-          `[collab] Failed to claim initial Buddy reply for ${message.id}: ${String(err)}`,
+          `[collab] Failed to claim initial Buddy reply for ${message.id}: ${String(
+            collaborationClaim.error,
+          )}`,
         )
-        return null
-      })
-    if (!claim?.ok) {
-      runtime.log?.(
-        `[collab] Skipping initial Buddy reply for ${message.id}; claim=${claim?.reason ?? 'failed'}`,
-      )
-      return
-    }
-    collaboration = claim.metadata.collaboration
-    collaborationReplyToId = claim.replyToId
-    collaborationTarget = claim.target
-    collaborationThreadId = claim.threadId
-  } else if (preflight.isProcessingBuddyMessage && !runtimeTaskCard && agentId) {
-    if (!triggerCollaboration) {
+      } else {
+        runtime.error?.(
+          `[collab] Failed to claim Buddy reply for ${message.id}: ${String(
+            collaborationClaim.error,
+          )}`,
+        )
+      }
+    } else if (collaborationClaim.reason === 'missing_collaboration') {
       runtime.log?.(
         `[collab] Skipping Buddy reply for ${message.id}; message has no collaboration claim`,
       )
-      return
-    }
-    const rootMessageId = triggerCollaboration.rootMessageId
-    const claim = await mediaClient
-      .claimBuddyReply({
-        channelId,
-        rootMessageId,
-        buddyId: agentId,
-        replyToMessageId: message.id,
-        maxTurns: preflight.policyConfig?.maxBuddyTurns,
-        mode: 'conversation',
-      })
-      .catch((err) => {
-        runtime.error?.(`[collab] Failed to claim Buddy reply for ${message.id}: ${String(err)}`)
-        return null
-      })
-    if (!claim?.ok) {
+    } else if (collaborationClaim.mode === 'initial') {
       runtime.log?.(
-        `[collab] Skipping Buddy reply for ${message.id}; claim=${claim?.reason ?? 'failed'}`,
+        `[collab] Skipping initial Buddy reply for ${message.id}; claim=${collaborationClaim.reason}`,
       )
-      return
+    } else {
+      runtime.log?.(
+        `[collab] Skipping Buddy reply for ${message.id}; claim=${collaborationClaim.reason}`,
+      )
     }
-    collaboration = claim.metadata.collaboration
-    collaborationReplyToId = claim.replyToId
-    collaborationTarget = claim.target
-    collaborationThreadId = claim.threadId
+    return
+  }
+  if (collaborationClaim.claimed) {
+    collaboration = collaborationClaim.collaboration
+    collaborationReplyToId = collaborationClaim.replyToId
+    collaborationTarget = collaborationClaim.target
+    collaborationThreadId = collaborationClaim.threadId
   }
 
   if (

--- a/packages/openclaw-shadowob/src/monitor/preflight.ts
+++ b/packages/openclaw-shadowob/src/monitor/preflight.ts
@@ -74,7 +74,7 @@ export function evaluateShadowMessagePreflight(params: {
   }
 
   if (message.author?.isBot) {
-    if (!policyConfig?.replyToBuddy && !hasActiveTaskForBuddy) {
+    if (policyConfig?.replyToBuddy === false && !hasActiveTaskForBuddy) {
       return {
         ok: false,
         reason: `[msg] Skipping Buddy message from ${senderLabel} (replyToBuddy=false) (${message.id})`,
@@ -103,7 +103,7 @@ export function evaluateShadowMessagePreflight(params: {
     }
 
     isProcessingBuddyMessage = true
-    const triggerReason = policyConfig?.replyToBuddy ? 'replyToBuddy=true' : 'active task-card'
+    const triggerReason = hasActiveTaskForBuddy ? 'active task-card' : 'replyToBuddy=true'
     runtime.log?.(
       `[msg] Processing Buddy message from ${senderLabel} (${triggerReason}) (${message.id})`,
     )

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1430,7 +1430,7 @@ export class ShadowClient {
       serverId: string
       agentId: string
       title?: string
-      priority?: 'low' | 'normal' | 'high' | 'urgent'
+      priority?: 'low' | 'normal' | 'medium' | 'high'
     },
   ): Promise<ShadowMessage> {
     return this.request<ShadowMessage>(`/api/messages/${messageId}/inbox/tasks`, {

--- a/packages/sdk/src/server-app.ts
+++ b/packages/sdk/src/server-app.ts
@@ -74,7 +74,7 @@ export interface ShadowServerAppLaunchOutboxDeliveryOptions
   result: unknown
 }
 
-export type ShadowServerAppInboxTaskPriority = 'low' | 'normal' | 'high' | 'urgent'
+export type ShadowServerAppInboxTaskPriority = 'low' | 'normal' | 'medium' | 'high'
 
 export interface ShadowServerAppInboxTaskResource {
   kind: string

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -292,7 +292,7 @@ export interface ShadowBuddyInboxAdmissionPendingActionResult {
 export interface ShadowInboxTaskInput {
   title: string
   body?: string
-  priority?: 'low' | 'normal' | 'high' | 'urgent'
+  priority?: 'low' | 'normal' | 'medium' | 'high'
   tags?: ShadowTaskMessageCardTag[]
   app?: ShadowMessageCardApp
   idempotencyKey?: string

--- a/packages/shared/__tests__/inbox.test.ts
+++ b/packages/shared/__tests__/inbox.test.ts
@@ -150,7 +150,7 @@ describe('Buddy Inbox view helpers', () => {
     expect(card?.privacy?.dataClass).toBe('server-private')
   })
 
-  it('keeps full channel history in chat mode', () => {
+  it('keeps Inbox display independent of composer mode and folds task replies', () => {
     const messages = [
       taskMessage('task-1', 'running'),
       { id: 'reply-1', replyToId: 'task-1' },
@@ -162,10 +162,16 @@ describe('Buddy Inbox view helpers', () => {
         isInboxChannel: true,
         mode: 'chat',
       }).map((message) => message.id),
-    ).toEqual(['task-1', 'reply-1', 'chat-1'])
+    ).toEqual(['task-1', 'chat-1'])
+    expect(
+      buildBuddyInboxViewMessages(messages, {
+        isInboxChannel: true,
+        mode: 'tasks',
+      }).map((message) => message.id),
+    ).toEqual(['task-1', 'chat-1'])
   })
 
-  it('shows task cards only in task mode and folds task replies under the card', () => {
+  it('filters task cards while preserving ordinary chat messages', () => {
     const messages = [
       taskMessage('task-1', 'running'),
       { id: 'reply-1', replyToId: 'task-1' },
@@ -178,7 +184,21 @@ describe('Buddy Inbox view helpers', () => {
         isInboxChannel: true,
         mode: 'tasks',
       }).map((message) => message.id),
-    ).toEqual(['task-1', 'task-2'])
+    ).toEqual(['task-1', 'chat-1', 'task-2'])
+    expect(
+      buildBuddyInboxViewMessages(messages, {
+        isInboxChannel: true,
+        mode: 'tasks',
+        taskFilter: 'open',
+      }).map((message) => message.id),
+    ).toEqual(['task-1'])
+    expect(
+      buildBuddyInboxViewMessages(messages, {
+        isInboxChannel: true,
+        mode: 'tasks',
+        taskFilter: 'done',
+      }).map((message) => message.id),
+    ).toEqual(['task-2'])
   })
 
   it('filters open and terminal task cards', () => {

--- a/packages/shared/src/types/inbox.types.ts
+++ b/packages/shared/src/types/inbox.types.ts
@@ -127,6 +127,11 @@ export function hasBuddyInboxTaskCard(message: BuddyInboxViewMessage) {
   return getBuddyInboxTaskCards(message).length > 0
 }
 
+function hasBuddyInboxTaskReplyNotificationCard(message: BuddyInboxViewMessage) {
+  const cards = message.metadata?.cards
+  return Array.isArray(cards) && cards.some(isTaskReplyNotificationCard)
+}
+
 export function getBuddyInboxTaskStatuses(message: BuddyInboxViewMessage): MessageCardStatus[] {
   return getBuddyInboxTaskCards(message).map((card) => card.status)
 }
@@ -161,18 +166,20 @@ export function buildBuddyInboxViewMessages<TMessage extends BuddyInboxViewMessa
   messages: readonly TMessage[],
   options: {
     isInboxChannel: boolean
-    mode: BuddyInboxViewMode
+    mode?: BuddyInboxViewMode
     taskFilter?: BuddyInboxTaskFilter
   },
 ) {
-  if (!options.isInboxChannel || options.mode === 'chat') return [...messages]
+  if (!options.isInboxChannel) return [...messages]
 
   const taskMessageIds = getBuddyInboxTaskMessageIds(messages)
-  return messages.filter(
-    (message) =>
-      !isBuddyInboxTaskReply(message, taskMessageIds) &&
-      buddyInboxMessageMatchesTaskFilter(message, options.taskFilter ?? 'all'),
-  )
+  const taskFilter = options.taskFilter ?? 'all'
+  return messages.filter((message) => {
+    if (isBuddyInboxTaskReply(message, taskMessageIds)) return false
+    if (hasBuddyInboxTaskReplyNotificationCard(message)) return false
+    if (!hasBuddyInboxTaskCard(message)) return taskFilter === 'all'
+    return buddyInboxMessageMatchesTaskFilter(message, taskFilter)
+  })
 }
 
 export type BuddyInboxAdmissionMode = 'allow' | 'deny' | 'first_time' | 'every_time'
@@ -197,7 +204,7 @@ export interface BuddyInboxAdmissionPolicy {
 export interface BuddyInboxAdmissionPendingTask {
   title: string
   body?: string
-  priority?: 'low' | 'normal' | 'high' | 'urgent'
+  priority?: 'low' | 'normal' | 'medium' | 'high'
   idempotencyKey?: string
   source?: MessageCardSource
   requirements?: TaskMessageRequirements
@@ -292,8 +299,8 @@ function parsePendingTask(value: unknown): BuddyInboxAdmissionPendingTask {
     priority !== undefined &&
     priority !== 'low' &&
     priority !== 'normal' &&
-    priority !== 'high' &&
-    priority !== 'urgent'
+    priority !== 'medium' &&
+    priority !== 'high'
   ) {
     throw new Error('Invalid Buddy Inbox pending task priority')
   }

--- a/packages/shared/src/types/message.types.ts
+++ b/packages/shared/src/types/message.types.ts
@@ -297,7 +297,7 @@ export interface TaskMessageCard {
   title: string
   body?: string
   status: MessageCardStatus
-  priority?: 'low' | 'normal' | 'high' | 'urgent'
+  priority?: 'low' | 'normal' | 'medium' | 'high'
   tags?: TaskMessageCardTag[]
   app?: MessageCardApp
   assignee?: {


### PR DESCRIPTION
## Summary

- Enable Buddy collaborative chat by default across server policy, OpenClaw, Hermes, cc-connect packaging, and the member policy UI; explicit `replyToBuddy: false` remains the opt-out.
- Split runtime collaboration claim handling into focused modules so local preflight only decides eligibility and server-side claim remains the authority for turn/thread/reply metadata.
- Document the no-mention, single-mention, multi-mention, human-triggered, Buddy-triggered, and custom-policy rules in the Buddy collaboration design note.
- Preserve the existing Inbox collaboration UX polish in this branch: composer mode is separate from list filtering, and task priority/modal behavior stays aligned across surfaces.

## Why

Buddy-to-Buddy collaboration should feel available by default without letting ordinary Buddy messages fan out. The new rule keeps the experience predictable: runtimes may consider Buddy messages by default, but they still require collaboration metadata and a successful server claim before speaking.

## Validation

Local clean worktree:

- `pnpm lint`
- `pnpm check:migrations`
- `pnpm check:i18n`
- `pnpm build:packages`
- `pnpm --filter "./packages/*" --parallel typecheck`
- `pnpm --filter "./apps/*" --parallel typecheck`
- `pnpm check:pre-push`
- `pnpm --filter @shadowob/openclaw-shadowob test`
- `python3 -m pytest tests/test_adapter_env.py -q` in `packages/connector/hermes-shadowob-plugin`
- `JWT_SECRET=shadow-test-secret pnpm exec vitest run __tests__/channel-slash-commands.test.ts` in `apps/server`
- `JWT_SECRET=shadow-test-secret pnpm exec vitest run src/infra/runtime-package.test.ts __tests__/runtimes/runtime-package-smoke.test.ts` in `apps/cloud`

Remote PR checks:

- `pr-checks / Lint & Typecheck` passed
- `pr-checks / Unit/Integration tests` passed
- `pr-checks / E2E via docker-compose` passed
- `pr-checks / Security static checks` passed
- `pr-checks / React Doctor` passed
- `security-architecture-scan / scan` passed
- `build-validation / Build packages` passed after rerunning an initial Docker Hub timeout while booting Buildx