### PR TITLE
[codex] continue buddy task runtime refactor

### DIFF
--- a/apps/cloud/images/claude-runner/Dockerfile
+++ b/apps/cloud/images/claude-runner/Dockerfile
@@ -10,7 +10,7 @@
 
 FROM golang:1.25-alpine AS cc-builder
 
-ARG CC_CONNECT_REF=62a55aa950abd13b8c7347a4243598929dc418fd
+ARG CC_CONNECT_REF=b343f7abd432f3aac4b86c8412cdc7a1c5a8991e
 ARG CC_CONNECT_REPO=https://github.com/buggyblues/cc-connect.git
 
 WORKDIR /build

--- a/apps/cloud/images/claude-runner/Dockerfile
+++ b/apps/cloud/images/claude-runner/Dockerfile
@@ -10,7 +10,7 @@
 
 FROM golang:1.25-alpine AS cc-builder
 
-ARG CC_CONNECT_REF=f382563cfebaef36c5d257461dfaf318161fe3ea
+ARG CC_CONNECT_REF=62a55aa950abd13b8c7347a4243598929dc418fd
 ARG CC_CONNECT_REPO=https://github.com/buggyblues/cc-connect.git
 
 WORKDIR /build

--- a/apps/mobile/app/(main)/servers/[serverSlug]/channels/[channelId].tsx
+++ b/apps/mobile/app/(main)/servers/[serverSlug]/channels/[channelId].tsx
@@ -1,5 +1,4 @@
 import type {
-  BuddyInboxTaskFilter,
   BuddyInboxViewMode,
   CommerceProductCard,
   MentionSuggestion,
@@ -11,7 +10,6 @@ import {
   assignMentionRanges,
   buildBuddyInboxViewMessages,
   canonicalMentionToken,
-  getBuddyInboxTaskMessageIds,
   parseBuddyInboxAgentId,
 } from '@shadowob/shared'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -333,7 +331,6 @@ export default function ChannelViewScreen() {
   const [taskTags, setTaskTags] = useState('')
   const [creatingTask, setCreatingTask] = useState(false)
   const [inboxViewMode, setInboxViewMode] = useState<BuddyInboxViewMode>('tasks')
-  const [inboxTaskFilter, setInboxTaskFilter] = useState<BuddyInboxTaskFilter>('all')
   const [showScrollBottom, setShowScrollBottom] = useState(false)
   const [showInputEmojiPicker, setShowInputEmojiPicker] = useState(false)
   const [showMemberList, setShowMemberList] = useState(false)
@@ -1126,28 +1123,11 @@ export default function ChannelViewScreen() {
     return latest?.id ?? null
   }, [messages])
 
-  const taskCardMessageIds = useMemo(() => {
-    return getBuddyInboxTaskMessageIds(messages)
-  }, [messages])
-
-  const taskRepliesByMessageId = useMemo(() => {
-    const replies = new Map<string, Message[]>()
-    for (const message of messages) {
-      const parentId = message.replyToId
-      if (!parentId || !taskCardMessageIds.has(parentId)) continue
-      const existing = replies.get(parentId) ?? []
-      existing.push(message)
-      replies.set(parentId, existing)
-    }
-    return replies
-  }, [messages, taskCardMessageIds])
-
   const timelineBaseMessages = useMemo(() => {
     return buildBuddyInboxViewMessages(messages, {
       isInboxChannel,
-      taskFilter: inboxTaskFilter,
     })
-  }, [inboxTaskFilter, isInboxChannel, messages])
+  }, [isInboxChannel, messages])
 
   const buildThreadName = useCallback(
     (message: Message) => {
@@ -2796,7 +2776,6 @@ export default function ChannelViewScreen() {
             channelId={channelId!}
             serverSlug={serverSlug}
             allMessages={messages}
-            taskReplies={isInboxChannel ? taskRepliesByMessageId.get(item.data.id) : undefined}
             isGrouped={isGrouped}
             selectionMode={selectionMode}
             isSelected={selectedMessageIds.has(item.data.id)}
@@ -2820,7 +2799,6 @@ export default function ChannelViewScreen() {
       messages,
       latestMessageId,
       isInboxChannel,
-      taskRepliesByMessageId,
       timeline,
       highlightMessageId,
       selectionMode,
@@ -2992,20 +2970,12 @@ export default function ChannelViewScreen() {
             icon={isInboxChannel ? ListTodo : Hash}
             title={
               isInboxChannel
-                ? inboxTaskFilter === 'all'
-                  ? t('inbox.empty.allTitle')
-                  : t('inbox.empty.filterTitle')
+                ? t('inbox.empty.allTitle')
                 : t('chat.welcomeChannel', {
                     channelName: channel?.name ?? t('chat.channelFallback'),
                   })
             }
-            description={
-              isInboxChannel
-                ? inboxTaskFilter === 'all'
-                  ? t('inbox.empty.allHint')
-                  : t('inbox.empty.filterHint')
-                : t('chat.welcomeStart')
-            }
+            description={isInboxChannel ? t('inbox.empty.allHint') : t('chat.welcomeStart')}
           />
         </Pressable>
       ) : (
@@ -3235,8 +3205,6 @@ export default function ChannelViewScreen() {
           enableTaskCards={isInboxChannel}
           inboxViewMode={inboxViewMode}
           onInboxViewModeChange={setInboxViewMode}
-          inboxTaskFilter={inboxTaskFilter}
-          onInboxTaskFilterChange={setInboxTaskFilter}
           taskDraft={taskDraft}
           onTaskDraftChange={setTaskDraft}
           taskPriority={taskPriority}

--- a/apps/mobile/src/components/chat/chat-composer.tsx
+++ b/apps/mobile/src/components/chat/chat-composer.tsx
@@ -1,8 +1,4 @@
-import type {
-  BuddyInboxTaskFilter,
-  BuddyInboxViewMode,
-  CommerceProductCard,
-} from '@shadowob/shared'
+import type { BuddyInboxViewMode, CommerceProductCard } from '@shadowob/shared'
 import { Image } from 'expo-image'
 import {
   AtSign,
@@ -352,8 +348,6 @@ interface ChatComposerProps {
   enableTaskCards?: boolean
   inboxViewMode?: BuddyInboxViewMode
   onInboxViewModeChange?: (mode: BuddyInboxViewMode) => void
-  inboxTaskFilter?: BuddyInboxTaskFilter
-  onInboxTaskFilterChange?: (filter: BuddyInboxTaskFilter) => void
   taskDraft?: string
   onTaskDraftChange?: (text: string) => void
   taskPriority?: 'low' | 'normal' | 'medium' | 'high'
@@ -486,8 +480,6 @@ export const ChatComposer = memo(function ChatComposer({
   enableTaskCards = false,
   inboxViewMode,
   onInboxViewModeChange,
-  inboxTaskFilter = 'all',
-  onInboxTaskFilterChange,
   taskDraft = '',
   onTaskDraftChange,
   taskPriority = 'normal',
@@ -815,37 +807,6 @@ export const ChatComposer = memo(function ChatComposer({
               )
             })}
           </View>
-          {onInboxTaskFilterChange && (
-            <View style={[styles.inboxSegment, { backgroundColor: colors.inputBackground }]}>
-              {(['all', 'done', 'open'] as const).map((filter) => {
-                const selected = inboxTaskFilter === filter
-                return (
-                  <Pressable
-                    key={filter}
-                    accessibilityRole="button"
-                    accessibilityState={{ selected }}
-                    style={[
-                      styles.inboxFilterButton,
-                      selected && { backgroundColor: colors.primary },
-                    ]}
-                    onPress={() => {
-                      selectionHaptic()
-                      onInboxTaskFilterChange(filter)
-                    }}
-                  >
-                    <Text
-                      style={[
-                        styles.inboxSegmentText,
-                        { color: selected ? colors.background : colors.textMuted },
-                      ]}
-                    >
-                      {t(`inbox.filter.${filter}`)}
-                    </Text>
-                  </Pressable>
-                )
-              })}
-            </View>
-          )}
         </View>
       )}
 
@@ -1424,13 +1385,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     gap: spacing.xs,
-  },
-  inboxFilterButton: {
-    minHeight: size.controlSm,
-    borderRadius: radius.full,
-    paddingHorizontal: spacing.sm,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   inboxSegmentText: {
     fontSize: fontSize.xs,

--- a/apps/mobile/src/components/chat/message-bubble.tsx
+++ b/apps/mobile/src/components/chat/message-bubble.tsx
@@ -40,7 +40,6 @@ import {
   Radio,
   RefreshCw,
   Save,
-  Send,
   Share2,
   Square as SquareIcon,
   Tag,
@@ -433,49 +432,6 @@ function taskSourceMeta(card: TaskMessageCard) {
   return { label, iconUrl }
 }
 
-function taskCardReplyCardId(message: Message) {
-  const custom = asRecord(message.metadata?.custom)
-  const reply = asRecord(custom?.taskCardReply)
-  return stringValue(reply?.cardId)
-}
-
-function taskReplyItems(card: TaskMessageCard, replies?: Message[]) {
-  const byKey = new Map<
-    string,
-    {
-      key: string
-      authorLabel: string | null
-      authorAvatarUrl: string | null
-      content: string
-      createdAt: string
-    }
-  >()
-  for (const reply of card.replies ?? []) {
-    const key = reply.messageId ?? reply.id ?? `${reply.createdAt}:${reply.content}`
-    byKey.set(key, {
-      key,
-      authorLabel: reply.authorLabel ?? reply.source?.label ?? null,
-      authorAvatarUrl: reply.authorAvatarUrl ?? null,
-      content: reply.content,
-      createdAt: reply.createdAt,
-    })
-  }
-  for (const message of replies ?? []) {
-    const cardId = taskCardReplyCardId(message)
-    if (cardId && cardId !== card.id) continue
-    byKey.set(message.id, {
-      key: message.id,
-      authorLabel: message.author?.displayName ?? message.author?.username ?? null,
-      authorAvatarUrl: message.author?.avatarUrl ?? null,
-      content: message.content,
-      createdAt: message.createdAt,
-    })
-  }
-  return [...byKey.values()].sort(
-    (left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
-  )
-}
-
 interface LaunchContext {
   iframeEntry: string | null
   launchToken: string
@@ -497,27 +453,17 @@ function withLaunchParams(entry: string, launch: LaunchContext, appPath?: string
 
 function TaskCardsView({
   cards,
-  channelId,
-  messageId,
-  replies,
+  onOpenThread,
 }: {
   cards?: MessageCard[]
-  channelId: string
-  messageId: string
-  replies?: Message[]
+  onOpenThread?: () => void
 }) {
   const taskCards = cards?.filter(isTaskMessageCard) ?? []
   if (taskCards.length === 0) return null
   return (
     <View style={styles.taskCards}>
       {taskCards.map((card) => (
-        <TaskCardMobile
-          key={card.id}
-          card={card}
-          channelId={channelId}
-          messageId={messageId}
-          replies={replies}
-        />
+        <TaskCardMobile key={card.id} card={card} onOpenThread={onOpenThread} />
       ))}
     </View>
   )
@@ -613,22 +559,14 @@ function ServerAppCardMobile({
 
 function TaskCardMobile({
   card,
-  channelId,
-  messageId,
-  replies,
+  onOpenThread,
 }: {
   card: TaskMessageCard
-  channelId: string
-  messageId: string
-  replies?: Message[]
+  onOpenThread?: () => void
 }) {
   const { t } = useTranslation()
   const colors = useColors()
-  const queryClient = useQueryClient()
   const [detailsOpen, setDetailsOpen] = useState(false)
-  const [repliesOpen, setRepliesOpen] = useState(false)
-  const [replyDraft, setReplyDraft] = useState('')
-  const [sendingReply, setSendingReply] = useState(false)
   const statusColor =
     card.status === 'completed'
       ? colors.success
@@ -649,41 +587,7 @@ function TaskCardMobile({
   const assigneeLabel = card.assignee?.label ?? t('inbox.unassigned')
   const tags = useMemo(() => (card.tags ?? []).map(taskTagLabel).filter(Boolean), [card.tags])
   const app = useMemo(() => taskSourceMeta(card), [card])
-  const replyItems = useMemo(() => taskReplyItems(card, replies), [card, replies])
   const bodyPreview = card.body?.replace(/\s+/g, ' ').trim()
-
-  const sendTaskReply = useCallback(async () => {
-    const content = replyDraft.trim()
-    if (!content || sendingReply) return
-    setSendingReply(true)
-    try {
-      await fetchApi(`/api/channels/${channelId}/messages`, {
-        method: 'POST',
-        body: JSON.stringify({
-          content,
-          replyToId: messageId,
-          metadata: {
-            custom: {
-              taskCardReply: {
-                kind: 'task_card_reply',
-                messageId,
-                cardId: card.id,
-              },
-            },
-          },
-        }),
-      })
-      setReplyDraft('')
-      setRepliesOpen(true)
-      successHaptic()
-      queryClient.invalidateQueries({ queryKey: ['messages', channelId] })
-    } catch (error) {
-      errorHaptic()
-      showToast(error instanceof Error ? error.message : t('inbox.task.replyFailed'), 'error')
-    } finally {
-      setSendingReply(false)
-    }
-  }, [card.id, channelId, messageId, queryClient, replyDraft, sendingReply, t])
 
   return (
     <View
@@ -775,22 +679,11 @@ function TaskCardMobile({
         <Pressable
           onPress={() => {
             selectionHaptic()
-            setRepliesOpen((value) => !value)
+            onOpenThread?.()
           }}
           style={[styles.taskReplyCount, { backgroundColor: colors.inputBackground }]}
         >
-          <MessageSquare
-            size={iconSize.xs}
-            color={repliesOpen ? colors.primary : colors.textMuted}
-          />
-          <Text
-            style={[
-              styles.taskFooterText,
-              { color: repliesOpen ? colors.primary : colors.textSecondary },
-            ]}
-          >
-            {replyItems.length}
-          </Text>
+          <MessageSquare size={iconSize.xs} color={colors.textMuted} />
         </Pressable>
         <View style={styles.taskAssigneeWrap}>
           <Avatar
@@ -804,74 +697,6 @@ function TaskCardMobile({
           </Text>
         </View>
       </View>
-
-      {repliesOpen ? (
-        <View style={[styles.taskReplies, { borderTopColor: colors.border }]}>
-          {replyItems.length > 0 ? (
-            replyItems.map((reply) => (
-              <View key={reply.key} style={styles.taskReplyRow}>
-                {reply.authorAvatarUrl ? (
-                  <Image
-                    source={{ uri: getImageUrl(reply.authorAvatarUrl) ?? reply.authorAvatarUrl }}
-                    style={styles.taskReplyAvatar}
-                  />
-                ) : (
-                  <View
-                    style={[
-                      styles.taskReplyAvatarFallback,
-                      { backgroundColor: colors.inputBackground },
-                    ]}
-                  >
-                    <Text style={[styles.taskReplyAvatarText, { color: colors.primary }]}>
-                      {(reply.authorLabel ?? '?').slice(0, 1)}
-                    </Text>
-                  </View>
-                )}
-                <View style={[styles.taskReplyBubble, { backgroundColor: colors.inputBackground }]}>
-                  <Text style={[styles.taskReplyAuthor, { color: colors.textMuted }]}>
-                    {reply.authorLabel ?? t('common.unknownUser')} ·{' '}
-                    {compactTaskDate(reply.createdAt)}
-                  </Text>
-                  <Text style={[styles.taskReplyText, { color: colors.textSecondary }]}>
-                    {reply.content}
-                  </Text>
-                </View>
-              </View>
-            ))
-          ) : (
-            <Text style={[styles.taskBody, { color: colors.textMuted }]}>
-              {t('inbox.task.noReplies')}
-            </Text>
-          )}
-          <View style={[styles.taskReplyInputRow, { backgroundColor: colors.inputBackground }]}>
-            <TextInput
-              value={replyDraft}
-              onChangeText={setReplyDraft}
-              placeholder={t('inbox.task.replyPlaceholder')}
-              placeholderTextColor={colors.textMuted}
-              style={[styles.taskReplyInput, { color: colors.text }]}
-              multiline
-              returnKeyType="send"
-            />
-            <Pressable
-              disabled={!replyDraft.trim() || sendingReply}
-              onPress={() => {
-                selectionHaptic()
-                void sendTaskReply()
-              }}
-              style={[
-                styles.taskReplySend,
-                { backgroundColor: replyDraft.trim() ? colors.primary : colors.surfaceHover },
-              ]}
-            >
-              <Send
-                size={iconSize.sm}
-                color={replyDraft.trim() ? palette.foundation : colors.textMuted}
-              />
-            </Pressable>
-          </View>
-        </View>
-      ) : null}
     </View>
   )
 }
@@ -885,7 +710,6 @@ interface MessageBubbleProps {
   channelId: string
   serverSlug?: string
   allMessages?: Message[]
-  taskReplies?: Message[]
   isGrouped?: boolean
   selectionMode?: boolean
   isSelected?: boolean
@@ -1181,7 +1005,6 @@ function MessageBubbleInner({
   channelId,
   serverSlug,
   allMessages = [],
-  taskReplies = [],
   isGrouped = false,
   selectionMode,
   isSelected,
@@ -1802,12 +1625,7 @@ function MessageBubbleInner({
 
           {walletRecharge && <WalletRechargeCard data={walletRecharge} />}
 
-          <TaskCardsView
-            cards={message.metadata?.cards}
-            channelId={channelId}
-            messageId={message.id}
-            replies={taskReplies}
-          />
+          <TaskCardsView cards={message.metadata?.cards} onOpenThread={onOpenThread} />
           <ServerAppCardsView cards={message.metadata?.cards} serverSlug={serverSlug} />
 
           {/* Attachments */}
@@ -2675,7 +2493,6 @@ export const MessageBubble = memo(MessageBubbleInner, (prev, next) => {
     prev.isGrouped === next.isGrouped &&
     prev.hasThread === next.hasThread &&
     prev.allMessages === next.allMessages &&
-    prev.taskReplies === next.taskReplies &&
     prev.onRetry === next.onRetry &&
     prev.onOpenThread === next.onOpenThread &&
     prev.selectionMode === next.selectionMode &&
@@ -2998,73 +2815,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xxs,
-  },
-  taskReplies: {
-    borderTopWidth: border.hairline,
-    paddingTop: spacing.sm,
-    gap: spacing.sm,
-  },
-  taskReplyRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: spacing.xs,
-  },
-  taskReplyAvatar: {
-    width: size.avatarXs,
-    height: size.avatarXs,
-    borderRadius: radius.full,
-  },
-  taskReplyAvatarFallback: {
-    width: size.avatarXs,
-    height: size.avatarXs,
-    borderRadius: radius.full,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  taskReplyAvatarText: {
-    fontSize: fontSize.micro,
-    fontWeight: '900',
-  },
-  taskReplyBubble: {
-    flex: 1,
-    minWidth: 0,
-    borderRadius: radius.lg,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-  },
-  taskReplyAuthor: {
-    fontSize: fontSize.micro,
-    fontWeight: '800',
-    marginBottom: spacing.xxs,
-  },
-  taskReplyText: {
-    fontSize: fontSize.sm,
-    lineHeight: lineHeight.sm,
-  },
-  taskReplyInputRow: {
-    minHeight: size.controlMd,
-    borderRadius: radius.lg,
-    paddingLeft: spacing.sm,
-    paddingRight: spacing.xs,
-    paddingVertical: spacing.xs,
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    gap: spacing.xs,
-  },
-  taskReplyInput: {
-    flex: 1,
-    minHeight: size.iconButtonSm,
-    maxHeight: size.panelStateMinHeight,
-    fontSize: fontSize.sm,
-    lineHeight: lineHeight.sm,
-    paddingVertical: 0,
-  },
-  taskReplySend: {
-    width: size.iconButtonSm,
-    height: size.iconButtonSm,
-    borderRadius: radius.full,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   serverAppCard: {
     flexDirection: 'row',

--- a/apps/server/__tests__/buddy-inbox-service.test.ts
+++ b/apps/server/__tests__/buddy-inbox-service.test.ts
@@ -472,38 +472,38 @@ describe('BuddyInboxService', () => {
     )
   })
 
-  it('does not claim legacy Inbox reply notification cards as tasks', async () => {
+  it('claims task cards even when the legacy reply notification marker is present', async () => {
     const { deps, service } = createService()
-    deps.messageDao.findByChannelId.mockResolvedValue({
-      messages: [
-        {
-          id: 'message-notification',
-          channelId,
-          metadata: {
-            cards: [
-              {
-                id: 'reply-notification-card',
-                kind: 'task',
-                version: 1,
-                title: 'Review reply: Render video',
-                status: 'queued',
-                assignee: {
-                  agentId,
-                  userId: buddyUserId,
-                  label: '算法助教',
-                },
-                data: {
-                  taskReplyNotification: true,
-                },
-                progress: [],
-                createdAt: new Date().toISOString(),
-              },
-            ],
+    const message = {
+      id: 'message-notification',
+      channelId,
+      metadata: {
+        cards: [
+          {
+            id: 'reply-notification-card',
+            kind: 'task',
+            version: 1,
+            title: 'Review reply: Render video',
+            status: 'queued',
+            assignee: {
+              agentId,
+              userId: buddyUserId,
+              label: '算法助教',
+            },
+            data: {
+              taskReplyNotification: true,
+            },
+            progress: [],
+            createdAt: new Date().toISOString(),
           },
-        },
-      ],
+        ],
+      },
+    }
+    deps.messageDao.findByChannelId.mockResolvedValue({
+      messages: [message],
       hasMore: false,
     })
+    deps.messageDao.findById.mockResolvedValue(message)
 
     const result = await service.claimNextTask(serverId, agentId, {
       kind: 'agent',
@@ -513,12 +513,42 @@ describe('BuddyInboxService', () => {
       scopes: [],
     })
 
-    expect(result.message).toBeNull()
-    expect(result.card).toBeNull()
-    expect(deps.messageService.updateMetadata).not.toHaveBeenCalled()
+    expect(result.message).toEqual(
+      expect.objectContaining({
+        id: 'message-notification',
+        metadata: expect.objectContaining({
+          cards: [
+            expect.objectContaining({
+              id: 'reply-notification-card',
+              status: 'claimed',
+              claim: expect.objectContaining({
+                actor: expect.objectContaining({ agentId, userId: buddyUserId }),
+              }),
+            }),
+          ],
+        }),
+      }),
+    )
+    expect(result.card).toEqual(
+      expect.objectContaining({
+        id: 'reply-notification-card',
+        status: 'claimed',
+      }),
+    )
+    expect(deps.messageService.updateMetadata).toHaveBeenCalledWith(
+      'message-notification',
+      expect.objectContaining({
+        cards: [
+          expect.objectContaining({
+            id: 'reply-notification-card',
+            status: 'claimed',
+          }),
+        ],
+      }),
+    )
   })
 
-  it('rejects direct claims against legacy Inbox reply notification cards', async () => {
+  it('allows direct claims against task cards with the legacy reply notification marker', async () => {
     const { deps, service } = createService()
     deps.messageDao.findById.mockResolvedValue({
       id: 'message-notification',
@@ -554,7 +584,19 @@ describe('BuddyInboxService', () => {
         ownerId: ownerUserId,
         scopes: [],
       }),
-    ).rejects.toThrow('Task card not found')
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: 'message-notification',
+        metadata: expect.objectContaining({
+          cards: [
+            expect.objectContaining({
+              id: 'reply-notification-card',
+              status: 'claimed',
+            }),
+          ],
+        }),
+      }),
+    )
   })
 
   it('lets a server Buddy discover peer Buddy inboxes without manage access', async () => {

--- a/apps/server/__tests__/buddy-inbox-service.test.ts
+++ b/apps/server/__tests__/buddy-inbox-service.test.ts
@@ -680,6 +680,51 @@ describe('BuddyInboxService', () => {
     )
   })
 
+  it('rejects direct claims against terminal task cards', async () => {
+    const { deps, service } = createService()
+    deps.messageDao.findById.mockResolvedValue({
+      id: 'message-completed',
+      channelId,
+      metadata: {
+        cards: [
+          {
+            id: 'completed-card',
+            kind: 'task',
+            version: 1,
+            title: 'Already done',
+            status: 'completed',
+            assignee: {
+              agentId,
+              userId: buddyUserId,
+              label: '算法助教',
+            },
+            progress: [
+              {
+                at: new Date().toISOString(),
+                status: 'completed',
+              },
+            ],
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      },
+    })
+
+    await expect(
+      service.claimTaskCard('message-completed', 'completed-card', {
+        kind: 'agent',
+        userId: buddyUserId,
+        agentId,
+        ownerId: ownerUserId,
+        scopes: [],
+      }),
+    ).rejects.toMatchObject({
+      message: 'Terminal task cards cannot be claimed',
+      status: 409,
+    })
+    expect(deps.messageService.updateMetadata).not.toHaveBeenCalled()
+  })
+
   it('lets a server Buddy discover peer Buddy inboxes without manage access', async () => {
     const { deps, service } = createService()
     const peerAgentId = '00000000-0000-4000-8000-000000000008'

--- a/apps/server/__tests__/buddy-inbox-service.test.ts
+++ b/apps/server/__tests__/buddy-inbox-service.test.ts
@@ -98,6 +98,16 @@ function createService() {
         channelId,
         metadata: {},
       }),
+      ensureThreadForMessage: vi.fn().mockResolvedValue({
+        id: 'thread-1',
+        channelId,
+        parentMessageId: 'message-1',
+        creatorId: ownerUserId,
+        name: 'Review Two Sum submission',
+        isArchived: false,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
       updateMetadata: vi.fn(async (messageId, metadata) => ({
         id: messageId,
         channelId,
@@ -189,7 +199,7 @@ describe('BuddyInboxService', () => {
   })
 
   it('activates the Inbox policy before enqueueing a task for an existing channel', async () => {
-    const { deps, service } = createService()
+    const { deps, emit, service } = createService()
     deps.agentPolicyDao.findByChannel.mockResolvedValue({
       id: 'policy-1',
       agentId,
@@ -199,6 +209,27 @@ describe('BuddyInboxService', () => {
       reply: false,
       mentionOnly: true,
       config: {},
+    })
+    deps.messageDao.findByChannelId.mockResolvedValue({
+      messages: [
+        {
+          id: 'context-message-1',
+          channelId,
+          authorId: ownerUserId,
+          content: 'Earlier context: the submission failed on empty arrays.',
+          threadId: null,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        },
+        {
+          id: 'context-message-2',
+          channelId,
+          authorId: buddyUserId,
+          content: 'Buddy suggested checking boundary conditions.',
+          threadId: null,
+          createdAt: new Date('2026-01-01T00:01:00.000Z'),
+        },
+      ],
+      hasMore: false,
     })
 
     await service.enqueueTaskForAgent(
@@ -269,6 +300,56 @@ describe('BuddyInboxService', () => {
             }),
           ]),
         }),
+      }),
+    )
+    expect(deps.messageService.ensureThreadForMessage).toHaveBeenCalledWith(
+      'message-1',
+      ownerUserId,
+      { name: 'Review Two Sum submission' },
+    )
+    expect(deps.messageService.updateMetadata).toHaveBeenCalledWith(
+      'message-1',
+      expect.objectContaining({
+        cards: [
+          expect.objectContaining({
+            title: 'Review Two Sum submission',
+            data: expect.objectContaining({
+              task: expect.objectContaining({
+                workspaceId: expect.stringMatching(/^task_/),
+                threadId: 'thread-1',
+                revision: 1,
+                contextPack: expect.objectContaining({
+                  snapshotAtMessageId: 'context-message-2',
+                  sourceSurface: 'channel',
+                  policy: 'auto_recent',
+                  items: [
+                    expect.objectContaining({
+                      kind: 'message',
+                      messageId: 'context-message-1',
+                      authorId: ownerUserId,
+                      text: 'Earlier context: the submission failed on empty arrays.',
+                    }),
+                    expect.objectContaining({
+                      kind: 'message',
+                      messageId: 'context-message-2',
+                      authorId: buddyUserId,
+                      text: 'Buddy suggested checking boundary conditions.',
+                    }),
+                  ],
+                  tokenEstimate: expect.any(Number),
+                }),
+              }),
+            }),
+          }),
+        ],
+      }),
+    )
+    expect(emit).toHaveBeenCalledWith(
+      'thread:created',
+      expect.objectContaining({
+        id: 'thread-1',
+        channelId,
+        parentMessageId: 'message-1',
       }),
     )
   })

--- a/apps/server/__tests__/commerce-entitlement-service.test.ts
+++ b/apps/server/__tests__/commerce-entitlement-service.test.ts
@@ -354,6 +354,11 @@ describe('CommerceCardService', () => {
           source: 'openclaw-shadowob',
           replyToId: 'message-1',
         },
+        ccConnectDelivery: {
+          id: 'delivery-2',
+          source: 'cc-connect-shadowob',
+          replyToId: 'message-1',
+        },
         removedField: true,
       },
       target: { kind: 'channel', channelId },
@@ -363,6 +368,7 @@ describe('CommerceCardService', () => {
 
     expect(metadata.agentChain).toMatchObject({ agentId: 'brandscout', depth: 1 })
     expect(metadata.shadowDelivery).toMatchObject({ id: 'delivery-1' })
+    expect(metadata.ccConnectDelivery).toMatchObject({ id: 'delivery-2' })
     expect(metadata.custom).toEqual({ removedField: true })
   })
 

--- a/apps/server/__tests__/services.test.ts
+++ b/apps/server/__tests__/services.test.ts
@@ -45,6 +45,8 @@ function createMockMessageDao(overrides = {}) {
     update: vi.fn(),
     delete: vi.fn(),
     createThread: vi.fn(),
+    findThreadByParentMessageId: vi.fn(),
+    moveRepliesToThread: vi.fn().mockResolvedValue(0),
     touchThread: vi.fn(),
     addReaction: vi.fn(),
     removeReaction: vi.fn(),
@@ -370,6 +372,47 @@ describe('MediaHandler', () => {
 })
 
 describe('MessageService', () => {
+  describe('threads', () => {
+    it('reuses an existing parent thread instead of creating a duplicate', async () => {
+      const parentMessage = {
+        id: 'message-1',
+        content: 'Task root',
+        channelId: 'channel-1',
+        authorId: 'user-1',
+        threadId: null,
+      }
+      const existingThread = {
+        id: 'thread-1',
+        channelId: 'channel-1',
+        parentMessageId: 'message-1',
+        creatorId: 'user-1',
+        name: 'Task root',
+        isArchived: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      const messageDao = createMockMessageDao({
+        findById: vi.fn().mockResolvedValue(parentMessage),
+        findThreadByParentMessageId: vi.fn().mockResolvedValue(existingThread),
+        createThread: vi.fn(),
+        moveRepliesToThread: vi.fn().mockResolvedValue(0),
+      })
+      const service = new MessageService({
+        messageDao: messageDao as any,
+        userDao: createMockUserDao() as any,
+      })
+
+      const result = await service.createThread('channel-1', 'user-1', {
+        name: 'Task root',
+        parentMessageId: 'message-1',
+      })
+
+      expect(result).toBe(existingThread)
+      expect(messageDao.createThread).not.toHaveBeenCalled()
+      expect(messageDao.moveRepliesToThread).toHaveBeenCalledWith('message-1', 'thread-1')
+    })
+  })
+
   describe('Inbox task replies', () => {
     it('records Buddy replies without completing the active task card', async () => {
       const agentId = 'agent-1'

--- a/apps/server/__tests__/services.test.ts
+++ b/apps/server/__tests__/services.test.ts
@@ -45,7 +45,9 @@ function createMockMessageDao(overrides = {}) {
     update: vi.fn(),
     delete: vi.fn(),
     createThread: vi.fn(),
+    findThreadById: vi.fn(),
     findThreadByParentMessageId: vi.fn(),
+    findTaskCardReadStatesForMessages: vi.fn().mockResolvedValue([]),
     moveRepliesToThread: vi.fn().mockResolvedValue(0),
     touchThread: vi.fn(),
     addReaction: vi.fn(),
@@ -411,9 +413,194 @@ describe('MessageService', () => {
       expect(messageDao.createThread).not.toHaveBeenCalled()
       expect(messageDao.moveRepliesToThread).toHaveBeenCalledWith('message-1', 'thread-1')
     })
+
+    it('routes replies to thread messages back into the same thread', async () => {
+      const replyTarget = {
+        id: 'thread-message-1',
+        content: 'Thread note',
+        channelId: 'channel-1',
+        authorId: 'user-1',
+        threadId: 'thread-1',
+      }
+      const thread = {
+        id: 'thread-1',
+        channelId: 'channel-1',
+        parentMessageId: 'root-message-1',
+        creatorId: 'user-1',
+        name: 'Task thread',
+        isArchived: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      const created = {
+        id: 'reply-message-1',
+        content: 'Reply in the task thread',
+        channelId: 'channel-1',
+        authorId: 'bot-user-1',
+        threadId: 'thread-1',
+        replyToId: 'thread-message-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isEdited: false,
+        isPinned: false,
+      }
+      const messageDao = createMockMessageDao({
+        findById: vi.fn().mockResolvedValue(replyTarget),
+        findThreadById: vi.fn().mockResolvedValue(thread),
+        create: vi.fn().mockResolvedValue(created),
+      })
+      const service = new MessageService({
+        messageDao: messageDao as any,
+        userDao: createMockUserDao() as any,
+        channelDao: { updateLastMessageAt: vi.fn() } as any,
+      })
+
+      const result = await service.send('channel-1', 'bot-user-1', {
+        content: 'Reply in the task thread',
+        replyToId: 'thread-message-1',
+      })
+
+      expect(messageDao.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: 'thread-1',
+          replyToId: 'thread-message-1',
+        }),
+      )
+      expect(messageDao.touchThread).toHaveBeenCalledWith('thread-1')
+      expect(result.threadId).toBe('thread-1')
+    })
   })
 
   describe('Inbox task replies', () => {
+    it('routes bare Buddy Inbox task replies into the task thread', async () => {
+      const agentId = 'agent-1'
+      const buddyUserId = 'bot-user-1'
+      const channelId = 'inbox-channel-1'
+      const taskMessageId = 'task-message-1'
+      const taskThreadId = 'task-thread-1'
+      const taskMessage = {
+        id: taskMessageId,
+        content: 'Find the trace from context',
+        channelId,
+        authorId: 'human-user-1',
+        threadId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        metadata: {
+          cards: [
+            {
+              id: 'task-card-1',
+              kind: 'task',
+              version: 1,
+              title: 'Context smoke',
+              status: 'running',
+              assignee: { agentId, userId: buddyUserId, label: 'BrandScout' },
+              data: {
+                task: {
+                  threadId: taskThreadId,
+                },
+              },
+              progress: [],
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        },
+      }
+      const thread = {
+        id: taskThreadId,
+        channelId,
+        parentMessageId: taskMessageId,
+        creatorId: 'human-user-1',
+        name: 'Context smoke',
+        isArchived: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      const created = {
+        id: 'reply-message-1',
+        content: 'TRACE found.',
+        channelId,
+        authorId: buddyUserId,
+        threadId: taskThreadId,
+        replyToId: taskMessageId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isEdited: false,
+        isPinned: false,
+      }
+      const messageDao = createMockMessageDao({
+        findById: vi.fn(async (id: string) => (id === taskMessageId ? taskMessage : null)),
+        findByChannelId: vi.fn().mockResolvedValue({ messages: [taskMessage], hasMore: false }),
+        findThreadById: vi.fn().mockResolvedValue(thread),
+        create: vi.fn().mockResolvedValue(created),
+        updateMetadata: vi.fn(async (id: string, metadata: Record<string, unknown> | null) => ({
+          ...taskMessage,
+          id,
+          metadata,
+        })),
+      })
+      const emit = vi.fn()
+      const service = new MessageService({
+        messageDao: messageDao as any,
+        userDao: createMockUserDao({
+          findById: vi.fn(async (userId: string) => ({
+            id: userId,
+            username: userId === buddyUserId ? 'brandscout' : 'admin',
+            displayName: userId === buddyUserId ? 'BrandScout' : 'Admin',
+            avatarUrl: null,
+            status: 'online',
+            isBot: userId === buddyUserId,
+          })),
+        }) as any,
+        channelDao: {
+          updateLastMessageAt: vi.fn(),
+          findById: vi.fn().mockResolvedValue({
+            id: channelId,
+            topic: `shadow:buddy-inbox:${agentId}`,
+          }),
+        } as any,
+        agentDao: {
+          findByUserId: vi.fn().mockResolvedValue({ id: agentId, userId: buddyUserId }),
+          findById: vi.fn().mockResolvedValue({ id: agentId, userId: buddyUserId }),
+        } as any,
+        agentDashboardDao: {
+          incrementMessageCount: vi.fn(),
+          incrementHourlyMessage: vi.fn(),
+          createEvent: vi.fn(),
+        } as any,
+        io: { to: vi.fn(() => ({ emit })) } as any,
+      })
+
+      const result = await service.send(channelId, buddyUserId, {
+        content: created.content,
+      })
+
+      expect(messageDao.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: taskThreadId,
+          replyToId: taskMessageId,
+        }),
+      )
+      expect(messageDao.touchThread).toHaveBeenCalledWith(taskThreadId)
+      expect(result.threadId).toBe(taskThreadId)
+      expect(messageDao.updateMetadata).toHaveBeenCalledWith(
+        taskMessageId,
+        expect.objectContaining({
+          cards: [
+            expect.objectContaining({
+              id: 'task-card-1',
+              progress: [
+                expect.objectContaining({
+                  status: 'running',
+                  note: expect.stringContaining('Buddy replied:'),
+                }),
+              ],
+            }),
+          ],
+        }),
+      )
+    })
+
     it('records Buddy replies without completing the active task card', async () => {
       const agentId = 'agent-1'
       const buddyUserId = 'bot-user-1'

--- a/apps/server/__tests__/services.test.ts
+++ b/apps/server/__tests__/services.test.ts
@@ -479,21 +479,12 @@ describe('MessageService', () => {
           cards: [
             expect.objectContaining({
               id: 'task-card-1',
-              status: 'running',
+              status: 'claimed',
               claim: taskMessage.metadata.cards[0]?.claim,
               capability: taskMessage.metadata.cards[0]?.capability,
-              replies: [
-                expect.objectContaining({
-                  messageId: replyMessage.id,
-                  cardId: 'task-card-1',
-                  authorId: buddyUserId,
-                  authorLabel: 'BrandScout',
-                  content: replyMessage.content,
-                }),
-              ],
               progress: expect.arrayContaining([
                 expect.objectContaining({
-                  status: 'running',
+                  status: 'claimed',
                   note: expect.stringContaining('Buddy replied:'),
                 }),
               ]),
@@ -507,16 +498,21 @@ describe('MessageService', () => {
           metadata: expect.objectContaining({
             cards: [
               expect.objectContaining({
-                status: 'running',
+                status: 'claimed',
                 claim: taskMessage.metadata.cards[0]?.claim,
               }),
             ],
           }),
         }),
       )
+      const updateCalls = messageDao.updateMetadata.mock.calls
+      const updatedMetadata = updateCalls[updateCalls.length - 1]?.[1] as {
+        cards?: Array<Record<string, unknown>>
+      }
+      expect(updatedMetadata.cards?.[0]).not.toHaveProperty('replies')
     })
 
-    it('completes active task cards on Buddy reply when output contract opts in', async () => {
+    it('ignores reply_terminal output contracts on ordinary Buddy replies', async () => {
       const agentId = 'agent-1'
       const buddyUserId = 'bot-user-1'
       const channelId = 'inbox-channel-1'
@@ -619,9 +615,9 @@ describe('MessageService', () => {
         taskMessageId,
         expect.objectContaining({
           cards: [
-            expect.not.objectContaining({
-              claim: expect.anything(),
-              capability: expect.anything(),
+            expect.objectContaining({
+              claim: taskMessage.metadata.cards[0]?.claim,
+              capability: taskMessage.metadata.cards[0]?.capability,
             }),
           ],
         }),
@@ -632,18 +628,22 @@ describe('MessageService', () => {
           cards: [
             expect.objectContaining({
               id: 'task-card-1',
-              status: 'completed',
-              replies: [expect.objectContaining({ messageId: replyMessage.id })],
+              status: 'running',
               progress: [
                 expect.objectContaining({
-                  status: 'completed',
-                  note: expect.stringContaining('Buddy reply completed task:'),
+                  status: 'running',
+                  note: expect.stringContaining('Buddy replied:'),
                 }),
               ],
             }),
           ],
         }),
       )
+      const updateCalls = messageDao.updateMetadata.mock.calls
+      const updatedMetadata = updateCalls[updateCalls.length - 1]?.[1] as {
+        cards?: Array<Record<string, unknown>>
+      }
+      expect(updatedMetadata.cards?.[0]).not.toHaveProperty('replies')
     })
 
     it.each([
@@ -651,7 +651,7 @@ describe('MessageService', () => {
       { taskStatus: 'completed', sourceKind: 'server_app' },
       { taskStatus: 'failed', sourceKind: 'server_app' },
       { taskStatus: 'completed', sourceKind: 'agent' },
-    ] as const)('handles dispatching Buddy Inbox reply notifications for a delegated $sourceKind task with $taskStatus status', async ({
+    ] as const)('does not dispatch legacy Buddy Inbox reply notifications for a delegated $sourceKind task with $taskStatus status', async ({
       taskStatus,
       sourceKind,
     }) => {
@@ -814,74 +814,30 @@ describe('MessageService', () => {
             expect.objectContaining({
               id: 'task-card-worker',
               status: taskStatus,
-              replies: [
+              progress: [
                 expect.objectContaining({
-                  messageId: replyMessage.id,
-                  cardId: 'task-card-worker',
-                  authorId: assigneeUserId,
+                  status: taskStatus,
+                  note: expect.stringContaining('Buddy replied:'),
                 }),
               ],
             }),
           ],
         }),
       )
+      const updateCalls = messageDao.updateMetadata.mock.calls
+      const updatedMetadata = updateCalls[updateCalls.length - 1]?.[1] as {
+        cards?: Array<Record<string, unknown>>
+      }
+      expect(updatedMetadata.cards?.[0]).not.toHaveProperty('replies')
       const notification = createdMessages.find(
         (message) => message.channelId === dispatcherInboxId,
       )
-      if (taskStatus === 'running') {
-        expect(notification).toBeUndefined()
-        expect(emit).not.toHaveBeenCalledWith(
-          'message:new',
-          expect.objectContaining({ id: 'dispatcher-notification' }),
-        )
-        return
-      }
-      expect(notification).toBeTruthy()
-      expect(notification.authorId).toBe(assigneeUserId)
-      expect(notification.content).toContain(
-        'ScriptSmith replied to delegated Inbox task "Write script".',
-      )
-      expect(notification.content).toContain(
-        'Open the referenced message to review the full response in context.',
-      )
-      expect(notification.content).not.toContain('Script is complete and saved to workspace.')
-      expect(notification.metadata.cards).toEqual([
-        expect.objectContaining({
-          id: `ref-${replyMessage.id}`,
-          kind: 'message_reference',
-          title: 'Write script',
-          description: 'Script is complete and saved to workspace.',
-          label: 'ScriptSmith',
-          target: {
-            channelId: workerInboxId,
-            messageId: replyMessage.id,
-            taskCardId: 'task-card-worker',
-            inboxAgentId: assigneeAgentId,
-            kind: 'inbox_message',
-          },
-          source: expect.objectContaining({
-            kind: 'agent',
-            agentId: assigneeAgentId,
-            label: 'ScriptSmith',
-          }),
-        }),
-      ])
-      expect(notification.metadata.custom).toMatchObject({
-        inboxTaskReplyNotification: {
-          kind: 'inbox_task_reply_notification',
-          title: 'Review reply: Write script',
-          originalTaskStatus: taskStatus,
-          responderAgentId: assigneeAgentId,
-          replyMessageId: replyMessage.id,
-          originalTaskMessageId: taskMessageId,
-          originalTaskCardId: 'task-card-worker',
-          ...(sourceKind === 'server_app' ? { resource: taskResource } : {}),
-        },
-      })
-      if (sourceKind === 'agent') {
-        expect(notification.metadata.custom.inboxTaskReplyNotification.resource).toBeUndefined()
-      }
+      expect(notification).toBeUndefined()
       expect(emit).toHaveBeenCalledWith(
+        'message:updated',
+        expect.objectContaining({ id: taskMessageId }),
+      )
+      expect(emit).not.toHaveBeenCalledWith(
         'message:new',
         expect.objectContaining({ id: 'dispatcher-notification' }),
       )

--- a/apps/server/__tests__/socket-realtime-e2e.test.ts
+++ b/apps/server/__tests__/socket-realtime-e2e.test.ts
@@ -605,6 +605,60 @@ describe('Socket.IO Real-time (mobile pattern)', () => {
     expect(msg.content).toBe('Hello from REST API')
   })
 
+  it('fanouts REST thread messages to channel listeners for runtime adapters', async () => {
+    await ws2.joinChannel(channelId)
+
+    const parentRes = await fetch(`${baseUrl}/api/channels/${channelId}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${userToken}`,
+      },
+      body: JSON.stringify({ content: 'Thread fanout parent' }),
+    })
+    expect(parentRes.status).toBe(201)
+    const parent = (await parentRes.json()) as { id: string }
+
+    const threadRes = await fetch(`${baseUrl}/api/channels/${channelId}/threads`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${userToken}`,
+      },
+      body: JSON.stringify({ name: 'Runtime fanout thread', parentMessageId: parent.id }),
+    })
+    expect(threadRes.status).toBeLessThan(300)
+    const thread = (await threadRes.json()) as { id: string }
+
+    const received = waitForRawEventMatching<{
+      id: string
+      content: string
+      channelId: string
+      threadId?: string | null
+    }>(
+      ws2,
+      'message:new',
+      (msg) =>
+        msg.content === 'Thread runtime fanout' &&
+        msg.channelId === channelId &&
+        msg.threadId === thread.id,
+    )
+
+    const threadMessageRes = await fetch(`${baseUrl}/api/threads/${thread.id}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${userToken}`,
+      },
+      body: JSON.stringify({ content: 'Thread runtime fanout' }),
+    })
+    expect(threadMessageRes.status).toBe(201)
+    const threadMessage = (await threadMessageRes.json()) as { id: string }
+
+    const msg = await received
+    expect(msg.id).toBe(threadMessage.id)
+  })
+
   it('loads a message window around a target channel message', async () => {
     const created: Array<{ id: string; content: string; createdAt: string }> = []
     for (let index = 0; index < 5; index += 1) {

--- a/apps/server/__tests__/validators.test.ts
+++ b/apps/server/__tests__/validators.test.ts
@@ -174,6 +174,11 @@ describe('Message Validators', () => {
             source: 'openclaw-shadowob',
             replyToId: '550e8400-e29b-41d4-a716-446655440000',
           },
+          ccConnectDelivery: {
+            id: 'delivery-2',
+            source: 'cc-connect-shadowob',
+            replyToId: '550e8400-e29b-41d4-a716-446655440000',
+          },
         },
       })
       expect(result.success).toBe(true)

--- a/apps/server/src/dao/message.dao.ts
+++ b/apps/server/src/dao/message.dao.ts
@@ -5,6 +5,7 @@ import {
   messageInteractiveSubmissions,
   messages,
   reactions,
+  taskCardReadStates,
   threads,
   users,
 } from '../db/schema'
@@ -23,6 +24,28 @@ export class MessageDao {
     avatarUrl: users.avatarUrl,
     status: users.status,
     isBot: users.isBot,
+  }
+
+  private threadColumns = {
+    id: threads.id,
+    name: threads.name,
+    channelId: threads.channelId,
+    parentMessageId: threads.parentMessageId,
+    creatorId: threads.creatorId,
+    isArchived: threads.isArchived,
+    createdAt: threads.createdAt,
+    updatedAt: threads.updatedAt,
+    messageCount: sql<number>`(
+      CASE WHEN EXISTS (
+        SELECT 1
+        FROM ${messages} source_message
+        WHERE source_message.id = ${sql.raw('"threads"."parent_message_id"')}
+      ) THEN 1 ELSE 0 END
+    ) + COALESCE((
+      SELECT COUNT(*)::int
+      FROM ${messages} thread_messages
+      WHERE thread_messages.thread_id = ${sql.raw('"threads"."id"')}
+    ), 0)`,
   }
 
   async findById(id: string) {
@@ -57,6 +80,50 @@ export class MessageDao {
         ),
       )
       .orderBy(asc(messageInteractiveSubmissions.createdAt))
+  }
+
+  async findTaskCardReadStatesForMessages(userId: string, messageIds: string[]) {
+    if (messageIds.length === 0) return []
+    return this.db
+      .select()
+      .from(taskCardReadStates)
+      .where(
+        and(
+          eq(taskCardReadStates.userId, userId),
+          inArray(taskCardReadStates.messageId, messageIds),
+        ),
+      )
+  }
+
+  async upsertTaskCardReadState(input: {
+    userId: string
+    messageId: string
+    cardId: string
+    readAt: Date
+  }) {
+    const now = new Date()
+    const result = await this.db
+      .insert(taskCardReadStates)
+      .values({
+        userId: input.userId,
+        messageId: input.messageId,
+        cardId: input.cardId,
+        readAt: input.readAt,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          taskCardReadStates.userId,
+          taskCardReadStates.messageId,
+          taskCardReadStates.cardId,
+        ],
+        set: {
+          readAt: input.readAt,
+          updatedAt: now,
+        },
+      })
+      .returning()
+    return result[0] ?? null
   }
 
   async createInteractiveSubmission(data: {
@@ -501,17 +568,22 @@ export class MessageDao {
     creatorId: string
   }) {
     const result = await this.db.insert(threads).values(data).returning()
-    return result[0]
+    const thread = result[0]
+    return thread ? this.findThreadById(thread.id) : null
   }
 
   async findThreadById(id: string) {
-    const result = await this.db.select().from(threads).where(eq(threads.id, id)).limit(1)
+    const result = await this.db
+      .select(this.threadColumns)
+      .from(threads)
+      .where(eq(threads.id, id))
+      .limit(1)
     return result[0] ?? null
   }
 
   async findThreadByParentMessageId(parentMessageId: string) {
     const result = await this.db
-      .select()
+      .select(this.threadColumns)
       .from(threads)
       .where(and(eq(threads.parentMessageId, parentMessageId), eq(threads.isArchived, false)))
       .orderBy(asc(threads.createdAt), asc(threads.id))
@@ -530,7 +602,7 @@ export class MessageDao {
 
   async findThreadsByChannelId(channelId: string) {
     return this.db
-      .select()
+      .select(this.threadColumns)
       .from(threads)
       .where(and(eq(threads.channelId, channelId), eq(threads.isArchived, false)))
       .orderBy(desc(threads.updatedAt), desc(threads.createdAt))
@@ -542,7 +614,8 @@ export class MessageDao {
       .set({ ...data, updatedAt: new Date() })
       .where(eq(threads.id, id))
       .returning()
-    return result[0] ?? null
+    const thread = result[0]
+    return thread ? this.findThreadById(thread.id) : null
   }
 
   async touchThread(id: string) {
@@ -551,7 +624,8 @@ export class MessageDao {
       .set({ updatedAt: new Date() })
       .where(eq(threads.id, id))
       .returning()
-    return result[0] ?? null
+    const thread = result[0]
+    return thread ? this.findThreadById(thread.id) : null
   }
 
   async deleteThread(id: string) {

--- a/apps/server/src/db/migrations/0098_task_card_read_states.sql
+++ b/apps/server/src/db/migrations/0098_task_card_read_states.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS "task_card_read_states" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE cascade,
+  "message_id" uuid NOT NULL REFERENCES "messages"("id") ON DELETE cascade,
+  "card_id" varchar(80) NOT NULL,
+  "read_at" timestamp with time zone NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "task_card_read_states_user_message_card_unique"
+  ON "task_card_read_states" ("user_id", "message_id", "card_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "task_card_read_states_message_idx"
+  ON "task_card_read_states" ("message_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "task_card_read_states_user_idx"
+  ON "task_card_read_states" ("user_id");--> statement-breakpoint
+
+UPDATE "messages" child
+SET "thread_id" = parent."thread_id"
+FROM "messages" parent
+WHERE child."thread_id" IS NULL
+  AND child."reply_to_id" = parent."id"
+  AND parent."thread_id" IS NOT NULL;

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -687,6 +687,13 @@
       "when": 1781040686000,
       "tag": "0097_buddy_inbox_task_priority_levels",
       "breakpoints": true
+    },
+    {
+      "idx": 98,
+      "version": "7",
+      "when": 1781140000000,
+      "tag": "0098_task_card_read_states",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/index.ts
+++ b/apps/server/src/db/schema/index.ts
@@ -90,7 +90,7 @@ export { friendshipStatusEnum, friendships } from './friendships'
 export { inviteCodes } from './invite-codes'
 export { memberRoleEnum, members } from './members'
 export { messageInteractiveSubmissions } from './message-interactive-submissions'
-export { messages } from './messages'
+export { messages, taskCardReadStates } from './messages'
 export {
   notificationChannelEnum,
   notificationChannelPreferences,

--- a/apps/server/src/db/schema/messages.ts
+++ b/apps/server/src/db/schema/messages.ts
@@ -1,5 +1,15 @@
 import { sql } from 'drizzle-orm'
-import { boolean, index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import {
+  boolean,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core'
 import { channels } from './channels'
 import { threads } from './threads'
 import { users } from './users'
@@ -286,5 +296,29 @@ export const messages = pgTable(
     messagesThreadCreatedAtDescIdx: index('messages_thread_created_at_desc_idx')
       .on(t.threadId, t.createdAt.desc())
       .where(sql`${t.threadId} IS NOT NULL`),
+  }),
+)
+
+export const taskCardReadStates = pgTable(
+  'task_card_read_states',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    messageId: uuid('message_id')
+      .notNull()
+      .references(() => messages.id, { onDelete: 'cascade' }),
+    cardId: varchar('card_id', { length: 80 }).notNull(),
+    readAt: timestamp('read_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    taskCardReadStatesUserMessageCardUnique: uniqueIndex(
+      'task_card_read_states_user_message_card_unique',
+    ).on(t.userId, t.messageId, t.cardId),
+    taskCardReadStatesMessageIdx: index('task_card_read_states_message_idx').on(t.messageId),
+    taskCardReadStatesUserIdx: index('task_card_read_states_user_idx').on(t.userId),
   }),
 )

--- a/apps/server/src/handlers/buddy-inbox.handler.ts
+++ b/apps/server/src/handlers/buddy-inbox.handler.ts
@@ -466,6 +466,14 @@ export function createBuddyInboxHandler(container: AppContainer) {
     },
   )
 
+  handler.post('/messages/:messageId/cards/:cardId/read', async (c) => {
+    const state = await container
+      .resolve('buddyInboxService')
+      .markTaskCardRead(c.req.param('messageId'), c.req.param('cardId'), c.get('actor'))
+
+    return c.json(state)
+  })
+
   handler.post(
     '/messages/:messageId/cards/:cardId/retry',
     zValidator('json', retryTaskCardSchema.optional().default({})),

--- a/apps/server/src/handlers/message.handler.ts
+++ b/apps/server/src/handlers/message.handler.ts
@@ -85,6 +85,27 @@ type ThreadEventPayload = {
   channelId: string
 }
 
+type NewMessageEventPayload = {
+  channelId: string
+  threadId?: string | null
+}
+
+function emitNewMessageEvent(
+  container: AppContainer,
+  message: NewMessageEventPayload,
+  options: { directPeerId?: string | null } = {},
+) {
+  try {
+    const io = container.resolve('io')
+    let target = io.to(`channel:${message.channelId}`)
+    if (message.threadId) target = target.to(`thread:${message.threadId}`)
+    if (options.directPeerId) target = target.to(`user:${options.directPeerId}`)
+    target.emit('message:new', message)
+  } catch {
+    /* io not yet registered */
+  }
+}
+
 function emitThreadEvent(
   container: AppContainer,
   event: 'thread:created' | 'thread:updated' | 'thread:deleted',
@@ -325,17 +346,7 @@ export function createMessageHandler(container: AppContainer) {
       // Emit WS event so all connected clients (including bots) see the message.
       // Direct message peers also receive it through their user room so a newly
       // started Buddy does not miss the first DM while joining the channel room.
-      try {
-        const io = container.resolve('io')
-        let target = io.to(`channel:${channelId}`)
-        if (directPeer) target = target.to(`user:${directPeer.id}`)
-        if (message.threadId) {
-          io.to(`thread:${message.threadId}`).emit('message:new', message)
-        }
-        target.emit('message:new', message)
-      } catch {
-        /* io not yet registered */
-      }
+      emitNewMessageEvent(container, message, { directPeerId: directPeer?.id })
 
       try {
         if (access.channel?.kind === 'dm') {
@@ -512,15 +523,7 @@ export function createMessageHandler(container: AppContainer) {
         await messageService.updateInteractiveSubmissionResponse(submission.id, message.id)
       }
 
-      try {
-        const io = container.resolve('io')
-        if (message.threadId) {
-          io.to(`thread:${message.threadId}`).emit('message:new', message)
-        }
-        io.to(`channel:${source.channelId}`).emit('message:new', message)
-      } catch {
-        /* io not yet registered */
-      }
+      emitNewMessageEvent(container, message)
       if (message.threadId) {
         await emitThreadEventById(container, 'thread:updated', message.threadId)
       }
@@ -726,13 +729,7 @@ export function createMessageHandler(container: AppContainer) {
       return c.json({ ok: false, error: 'Failed to create thread message' }, 500)
     }
 
-    try {
-      const io = container.resolve('io')
-      io.to(`thread:${id}`).emit('message:new', message)
-      io.to(`channel:${thread.channelId}`).emit('message:new', message)
-    } catch {
-      /* io not yet registered */
-    }
+    emitNewMessageEvent(container, message)
     await emitThreadEventById(container, 'thread:updated', id)
 
     try {

--- a/apps/server/src/services/buddy-inbox.service.ts
+++ b/apps/server/src/services/buddy-inbox.service.ts
@@ -104,9 +104,7 @@ function taskContent(input: { title: string; body?: string }) {
 function isTaskCard(card: unknown): card is TaskMessageCardMetadata {
   if (!card || typeof card !== 'object' || Array.isArray(card)) return false
   const record = card as Record<string, unknown>
-  if (record.kind !== 'task' || typeof record.id !== 'string') return false
-  const data = recordValue(record.data)
-  return data?.taskReplyNotification !== true
+  return record.kind === 'task' && typeof record.id === 'string'
 }
 
 function claimExpired(card: TaskMessageCardMetadata) {

--- a/apps/server/src/services/buddy-inbox.service.ts
+++ b/apps/server/src/services/buddy-inbox.service.ts
@@ -160,6 +160,13 @@ function claimExpired(card: TaskMessageCardMetadata) {
   return new Date(card.claim.expiresAt).getTime() <= Date.now()
 }
 
+function taskCardClaimable(card: TaskMessageCardMetadata) {
+  return (
+    card.status === 'queued' ||
+    ((card.status === 'claimed' || card.status === 'running') && claimExpired(card))
+  )
+}
+
 function taskIdempotencyKey(card: TaskMessageCardMetadata) {
   const data = card.data
   if (!data || typeof data !== 'object' || Array.isArray(data)) return null
@@ -276,6 +283,30 @@ function normalizedToken(value: string | null | undefined) {
 function taskWorkspaceId(card: TaskMessageCardMetadata) {
   const value = card.data?.task?.workspaceId
   return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function taskRuntimeBinding(input: {
+  channelId: string
+  messageId: string
+  cardId: string
+  threadId: string
+}) {
+  const base = `shadowob inbox update ${input.messageId} ${input.cardId}`
+  return {
+    protocol: 'shadowob.task.v1',
+    messageId: input.messageId,
+    cardId: input.cardId,
+    threadId: input.threadId,
+    replyTarget: {
+      channelId: input.channelId,
+      threadId: input.threadId,
+    },
+    runningCommand: `${base} --status running --note "Started" --json`,
+    completedCommand: `${base} --status completed --note "Done" --json`,
+    failedCommand: `${base} --status failed --note "Blocked: <reason>" --json`,
+    instruction:
+      'This is a Shadow Task Card. Update Shadow task status with shadowob inbox update; do not use a server App such as Kanban to mark the Shadow task complete. Send ordinary discussion to the task thread.',
+  }
 }
 
 function taskContextSourceMessageId(input: EnqueueTaskInput) {
@@ -1305,6 +1336,7 @@ export class BuddyInboxService {
             ? data.task
             : {}),
           workspaceId,
+          cardId,
           revision: 1,
           contextPack,
         },
@@ -1329,7 +1361,15 @@ export class BuddyInboxService {
         task: {
           ...cardTaskData,
           threadId: thread.id,
+          messageId: message.id,
+          cardId,
           revision: 1,
+          runtimeBinding: taskRuntimeBinding({
+            channelId,
+            messageId: message.id,
+            cardId,
+            threadId: thread.id,
+          }),
           contextPack,
         },
       },
@@ -1512,10 +1552,7 @@ export class BuddyInboxService {
       for (const card of cards) {
         if (!isTaskCard(card)) continue
         if (card.assignee?.agentId !== agentId && card.assignee?.userId !== agent.userId) continue
-        const claimable =
-          card.status === 'queued' ||
-          ((card.status === 'claimed' || card.status === 'running') && claimExpired(card))
-        if (!claimable) continue
+        if (!taskCardClaimable(card)) continue
         const updated = await this.claimTaskCard(message.id, card.id, actor)
         const updatedMetadata = (updated?.metadata ?? {}) as MessageMetadata
         const updatedCards = Array.isArray(updatedMetadata.cards) ? updatedMetadata.cards : []
@@ -1544,6 +1581,16 @@ export class BuddyInboxService {
     )
     if (!targetCard) {
       throw Object.assign(new Error('Task card not found'), { status: 404 })
+    }
+    if (!taskCardClaimable(targetCard)) {
+      throw Object.assign(
+        new Error(
+          isTerminalTaskMessageCardStatus(targetCard.status)
+            ? 'Terminal task cards cannot be claimed'
+            : 'Task card is already claimed',
+        ),
+        { status: 409 },
+      )
     }
     await this.assertCanUseTaskCard(access, targetCard, actor, 'claim')
     const now = new Date()
@@ -1679,6 +1726,34 @@ export class BuddyInboxService {
       ...metadata,
       cards: nextCards,
     })
+  }
+
+  async markTaskCardRead(messageId: string, cardId: string, actor: Actor) {
+    const message = await this.deps.messageDao.findById(messageId)
+    if (!message) {
+      throw Object.assign(new Error('Message not found'), { status: 404 })
+    }
+    await this.deps.policyService.requireChannelRead(actor, message.channelId)
+    const metadata = (message.metadata ?? {}) as MessageMetadata
+    const cards = Array.isArray(metadata.cards) ? metadata.cards : []
+    const targetCard = cards.find(
+      (card): card is TaskMessageCardMetadata => isTaskCard(card) && card.id === cardId,
+    )
+    if (!targetCard) {
+      throw Object.assign(new Error('Task card not found'), { status: 404 })
+    }
+    const readAt = new Date()
+    const state = await this.deps.messageDao.upsertTaskCardReadState({
+      userId: actorUserId(actor),
+      messageId,
+      cardId,
+      readAt,
+    })
+    return {
+      messageId,
+      cardId,
+      readAt: (state?.readAt ?? readAt).toISOString(),
+    }
   }
 
   async assertTaskCommandAccess(

--- a/apps/server/src/services/buddy-inbox.service.ts
+++ b/apps/server/src/services/buddy-inbox.service.ts
@@ -47,6 +47,51 @@ type EnqueueTaskInput = {
   data?: Record<string, unknown>
 }
 
+type TaskContextSourceMessage = {
+  id: string
+  channelId: string
+  authorId: string
+  content: string
+  threadId?: string | null
+  createdAt: Date | string
+}
+
+type TaskContextPack = {
+  snapshotAtMessageId: string | null
+  sourceSurface: 'channel' | 'thread' | 'task-thread' | 'app'
+  policy: 'auto_recent' | 'explicit_refs' | 'thread_context' | 'manual'
+  summary: string | null
+  items: Array<
+    | {
+        kind: 'message'
+        messageId: string
+        threadId?: string | null
+        authorId: string
+        createdAt: string
+        text: string
+      }
+    | {
+        kind: 'resource'
+        resourceType: string
+        resourceId: string
+        title?: string
+        summary?: string
+      }
+    | {
+        kind: 'task_result'
+        messageId: string
+        cardId: string
+        title: string
+        summary: string
+      }
+  >
+  omitted: Array<{
+    messageCount: number
+    reason: 'token_budget' | 'permission' | 'privacy' | 'not_relevant'
+  }>
+  tokenEstimate: number
+}
+
 type AdmissionSubject = {
   kind: BuddyInboxAdmissionSubjectKind
   id?: string
@@ -66,6 +111,9 @@ type UserSummary = {
   avatarUrl: string | null
   isBot?: boolean | null
 }
+
+const TASK_CONTEXT_MESSAGE_LIMIT = 20
+const TASK_CONTEXT_TEXT_LIMIT = 2000
 
 function canManageServer(role: string | null | undefined) {
   return role === 'owner' || role === 'admin'
@@ -228,6 +276,61 @@ function normalizedToken(value: string | null | undefined) {
 function taskWorkspaceId(card: TaskMessageCardMetadata) {
   const value = card.data?.task?.workspaceId
   return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function taskContextSourceMessageId(input: EnqueueTaskInput) {
+  const data = recordValue(input.data)
+  const sourceResource =
+    input.source?.resource && typeof input.source.resource === 'object'
+      ? recordValue(input.source.resource)
+      : null
+  const resourceKind = recordString(sourceResource, 'kind')
+  if (resourceKind === 'message') {
+    return recordString(sourceResource, 'id')
+  }
+  return recordString(data, 'promotedFromMessageId')
+}
+
+function taskContextExplicitChannelId(input: EnqueueTaskInput) {
+  const data = recordValue(input.data)
+  return recordString(data, 'promotedFromChannelId') ?? input.source?.channelId
+}
+
+function taskContextText(content: string) {
+  const text = content.replace(/\s+/g, ' ').trim()
+  if (text.length <= TASK_CONTEXT_TEXT_LIMIT) return text
+  return `${text.slice(0, TASK_CONTEXT_TEXT_LIMIT - 3)}...`
+}
+
+function taskContextCreatedAt(value: TaskContextSourceMessage['createdAt']) {
+  if (value instanceof Date) return value.toISOString()
+  return value
+}
+
+function taskContextSourceSurface(input: EnqueueTaskInput): TaskContextPack['sourceSurface'] {
+  if (input.source?.kind === 'server_app') return 'app'
+  return 'channel'
+}
+
+function taskContextItem(message: TaskContextSourceMessage) {
+  return {
+    kind: 'message' as const,
+    messageId: message.id,
+    ...(message.threadId ? { threadId: message.threadId } : {}),
+    authorId: message.authorId,
+    createdAt: taskContextCreatedAt(message.createdAt),
+    text: taskContextText(message.content),
+  }
+}
+
+function taskContextTokenEstimate(items: TaskContextPack['items']) {
+  const chars = items.reduce((sum, item) => {
+    if (item.kind === 'message') return sum + item.text.length
+    if (item.kind === 'resource')
+      return sum + (item.title?.length ?? 0) + (item.summary?.length ?? 0)
+    return sum + item.title.length + item.summary.length
+  }, 0)
+  return Math.ceil(chars / 4)
 }
 
 function assertTaskStatusTransition(from: MessageCardStatusInput, to: MessageCardStatusInput) {
@@ -788,6 +891,74 @@ export class BuddyInboxService {
     return null
   }
 
+  private async resolveTaskContextChannelId(
+    defaultChannelId: string,
+    input: EnqueueTaskInput,
+    actor: Actor,
+  ) {
+    const explicitChannelId = taskContextExplicitChannelId(input)
+    if (!explicitChannelId || explicitChannelId === defaultChannelId) return defaultChannelId
+    try {
+      await this.deps.policyService.requireChannelRead(actor, explicitChannelId)
+      return explicitChannelId
+    } catch {
+      return defaultChannelId
+    }
+  }
+
+  private async buildTaskContextPack(
+    channelId: string,
+    input: EnqueueTaskInput,
+    actor: Actor,
+  ): Promise<TaskContextPack> {
+    const contextChannelId = await this.resolveTaskContextChannelId(channelId, input, actor)
+    const recent = await this.deps.messageDao.findByChannelId(
+      contextChannelId,
+      TASK_CONTEXT_MESSAGE_LIMIT,
+    )
+    const messages = recent.messages as TaskContextSourceMessage[]
+    const sourceMessageId = taskContextSourceMessageId(input)
+    const items = messages
+      .filter((message) => message.content.trim().length > 0)
+      .map((message) => taskContextItem(message))
+
+    if (
+      sourceMessageId &&
+      !items.some((item) => item.kind === 'message' && item.messageId === sourceMessageId)
+    ) {
+      const sourceMessage = (await this.deps.messageDao.findById(
+        sourceMessageId,
+      )) as TaskContextSourceMessage | null
+      if (
+        sourceMessage &&
+        sourceMessage.channelId === contextChannelId &&
+        sourceMessage.content.trim().length > 0
+      ) {
+        items.push(taskContextItem(sourceMessage))
+      }
+    }
+    const includedSourceMessageId =
+      sourceMessageId &&
+      items.some((item) => item.kind === 'message' && item.messageId === sourceMessageId)
+        ? sourceMessageId
+        : null
+
+    const snapshotAtMessageId =
+      includedSourceMessageId ??
+      [...items].reverse().find((item) => item.kind === 'message')?.messageId ??
+      null
+
+    return {
+      snapshotAtMessageId,
+      sourceSurface: taskContextSourceSurface(input),
+      policy: 'auto_recent',
+      summary: null,
+      items,
+      omitted: recent.hasMore ? [{ messageCount: 1, reason: 'token_budget' }] : [],
+      tokenEstimate: taskContextTokenEstimate(items),
+    }
+  }
+
   async listForServer(
     serverId: string,
     actor: ActorInput,
@@ -1085,9 +1256,10 @@ export class BuddyInboxService {
     const existing = await this.findMessageByTaskIdempotencyKey(channelId, input.idempotencyKey)
     if (existing) return existing
 
-    const [botUser, author] = await Promise.all([
+    const [botUser, author, contextPack] = await Promise.all([
       this.deps.userDao.findById(agent.userId),
       this.deps.userDao.findById(actorUserId(actor)),
+      this.buildTaskContextPack(channelId, input, actor),
     ])
     const now = new Date().toISOString()
     const data: Record<string, unknown> = {
@@ -1133,14 +1305,42 @@ export class BuddyInboxService {
             ? data.task
             : {}),
           workspaceId,
+          revision: 1,
+          contextPack,
         },
       },
     }
 
-    return this.deps.messageService.send(channelId, actorUserId(actor), {
+    const message = await this.deps.messageService.send(channelId, actorUserId(actor), {
       content: taskContent(input),
       metadata: { cards: [card as unknown as MessageCardInput] },
     })
+    const thread = await this.deps.messageService.ensureThreadForMessage(
+      message.id,
+      actorUserId(actor),
+      { name: input.title.trim() },
+    )
+    const cardTaskData = recordValue(card.data?.task) ?? {}
+    const nextCard: TaskMessageCardMetadata = {
+      ...card,
+      updatedAt: new Date().toISOString(),
+      data: {
+        ...(card.data ?? {}),
+        task: {
+          ...cardTaskData,
+          threadId: thread.id,
+          revision: 1,
+          contextPack,
+        },
+      },
+    }
+    const metadata = (message.metadata ?? {}) as MessageMetadata
+    const updated = await this.deps.messageService.updateMetadata(message.id, {
+      ...metadata,
+      cards: [nextCard as unknown as MessageCardInput],
+    })
+    this.deps.io?.to(`channel:${channelId}`).emit('thread:created', thread)
+    return updated
   }
 
   async enqueueTask(channelId: string, input: EnqueueTaskInput, actor: Actor) {

--- a/apps/server/src/services/commerce-card.service.ts
+++ b/apps/server/src/services/commerce-card.service.ts
@@ -46,6 +46,7 @@ function normalizeMetadata(metadata?: Record<string, unknown>) {
     'interactive',
     'interactiveResponse',
     'mentions',
+    'ccConnectDelivery',
     'shadowDelivery',
     'slashCommand',
     'cards',

--- a/apps/server/src/services/message.service.ts
+++ b/apps/server/src/services/message.service.ts
@@ -755,16 +755,7 @@ export class MessageService {
       })
     }
 
-    const thread = await this.deps.messageDao.createThread({
-      name: input.name,
-      channelId,
-      parentMessageId: input.parentMessageId,
-      creatorId: userId,
-    })
-    if (!thread) {
-      throw Object.assign(new Error('Failed to create thread'), { status: 500 })
-    }
-    return thread
+    return this.ensureThreadForMessage(input.parentMessageId, userId, { name: input.name })
   }
 
   async ensureThreadForMessage(

--- a/apps/server/src/services/message.service.ts
+++ b/apps/server/src/services/message.service.ts
@@ -118,28 +118,6 @@ function isReplyableTaskCard(card: TaskMessageCardMetadata) {
   return isActiveTaskCard(card) || card.status === 'completed' || card.status === 'failed'
 }
 
-function taskCardDataRecord(card: TaskMessageCardMetadata) {
-  return card.data && typeof card.data === 'object' && !Array.isArray(card.data) ? card.data : null
-}
-
-function taskCardOutputContractRecord(card: TaskMessageCardMetadata) {
-  return card.outputContract && typeof card.outputContract === 'object'
-    ? (card.outputContract as Record<string, unknown>)
-    : null
-}
-
-function taskCardReplyCompletionStatus(card: TaskMessageCardMetadata) {
-  const outputContract = taskCardOutputContractRecord(card)
-  const data = taskCardDataRecord(card)
-  const policy: Record<string, unknown> | null = isRecord(outputContract?.completionPolicy)
-    ? outputContract.completionPolicy
-    : isRecord(data?.completionPolicy)
-      ? data.completionPolicy
-      : null
-  if (!policy || policy.mode !== 'reply_terminal') return null
-  return policy.status === 'failed' ? 'failed' : 'completed'
-}
-
 function isVoiceRecordingLike(attachment: {
   filename?: string
   contentType: string
@@ -642,15 +620,12 @@ export class MessageService {
       const now = new Date().toISOString()
       let changed = false
       let matched = false
-      let repliedTaskCard: TaskMessageCardMetadata | null = null
       const nextCards = cards.map((card) => {
         if (!isTaskCard(card) || matched || !isReplyableTaskCard(card)) return card
         if (card.assignee?.userId !== input.authorId && card.assignee?.agentId !== agentId) {
           return card
         }
         matched = true
-        const existingReplies = Array.isArray(card.replies) ? card.replies : []
-        if (existingReplies.some((reply) => reply.messageId === input.messageId)) return card
         const existingProgress = Array.isArray(card.progress) ? card.progress : []
         const actor = {
           kind: 'agent' as const,
@@ -658,53 +633,20 @@ export class MessageService {
           userId: input.authorId,
           label: input.authorLabel,
         }
-        const replyCompletionStatus = isActiveTaskCard(card)
-          ? taskCardReplyCompletionStatus(card)
-          : null
-        const nextStatus =
-          replyCompletionStatus ??
-          (card.status === 'queued' || card.status === 'claimed'
-            ? ('running' as const)
-            : card.status)
-        const progressNotePrefix =
-          replyCompletionStatus === 'failed'
-            ? 'Buddy reply marked task failed'
-            : replyCompletionStatus === 'completed'
-              ? 'Buddy reply completed task'
-              : 'Buddy replied'
         const nextCard = {
           ...card,
-          status: nextStatus,
           updatedAt: now,
-          replies: [
-            ...existingReplies,
-            {
-              messageId: input.messageId,
-              cardId: card.id,
-              authorId: input.authorId,
-              authorLabel: input.authorLabel,
-              content: input.content.slice(0, 4000),
-              createdAt: now,
-              source: actor,
-            },
-          ].slice(-100),
           progress: [
             ...existingProgress,
             {
               at: now,
-              status: nextStatus,
-              note: `${progressNotePrefix}: ${input.content.slice(0, 240)}`,
+              status: card.status,
+              note: `Buddy replied: ${input.content.slice(0, 240)}`,
               actor,
             },
           ].slice(-100),
         }
         changed = true
-        if (replyCompletionStatus) {
-          const { claim: _claim, capability: _capability, ...terminalCard } = nextCard
-          repliedTaskCard = terminalCard
-          return terminalCard
-        }
-        repliedTaskCard = nextCard
         return nextCard
       })
       if (!changed) return
@@ -713,134 +655,12 @@ export class MessageService {
         cards: nextCards,
       })
       this.deps.io?.to(`channel:${input.channelId}`).emit('message:updated', updated)
-      if (repliedTaskCard) {
-        await this.notifyInboxTaskDispatcher({
-          serverId: channel?.serverId ?? null,
-          taskMessage: target,
-          taskCard: repliedTaskCard,
-          reply: input,
-          responderAgentId: agentId,
-        })
-      }
     } catch (err) {
       this.deps.logger?.warn?.(
         { err, channelId: input.channelId, messageId: input.messageId },
         'Failed to record Inbox task reply from Buddy reply',
       )
     }
-  }
-
-  private async notifyInboxTaskDispatcher(input: {
-    serverId: string | null
-    taskMessage: { id: string; channelId: string; authorId: string }
-    taskCard: TaskMessageCardMetadata
-    reply: {
-      channelId: string
-      messageId: string
-      authorId: string
-      authorLabel: string
-      content: string
-    }
-    responderAgentId: string
-  }) {
-    if (!input.serverId) return
-    if (input.taskMessage.authorId === input.reply.authorId) return
-    if (taskCardDataRecord(input.taskCard)?.taskReplyNotification === true) return
-    if (input.taskCard.status !== 'completed' && input.taskCard.status !== 'failed') return
-
-    const dispatcherAgent = await this.deps.agentDao.findByUserId(input.taskMessage.authorId)
-    if (!dispatcherAgent) return
-    const channels = await this.deps.channelDao.findByServerId(input.serverId)
-    const dispatcherInbox = channels.find(
-      (channel) => parseBuddyInboxAgentId(channel.topic) === dispatcherAgent.id,
-    )
-    if (!dispatcherInbox || dispatcherInbox.id === input.reply.channelId) return
-
-    const idempotencyKey = [
-      'inbox-task-reply',
-      input.taskMessage.id,
-      input.taskCard.id,
-      input.reply.messageId,
-    ].join(':')
-    const recent = await this.deps.messageDao.findByChannelId(dispatcherInbox.id, 25)
-    const alreadyNotified = recent.messages.some((message) => {
-      const metadata = (message.metadata ?? {}) as MessageMetadata
-      const custom = metadata.custom && typeof metadata.custom === 'object' ? metadata.custom : {}
-      const notification =
-        'inboxTaskReplyNotification' in custom &&
-        custom.inboxTaskReplyNotification &&
-        typeof custom.inboxTaskReplyNotification === 'object'
-          ? (custom.inboxTaskReplyNotification as Record<string, unknown>)
-          : null
-      if (notification?.idempotencyKey === idempotencyKey) return true
-      const cards = Array.isArray(metadata.cards) ? metadata.cards : []
-      return cards.some((card) => {
-        if (!isTaskCard(card)) return false
-        return taskCardDataRecord(card)?.idempotencyKey === idempotencyKey
-      })
-    })
-    if (alreadyNotified) return
-
-    const now = new Date().toISOString()
-    const resource =
-      input.taskCard.source &&
-      typeof input.taskCard.source === 'object' &&
-      'resource' in input.taskCard.source
-        ? input.taskCard.source.resource
-        : undefined
-    const taskTitle = `Review reply: ${input.taskCard.title}`
-    const taskBody = [
-      `${input.reply.authorLabel} replied to delegated Inbox task "${input.taskCard.title}".`,
-      'Open the referenced message to review the full response in context.',
-    ].join('\n')
-    const notification = await this.send(dispatcherInbox.id, input.reply.authorId, {
-      content: taskBody,
-      metadata: {
-        cards: [
-          {
-            id: `ref-${input.reply.messageId}`,
-            kind: 'message_reference',
-            version: 1,
-            title: input.taskCard.title,
-            description: input.reply.content.slice(0, 600),
-            label: input.reply.authorLabel,
-            target: {
-              channelId: input.reply.channelId,
-              messageId: input.reply.messageId,
-              taskCardId: input.taskCard.id,
-              inboxAgentId: input.responderAgentId,
-              kind: 'inbox_message',
-            },
-            source: {
-              kind: 'agent',
-              id: input.responderAgentId,
-              agentId: input.responderAgentId,
-              label: input.reply.authorLabel,
-              ...(resource ? { resource } : {}),
-            },
-            createdAt: now,
-          },
-        ],
-        custom: {
-          inboxTaskReplyNotification: {
-            kind: 'inbox_task_reply_notification',
-            idempotencyKey,
-            replyMessageId: input.reply.messageId,
-            replyChannelId: input.reply.channelId,
-            replyAuthorId: input.reply.authorId,
-            replyAuthorLabel: input.reply.authorLabel,
-            responderAgentId: input.responderAgentId,
-            originalTaskMessageId: input.taskMessage.id,
-            originalTaskCardId: input.taskCard.id,
-            originalTaskTitle: input.taskCard.title,
-            originalTaskStatus: input.taskCard.status,
-            title: taskTitle,
-            ...(resource ? { resource } : {}),
-          },
-        },
-      } as SendMessageInput['metadata'],
-    })
-    this.deps.io?.to(`channel:${dispatcherInbox.id}`).emit('message:new', notification)
   }
 
   async update(id: string, userId: string, input: UpdateMessageInput) {

--- a/apps/server/src/services/message.service.ts
+++ b/apps/server/src/services/message.service.ts
@@ -34,6 +34,9 @@ type MessageAuthorWithAvatar = {
 type InteractiveSubmissionRecord = NonNullable<
   Awaited<ReturnType<MessageDao['findInteractiveSubmission']>>
 >
+type TaskCardReadStateRecord = Awaited<
+  ReturnType<MessageDao['findTaskCardReadStatesForMessages']>
+>[number]
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -76,6 +79,32 @@ function getInteractiveBlockId(message: MessageWithMetadata): string | null {
   if (!isRecord(interactive)) return null
   const id = (interactive as Record<string, unknown>).id
   return typeof id === 'string' && id.trim() ? id : null
+}
+
+function isTaskCardMetadata(value: unknown): value is TaskMessageCardMetadata {
+  return (
+    isRecord(value) &&
+    value.kind === 'task' &&
+    typeof value.id === 'string' &&
+    typeof value.title === 'string'
+  )
+}
+
+function taskCardReadKey(messageId: string, cardId: string) {
+  return `${messageId}:${cardId}`
+}
+
+function taskCardReadAtIso(state: TaskCardReadStateRecord | undefined) {
+  return state?.readAt instanceof Date ? state.readAt.toISOString() : undefined
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function taskCardThreadId(card: TaskMessageCardMetadata) {
+  const task = isRecord(card.data?.task) ? card.data.task : null
+  return stringValue(task?.threadId)
 }
 
 function buildInteractiveState(sourceMessageId: string, blockId: string) {
@@ -316,13 +345,17 @@ export class MessageService {
     const messages = this.resolveAuthorAvatars(result.messages)
     if (!viewerUserId) return { ...result, messages }
     const messagesWithInteractiveState = await this.attachInteractiveStates(messages, viewerUserId)
+    const messagesWithTaskCardReadStates = await this.attachTaskCardReadStates(
+      messagesWithInteractiveState,
+      viewerUserId,
+    )
     return {
       ...result,
       messages:
         (await this.deps.voiceMessageService?.enrichMessagesForViewer(
-          messagesWithInteractiveState,
+          messagesWithTaskCardReadStates,
           viewerUserId,
-        )) ?? messagesWithInteractiveState,
+        )) ?? messagesWithTaskCardReadStates,
     }
   }
 
@@ -334,12 +367,21 @@ export class MessageService {
       [{ ...message, attachments }],
       viewerUserId,
     )
+    const [messageWithTaskCardReadState] = await this.attachTaskCardReadStates(
+      messageWithInteractiveState ? [messageWithInteractiveState] : [],
+      viewerUserId,
+    )
     const [messageWithVoiceState] =
       (await this.deps.voiceMessageService?.enrichMessagesForViewer(
-        messageWithInteractiveState ? [messageWithInteractiveState] : [],
+        messageWithTaskCardReadState ? [messageWithTaskCardReadState] : [],
         viewerUserId,
       )) ?? []
-    return messageWithVoiceState ?? messageWithInteractiveState ?? message
+    return (
+      messageWithVoiceState ??
+      messageWithTaskCardReadState ??
+      messageWithInteractiveState ??
+      message
+    )
   }
 
   async getWindowAroundMessage(
@@ -353,13 +395,17 @@ export class MessageService {
     const messages = this.resolveAuthorAvatars(result.messages)
     if (!viewerUserId) return { ...result, messages }
     const messagesWithInteractiveState = await this.attachInteractiveStates(messages, viewerUserId)
+    const messagesWithTaskCardReadStates = await this.attachTaskCardReadStates(
+      messagesWithInteractiveState,
+      viewerUserId,
+    )
     return {
       ...result,
       messages:
         (await this.deps.voiceMessageService?.enrichMessagesForViewer(
-          messagesWithInteractiveState,
+          messagesWithTaskCardReadStates,
           viewerUserId,
-        )) ?? messagesWithInteractiveState,
+        )) ?? messagesWithTaskCardReadStates,
     }
   }
 
@@ -435,9 +481,139 @@ export class MessageService {
     })
   }
 
+  private async attachTaskCardReadStates<T extends MessageWithMetadata>(
+    messages: T[],
+    viewerUserId: string,
+  ): Promise<T[]> {
+    const taskEntries = messages.flatMap((message) => {
+      const cards = Array.isArray(message.metadata?.cards) ? message.metadata.cards : []
+      return cards
+        .filter(isTaskCardMetadata)
+        .map((card) => ({ messageId: message.id, cardId: card.id }))
+    })
+    if (taskEntries.length === 0) return messages
+
+    const states = await this.deps.messageDao.findTaskCardReadStatesForMessages(viewerUserId, [
+      ...new Set(taskEntries.map((entry) => entry.messageId)),
+    ])
+    if (states.length === 0) return messages
+
+    const byKey = new Map(
+      states.map((state) => [taskCardReadKey(state.messageId, state.cardId), state] as const),
+    )
+
+    return messages.map((message) => {
+      const cards = Array.isArray(message.metadata?.cards) ? message.metadata.cards : null
+      if (!cards) return message
+
+      let changed = false
+      const nextCards = cards.map((card) => {
+        if (!isTaskCardMetadata(card)) return card
+        const viewerReadAt = taskCardReadAtIso(byKey.get(taskCardReadKey(message.id, card.id)))
+        if (!viewerReadAt) return card
+        changed = true
+        const taskData = isRecord(card.data?.task) ? card.data.task : {}
+        return {
+          ...card,
+          data: {
+            ...(card.data ?? {}),
+            task: {
+              ...taskData,
+              viewerReadAt,
+            },
+          },
+        }
+      })
+
+      if (!changed) return message
+      return {
+        ...message,
+        metadata: {
+          ...(message.metadata ?? {}),
+          cards: nextCards,
+        },
+      }
+    })
+  }
+
+  private async inferInboxTaskReplyRoute(input: {
+    channelId: string
+    authorId: string
+    replyToId?: string
+  }): Promise<{ threadId?: string; replyToId?: string }> {
+    const authorAgent = await this.deps.agentDao?.findByUserId?.(input.authorId)
+    if (!authorAgent) return {}
+
+    const matchesAuthorAgent = (card: TaskMessageCardMetadata) =>
+      card.assignee?.userId === input.authorId || card.assignee?.agentId === authorAgent.id
+
+    if (input.replyToId) {
+      const replyTarget = await this.deps.messageDao.findById(input.replyToId)
+      if (!replyTarget || replyTarget.channelId !== input.channelId) return {}
+      if (replyTarget.threadId) return { threadId: replyTarget.threadId }
+
+      const cards = Array.isArray(replyTarget.metadata?.cards) ? replyTarget.metadata.cards : []
+      const card = cards.find(
+        (item): item is TaskMessageCardMetadata =>
+          isTaskCard(item) && isReplyableTaskCard(item) && matchesAuthorAgent(item),
+      )
+      const threadId = card ? taskCardThreadId(card) : undefined
+      if (threadId) return { threadId, replyToId: input.replyToId }
+    }
+
+    const channel = await this.deps.channelDao.findById(input.channelId)
+    const inboxAgentId = parseBuddyInboxAgentId(channel?.topic)
+    if (inboxAgentId && inboxAgentId !== authorAgent.id) return {}
+    if (!inboxAgentId) return {}
+
+    const recent = await this.deps.messageDao.findByChannelId(input.channelId, 25)
+    const candidates = [...recent.messages].reverse().flatMap((message) => {
+      const cards = Array.isArray(message.metadata?.cards) ? message.metadata.cards : []
+      return cards
+        .filter(
+          (card): card is TaskMessageCardMetadata =>
+            isTaskCard(card) &&
+            isReplyableTaskCard(card) &&
+            matchesAuthorAgent(card) &&
+            Boolean(taskCardThreadId(card)),
+        )
+        .map((card) => ({
+          message,
+          card,
+          active: isActiveTaskCard(card),
+        }))
+    })
+
+    const target =
+      candidates.find((candidate) => candidate.active) ??
+      candidates.find((candidate) => Boolean(candidate.card))
+    const threadId = target ? taskCardThreadId(target.card) : undefined
+    return threadId ? { threadId, replyToId: input.replyToId ?? target?.message.id } : {}
+  }
+
   async send(channelId: string, authorId: string, input: SendMessageInput) {
-    if (input.threadId) {
-      const thread = await this.deps.messageDao.findThreadById(input.threadId)
+    let threadId = input.threadId
+    let replyToId = input.replyToId
+    if (!threadId && input.replyToId) {
+      const replyTarget = await this.deps.messageDao.findById(input.replyToId)
+      if (replyTarget?.channelId === channelId && replyTarget.threadId) {
+        threadId = replyTarget.threadId
+      }
+    }
+    if (!threadId) {
+      const taskReplyRoute = await this.inferInboxTaskReplyRoute({
+        channelId,
+        authorId,
+        replyToId,
+      })
+      if (taskReplyRoute.threadId) {
+        threadId = taskReplyRoute.threadId
+        replyToId = taskReplyRoute.replyToId ?? replyToId
+      }
+    }
+
+    if (threadId) {
+      const thread = await this.deps.messageDao.findThreadById(threadId)
       if (!thread || thread.channelId !== channelId) {
         throw Object.assign(new Error('Thread not found'), { status: 404 })
       }
@@ -453,15 +629,15 @@ export class MessageService {
     await this.assertBuddyReplyCollaboration({
       channelId,
       authorId,
-      replyToId: input.replyToId,
+      replyToId,
       metadata,
     })
     const message = await this.deps.messageDao.create({
       content: input.content,
       channelId,
       authorId,
-      threadId: input.threadId,
-      replyToId: input.replyToId,
+      threadId,
+      replyToId,
       metadata,
     })
     if (!message) {
@@ -475,8 +651,8 @@ export class MessageService {
       // Non-critical: don't fail message creation if this fails
     }
 
-    if (input.threadId) {
-      await this.deps.messageDao.touchThread(input.threadId)
+    if (threadId) {
+      await this.deps.messageDao.touchThread(threadId)
     }
 
     // Create attachment records if provided (pre-uploaded files)
@@ -539,7 +715,7 @@ export class MessageService {
     await this.recordInboxTaskReplyFromBuddyReply({
       channelId,
       messageId: message.id,
-      replyToId: input.replyToId,
+      replyToId,
       authorId,
       authorLabel: user?.displayName ?? user?.username ?? authorId,
       content: input.content,

--- a/apps/server/src/validators/message.schema.ts
+++ b/apps/server/src/validators/message.schema.ts
@@ -377,6 +377,7 @@ export const metadataSchema = z
     interactive: interactiveBlockSchema.optional(),
     interactiveResponse: interactiveResponseSchema.optional(),
     mentions: messageMentionsSchema.optional(),
+    ccConnectDelivery: z.record(z.unknown()).optional(),
     shadowDelivery: z.record(z.unknown()).optional(),
     slashCommand: z.record(z.unknown()).optional(),
     cards: z.array(messageCardSchema).max(8).optional(),

--- a/apps/server/src/ws/chat.gateway.ts
+++ b/apps/server/src/ws/chat.gateway.ts
@@ -259,7 +259,20 @@ export function setupChatGateway(io: SocketIOServer, container: AppContainer): v
           // depend on a newly connected Buddy joining the channel room first.
           let target = io.to(`channel:${data.channelId}`)
           if (directPeer) target = target.to(`user:${directPeer.id}`)
-          target.emit('message:new', message)
+          if (message.threadId) {
+            io.to(`thread:${message.threadId}`).emit('message:new', message)
+            try {
+              const thread = await messageService.getThread(message.threadId)
+              io.to(`channel:${data.channelId}`).emit('thread:updated', thread)
+            } catch (err) {
+              logger.warn(
+                { err, userId, channelId: data.channelId, threadId: message.threadId },
+                'Thread update fanout failed',
+              )
+            }
+          } else {
+            target.emit('message:new', message)
+          }
 
           try {
             if (directPeer) {

--- a/apps/web/src/components/chat/chat-area.tsx
+++ b/apps/web/src/components/chat/chat-area.tsx
@@ -1,8 +1,6 @@
 import {
-  type BuddyInboxTaskFilter,
   type BuddyInboxViewMode,
   buildBuddyInboxViewMessages,
-  getBuddyInboxTaskMessageIds,
   parseBuddyInboxAgentId,
 } from '@shadowob/shared'
 import {
@@ -433,7 +431,6 @@ export function ChatArea({
   const [selectionDragBox, setSelectionDragBox] = useState<SelectionDragBox | null>(null)
   const [showPageQr, setShowPageQr] = useState(false)
   const [inboxViewMode, setInboxViewModeState] = useState<BuddyInboxViewMode>('chat')
-  const [inboxTaskFilter, setInboxTaskFilter] = useState<BuddyInboxTaskFilter>('all')
   const [activeThread, setActiveThread] = useState<Thread | null>(null)
   const [activeThreadParent, setActiveThreadParent] = useState<Message | null>(null)
   const pageShareUrl = window.location.href
@@ -846,28 +843,11 @@ export function ChatArea({
     return [...data.pages].reverse().flatMap((p) => p.messages)
   }, [data])
 
-  const taskCardMessageIds = useMemo(() => {
-    return getBuddyInboxTaskMessageIds(messages)
-  }, [messages])
-
-  const taskRepliesByMessageId = useMemo(() => {
-    const replies = new Map<string, Message[]>()
-    for (const message of messages) {
-      const parentId = message.replyToId
-      if (!parentId || !taskCardMessageIds.has(parentId)) continue
-      const existing = replies.get(parentId) ?? []
-      existing.push(message)
-      replies.set(parentId, existing)
-    }
-    return replies
-  }, [messages, taskCardMessageIds])
-
   const timelineMessages = useMemo(() => {
     return buildBuddyInboxViewMessages(messages, {
       isInboxChannel: usesInboxTaskView,
-      taskFilter: inboxTaskFilter,
     })
-  }, [inboxTaskFilter, messages, usesInboxTaskView])
+  }, [messages, usesInboxTaskView])
 
   // O(1) message lookup map — avoids O(n) .find() for replyToMessage
   const messageMap = useMemo(() => {
@@ -1444,7 +1424,7 @@ export function ChatArea({
   useLayoutEffect(() => {
     if (!shouldVirtualize) return
     virtualizer.measure()
-  }, [activeChannelId, inboxTaskFilter, shouldVirtualize, virtualizer])
+  }, [activeChannelId, shouldVirtualize, virtualizer])
 
   const scrollToBottom = useCallback(
     (behavior: 'auto' | 'smooth' = 'auto') => {
@@ -1508,23 +1488,6 @@ export function ChatArea({
     },
     [shouldVirtualize, timeline, virtualizer],
   )
-
-  useLayoutEffect(() => {
-    if (!pendingAnchorMessageId || !usesInboxTaskView) return
-    const pendingMessage = messageMap.get(pendingAnchorMessageId)
-    if (!pendingMessage) return
-    if (inboxTaskFilter !== 'all') setInboxTaskFilter('all')
-
-    const taskReplyParentId =
-      pendingMessage.replyToId && taskCardMessageIds.has(pendingMessage.replyToId)
-        ? pendingMessage.replyToId
-        : null
-    if (taskReplyParentId) {
-      setPendingAnchorMessageId(taskReplyParentId)
-      setHighlightMsgId(taskReplyParentId)
-      return
-    }
-  }, [inboxTaskFilter, messageMap, pendingAnchorMessageId, taskCardMessageIds, usesInboxTaskView])
 
   const requestMessageFocus = useCallback((messageId: string) => {
     anchorRequestRef.current += 1
@@ -1687,7 +1650,7 @@ export function ChatArea({
     shouldStickToBottomRef.current = true
     pendingPrependRef.current = null
     setLastReadCount(0)
-  }, [activeChannelId, inboxTaskFilter])
+  }, [activeChannelId])
 
   // Scroll event handler — load older messages + track stick-to-bottom
   useEffect(() => {
@@ -2038,7 +2001,6 @@ export function ChatArea({
           replyToMessage={
             item.data.replyToId ? (messageMap.get(item.data.replyToId) ?? null) : null
           }
-          taskReplies={usesInboxTaskView ? taskRepliesByMessageId.get(item.data.id) : undefined}
           selectionMode={selectionMode}
           isSelected={selectedMessageIds.has(item.data.id)}
           selectionAnchorId={selectionAnchorId}
@@ -2253,33 +2215,6 @@ export function ChatArea({
           )}
           {/* Right side: mobile QR + members toggle */}
           <div className="ml-auto flex shrink-0 items-center gap-1.5">
-            {usesInboxTaskView && (
-              <div
-                className="hidden h-8 items-center gap-3 border-b border-border-subtle/70 px-1 sm:flex"
-                role="tablist"
-                aria-label={t('inbox.filter.label')}
-              >
-                {(['all', 'done', 'open'] as const).map((filter) => {
-                  const selected = inboxTaskFilter === filter
-                  return (
-                    <button
-                      key={filter}
-                      type="button"
-                      role="tab"
-                      aria-selected={selected}
-                      onClick={() => setInboxTaskFilter(filter)}
-                      className={cn(
-                        'relative h-8 px-0.5 text-xs font-black text-text-muted transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35',
-                        'after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-full after:bg-transparent after:transition',
-                        selected ? 'text-primary after:bg-primary' : 'hover:text-text-primary',
-                      )}
-                    >
-                      {t(`inbox.filter.${filter}`)}
-                    </button>
-                  )
-                })}
-              </div>
-            )}
             <Button
               variant="ghost"
               size="icon"
@@ -2423,7 +2358,7 @@ export function ChatArea({
             </div>
           ) : timelineMessages.length === 0 && systemEvents.length === 0 ? (
             usesInboxTaskView ? (
-              <InboxEmptyState filter={inboxTaskFilter} hasMessages={messages.length > 0} />
+              <InboxEmptyState />
             ) : (
               <EmptyChannelState
                 channelName={channel?.name}
@@ -2799,26 +2734,17 @@ function HighlightedSearchText({ content, query }: { content: string; query: str
   )
 }
 
-function InboxEmptyState({
-  filter,
-  hasMessages,
-}: {
-  filter: BuddyInboxTaskFilter
-  hasMessages: boolean
-}) {
+function InboxEmptyState() {
   const { t } = useTranslation()
-  const isFilteredEmpty = hasMessages && filter !== 'all'
 
   return (
     <div className="flex h-full flex-col items-center justify-center px-4 text-center text-text-muted">
       <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/25 bg-primary/10 text-primary">
         <Inbox size={24} strokeWidth={2.4} />
       </div>
-      <p className="mb-2 text-lg font-black text-text-primary">
-        {isFilteredEmpty ? t('inbox.empty.filterTitle') : t('inbox.empty.allTitle')}
-      </p>
+      <p className="mb-2 text-lg font-black text-text-primary">{t('inbox.empty.allTitle')}</p>
       <p className="max-w-md text-sm font-semibold leading-6 text-text-muted">
-        {isFilteredEmpty ? t('inbox.empty.filterHint') : t('inbox.empty.allHint')}
+        {t('inbox.empty.allHint')}
       </p>
     </div>
   )

--- a/apps/web/src/components/chat/chat-area.tsx
+++ b/apps/web/src/components/chat/chat-area.tsx
@@ -87,6 +87,7 @@ import {
   fetchChatMessagesPage,
   getChatMessagesNextPageParam,
 } from './chat-messages-query'
+import { shouldAdvanceReadBoundaryForTimelineAppend } from './chat-read-boundary'
 import { buildChatTimeline, type ChatTimelineItem } from './chat-timeline'
 import {
   CHAT_SCROLLING_RESET_DELAY,
@@ -152,6 +153,29 @@ interface SearchMessageResult {
 type MessagesPage = ChatMessagesPage<Message>
 
 export type ChatInitialMessagesPage = MessagesPage
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function taskCardThreadId(message: Message) {
+  const cards = Array.isArray(message.metadata?.cards) ? message.metadata.cards : []
+  for (const card of cards) {
+    const record = recordValue(card)
+    if (record?.kind !== 'task') continue
+    const data = recordValue(record.data)
+    const task = recordValue(data?.task)
+    const threadId = stringValue(task?.threadId)
+    if (threadId) return threadId
+  }
+  return null
+}
 
 function flattenMessagePages(data: InfiniteData<MessagesPage, string | null> | undefined) {
   return data?.pages.flatMap((page) => page.messages) ?? []
@@ -763,7 +787,7 @@ export function ChatArea({
   const { data: threads = [] } = useQuery({
     queryKey: ['threads', activeChannelId],
     queryFn: () => fetchApi<Thread[]>(`/api/channels/${activeChannelId}/threads`),
-    enabled: Boolean(activeChannelId && loadThreadMetadata),
+    enabled: Boolean(activeChannelId && (loadThreadMetadata || usesInboxTaskView)),
     staleTime: 30_000,
   })
 
@@ -863,6 +887,24 @@ export function ChatArea({
     }
     return map
   }, [threads])
+
+  const threadsById = useMemo(() => {
+    const map = new Map<string, Thread>()
+    for (const thread of threads) {
+      map.set(thread.id, thread)
+    }
+    return map
+  }, [threads])
+
+  const threadForMessage = useCallback(
+    (message: Message) => {
+      const parentThread = threadsByParentId.get(message.id)
+      if (parentThread) return parentThread
+      const taskThreadId = taskCardThreadId(message)
+      return taskThreadId ? (threadsById.get(taskThreadId) ?? null) : null
+    },
+    [threadsById, threadsByParentId],
+  )
 
   const buildThreadName = useCallback(
     (message: Message) => {
@@ -1028,14 +1070,14 @@ export function ChatArea({
     (messageId: string) => {
       const message = messageMap.get(messageId)
       if (!message || message.threadId) return
-      const existing = threadsByParentId.get(messageId)
+      const existing = threadForMessage(message)
       if (existing) {
         openThreadPanel(existing, message)
         return
       }
       createThreadMutation.mutate({ message })
     },
-    [createThreadMutation, messageMap, openThreadPanel, threadsByParentId],
+    [createThreadMutation, messageMap, openThreadPanel, threadForMessage],
   )
 
   useEffect(() => {
@@ -1622,18 +1664,23 @@ export function ChatArea({
 
     if (currentCount > prevCount) {
       const addedCount = currentCount - prevCount
-      const scrollEl = parentRef.current
-      if (scrollEl && addedCount > 0) {
-        // Check if new messages were prepended (loading older) or appended (new messages)
-        // Heuristic: if we were loading older messages, the new items are at the beginning
-        // For new messages at the end, auto-scroll only if user was near bottom
+      if (addedCount > 0) {
+        const shouldStickToBottom = shouldStickToBottomRef.current
         if (shouldStickToBottomRef.current) {
           // User was at bottom — scroll to new bottom
           scrollToBottom('auto')
-          // Track read count
+        }
+        if (
+          shouldAdvanceReadBoundaryForTimelineAppend({
+            appendedItems: timeline.slice(prevCount, currentCount),
+            currentItemCount: currentCount,
+            currentUserId: user?.id,
+            previousItemCount: prevCount,
+            previousReadCount: lastReadCount,
+            shouldStickToBottom,
+          })
+        ) {
           setLastReadCount(currentCount)
-        } else {
-          // User was reading older messages — show indicator but don't auto-scroll
         }
       }
     } else if (currentCount < prevCount && shouldStickToBottomRef.current) {
@@ -1641,7 +1688,7 @@ export function ChatArea({
     }
 
     prevMessageCountRef.current = currentCount
-  }, [timeline.length, virtualizer, scrollToBottom])
+  }, [timeline, virtualizer, scrollToBottom, user?.id, lastReadCount])
 
   // Reset scroll state when the visible message set changes substantially.
   useEffect(() => {
@@ -1996,8 +2043,8 @@ export function ChatArea({
           onPreviewOAuthLink={openOAuthPreview}
           onSaveToWorkspace={activeServerId ? (att) => setSaveToWorkspaceFile(att) : undefined}
           highlight={highlightMsgId === item.data.id}
-          hasThread={threadsByParentId.has(item.data.id)}
-          thread={threadsByParentId.get(item.data.id) ?? null}
+          hasThread={Boolean(threadForMessage(item.data))}
+          thread={threadForMessage(item.data)}
           replyToMessage={
             item.data.replyToId ? (messageMap.get(item.data.replyToId) ?? null) : null
           }

--- a/apps/web/src/components/chat/chat-read-boundary.test.ts
+++ b/apps/web/src/components/chat/chat-read-boundary.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { shouldAdvanceReadBoundaryForTimelineAppend } from './chat-read-boundary'
+
+const messageItem = (authorId: string) => ({
+  kind: 'message' as const,
+  data: { authorId },
+})
+
+describe('shouldAdvanceReadBoundaryForTimelineAppend', () => {
+  it('advances the read boundary for the current user own appended message', () => {
+    expect(
+      shouldAdvanceReadBoundaryForTimelineAppend({
+        appendedItems: [messageItem('user-1')],
+        currentItemCount: 4,
+        currentUserId: 'user-1',
+        previousItemCount: 3,
+        previousReadCount: 3,
+        shouldStickToBottom: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('does not advance the read boundary for another user message while reading above bottom', () => {
+    expect(
+      shouldAdvanceReadBoundaryForTimelineAppend({
+        appendedItems: [messageItem('user-2')],
+        currentItemCount: 4,
+        currentUserId: 'user-1',
+        previousItemCount: 3,
+        previousReadCount: 3,
+        shouldStickToBottom: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not clear an existing unread boundary when the current user sends later', () => {
+    expect(
+      shouldAdvanceReadBoundaryForTimelineAppend({
+        appendedItems: [messageItem('user-1')],
+        currentItemCount: 5,
+        currentUserId: 'user-1',
+        previousItemCount: 4,
+        previousReadCount: 3,
+        shouldStickToBottom: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/web/src/components/chat/chat-read-boundary.ts
+++ b/apps/web/src/components/chat/chat-read-boundary.ts
@@ -1,0 +1,34 @@
+export interface ReadBoundaryMessage {
+  authorId: string
+}
+
+export type ReadBoundaryTimelineItem<TMessage extends ReadBoundaryMessage> =
+  | { kind: 'message'; data: TMessage }
+  | { kind: 'system'; data: unknown }
+
+export function shouldAdvanceReadBoundaryForTimelineAppend<TMessage extends ReadBoundaryMessage>({
+  appendedItems,
+  currentItemCount,
+  currentUserId,
+  previousItemCount,
+  previousReadCount,
+  shouldStickToBottom,
+}: {
+  appendedItems: ReadBoundaryTimelineItem<TMessage>[]
+  currentItemCount: number
+  currentUserId?: string | null
+  previousItemCount: number
+  previousReadCount: number
+  shouldStickToBottom: boolean
+}) {
+  if (currentItemCount <= previousItemCount) return false
+  if (shouldStickToBottom) return true
+  if (!currentUserId) return false
+  if (previousReadCount < previousItemCount) return false
+
+  const appendedMessages = appendedItems.filter((item) => item.kind === 'message')
+  return (
+    appendedMessages.length > 0 &&
+    appendedMessages.every((item) => item.data.authorId === currentUserId)
+  )
+}

--- a/apps/web/src/components/chat/message-bubble/message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/message-bubble.tsx
@@ -38,7 +38,6 @@ function MessageBubbleInner({
   deleteApi,
   highlight,
   replyToMessage,
-  taskReplies,
   hasThread,
   thread,
   selectionMode,
@@ -197,7 +196,6 @@ function MessageBubbleInner({
         sendingSlashCommand={slashCommand.sendingSlashCommand}
         slashCommandActions={rendering.slashCommandActions}
         submittedInteractiveResponse={submittedInteractiveResponse}
-        taskReplies={taskReplies}
         thread={thread}
         time={time}
         walletRecharge={rendering.walletRecharge}

--- a/apps/web/src/components/chat/message-bubble/message-compare.ts
+++ b/apps/web/src/components/chat/message-bubble/message-compare.ts
@@ -28,15 +28,6 @@ export function areMessageBubblePropsEqual(prev: MessageBubbleProps, next: Messa
   if (!reactionsEqual(prev.message.reactions, next.message.reactions, true)) return false
   if (prev.replyToMessage?.id !== next.replyToMessage?.id) return false
   if (prev.replyToMessage?.content !== next.replyToMessage?.content) return false
-  if (prev.taskReplies?.length !== next.taskReplies?.length) return false
-
-  for (let index = 0; index < (prev.taskReplies?.length ?? 0); index += 1) {
-    const prevReply = prev.taskReplies?.[index]
-    const nextReply = next.taskReplies?.[index]
-    if (prevReply?.id !== nextReply?.id) return false
-    if (prevReply?.content !== nextReply?.content) return false
-    if (prevReply?.updatedAt !== nextReply?.updatedAt) return false
-  }
 
   return attachmentsEqual(prev.message.attachments, next.message.attachments)
 }

--- a/apps/web/src/components/chat/message-bubble/message-compare.ts
+++ b/apps/web/src/components/chat/message-bubble/message-compare.ts
@@ -14,6 +14,7 @@ export function areMessageBubblePropsEqual(prev: MessageBubbleProps, next: Messa
   if (prev.hasThread !== next.hasThread) return false
   if (prev.thread?.id !== next.thread?.id) return false
   if (prev.thread?.name !== next.thread?.name) return false
+  if (prev.thread?.messageCount !== next.thread?.messageCount) return false
   if (prev.isGrouped !== next.isGrouped) return false
   if (prev.selectionMode !== next.selectionMode) return false
   if (prev.isSelected !== next.isSelected) return false

--- a/apps/web/src/components/chat/message-bubble/message-content.tsx
+++ b/apps/web/src/components/chat/message-bubble/message-content.tsx
@@ -25,7 +25,7 @@ import {
 } from './pure'
 import { ServerAppCardsView } from './server-app-card'
 import { SlashCommandActions } from './slash-command-actions'
-import { TaskCardsView } from './task-card'
+import { isTaskCard, TaskCardsView } from './task-card'
 import type {
   Attachment,
   Author,
@@ -107,6 +107,7 @@ function MessageBubbleContentBase({
     filename?: string
     size?: number
   } | null>(null)
+  const hasTaskCards = (message.metadata?.cards ?? []).some((card) => isTaskCard(card))
 
   const handleImageContextMenu = useCallback((event: MouseEvent, attachment: Attachment) => {
     event.preventDefault()
@@ -182,6 +183,7 @@ function MessageBubbleContentBase({
         cards={message.metadata?.cards}
         messageId={message.id}
         onOpenThread={onOpenThread}
+        thread={thread}
       />
 
       <ServerAppCardsView cards={message.metadata?.cards} />
@@ -266,7 +268,7 @@ function MessageBubbleContentBase({
         />
       )}
 
-      {thread && !message.threadId && onOpenThread && (
+      {thread && !message.threadId && onOpenThread && !hasTaskCards && (
         <ThreadPreviewButton messageId={message.id} onOpenThread={onOpenThread} thread={thread} />
       )}
 

--- a/apps/web/src/components/chat/message-bubble/message-content.tsx
+++ b/apps/web/src/components/chat/message-bubble/message-content.tsx
@@ -61,7 +61,6 @@ interface MessageBubbleContentProps {
   sendingSlashCommand: string | null
   slashCommandActions: SlashCommandAction[]
   submittedInteractiveResponse?: InteractiveResponseMetadata | null
-  taskReplies?: Message[]
   thread?: ThreadPreview | null
   time: string
   walletRecharge: WalletRechargeMetadata | null
@@ -93,7 +92,6 @@ function MessageBubbleContentBase({
   sendingSlashCommand,
   slashCommandActions,
   submittedInteractiveResponse,
-  taskReplies,
   thread,
   time,
   walletRecharge,
@@ -183,8 +181,7 @@ function MessageBubbleContentBase({
       <TaskCardsView
         cards={message.metadata?.cards}
         messageId={message.id}
-        channelId={message.channelId}
-        replies={taskReplies}
+        onOpenThread={onOpenThread}
       />
 
       <ServerAppCardsView cards={message.metadata?.cards} />

--- a/apps/web/src/components/chat/message-bubble/task-card.test.tsx
+++ b/apps/web/src/components/chat/message-bubble/task-card.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { isTaskCard } from './task-card'
 
 describe('isTaskCard', () => {
-  it('does not treat Inbox reply notifications as actionable task cards', () => {
+  it('does not apply legacy reply notification compatibility', () => {
     const card = {
       id: 'reply-notification',
       kind: 'task',
@@ -13,7 +13,7 @@ describe('isTaskCard', () => {
       },
     } as MessageCard
 
-    expect(isTaskCard(card)).toBe(false)
+    expect(isTaskCard(card)).toBe(true)
   })
 
   it('keeps ordinary task cards actionable', () => {

--- a/apps/web/src/components/chat/message-bubble/task-card.tsx
+++ b/apps/web/src/components/chat/message-bubble/task-card.tsx
@@ -1,5 +1,5 @@
 import type { MessageCard, MessageCardStatus, TaskMessageCard } from '@shadowob/shared'
-import { Button, cn, GlassPanel } from '@shadowob/ui'
+import { cn } from '@shadowob/ui'
 import {
   AppWindow,
   ArrowRightLeft,
@@ -13,23 +13,15 @@ import {
   MessageSquare,
   Square,
   UserCheck,
-  X,
   XCircle,
 } from 'lucide-react'
-import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getApiUrl } from '../../../lib/api-url'
-import { MessageInput } from '../message-input'
 import { MessageMarkdown } from './markdown'
-import type { Message } from './types'
 
 export function isTaskCard(card: MessageCard): card is TaskMessageCard {
-  return (
-    card.kind === 'task' &&
-    typeof card.id === 'string' &&
-    typeof card.title === 'string' &&
-    asRecord(card.data)?.taskReplyNotification !== true
-  )
+  return card.kind === 'task' && typeof card.id === 'string' && typeof card.title === 'string'
 }
 
 function renderNoMentions(children: ReactNode) {
@@ -200,17 +192,6 @@ function sourceMeta(card: TaskMessageCard): {
   }
 }
 
-function compactDate(value?: string) {
-  if (!value) return null
-  try {
-    const date = new Date(value)
-    if (Number.isNaN(date.getTime())) return null
-    return `${date.getMonth() + 1}/${date.getDate()}`
-  } catch {
-    return null
-  }
-}
-
 function currentServerSegment() {
   if (typeof window === 'undefined') return null
   const match = window.location.pathname.match(/\/(?:app\/)?servers\/([^/]+)/u)
@@ -229,52 +210,6 @@ function sourceHref(card: TaskMessageCard, source: ReturnType<typeof sourceMeta>
 function taskTagLabel(tag: NonNullable<TaskMessageCard['tags']>[number]) {
   if (typeof tag === 'string') return tag.trim().replace(/^#+/u, '')
   return tag.label?.trim().replace(/^#+/u, '') ?? ''
-}
-
-function taskCardReplyCardId(message: Message) {
-  const custom = asRecord(message.metadata?.custom)
-  const reply = asRecord(custom?.taskCardReply)
-  return stringValue(reply?.cardId)
-}
-
-function taskReplyItems(card: TaskMessageCard, replies: Message[] | undefined) {
-  const byKey = new Map<
-    string,
-    {
-      key: string
-      authorLabel: string | null
-      authorAvatarUrl: string | null
-      content: string
-      createdAt: string
-    }
-  >()
-
-  for (const reply of card.replies ?? []) {
-    const key = reply.messageId ?? reply.id ?? `${reply.createdAt}:${reply.content}`
-    byKey.set(key, {
-      key,
-      authorLabel: reply.authorLabel ?? reply.source?.label ?? null,
-      authorAvatarUrl: reply.authorAvatarUrl ?? null,
-      content: reply.content,
-      createdAt: reply.createdAt,
-    })
-  }
-
-  for (const message of replies ?? []) {
-    const cardId = taskCardReplyCardId(message)
-    if (cardId && cardId !== card.id) continue
-    byKey.set(message.id, {
-      key: message.id,
-      authorLabel: message.author?.displayName ?? message.author?.username ?? null,
-      authorAvatarUrl: message.author?.avatarUrl ?? null,
-      content: message.content,
-      createdAt: message.createdAt,
-    })
-  }
-
-  return [...byKey.values()].sort(
-    (left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
-  )
 }
 
 function plainText(value: string) {
@@ -311,26 +246,18 @@ function stripTodoItems(markdown?: string) {
 export function TaskCardsView({
   cards,
   messageId,
-  channelId,
-  replies,
+  onOpenThread,
 }: {
   cards: MessageCard[] | undefined
   messageId: string
-  channelId?: string
-  replies?: Message[]
+  onOpenThread?: (messageId: string) => void
 }) {
   const taskCards = useMemo(() => cards?.filter(isTaskCard) ?? [], [cards])
   if (taskCards.length === 0) return null
   return (
     <div className="my-2 flex w-full max-w-[min(960px,100%)] flex-col gap-3">
       {taskCards.map((card) => (
-        <TaskCardView
-          key={card.id}
-          card={card}
-          messageId={messageId}
-          channelId={channelId}
-          replies={replies}
-        />
+        <TaskCardView key={card.id} card={card} messageId={messageId} onOpenThread={onOpenThread} />
       ))}
     </div>
   )
@@ -339,17 +266,14 @@ export function TaskCardsView({
 function TaskCardView({
   card,
   messageId,
-  channelId,
-  replies,
+  onOpenThread,
 }: {
   card: TaskMessageCard
   messageId: string
-  channelId?: string
-  replies?: Message[]
+  onOpenThread?: (messageId: string) => void
 }) {
   const { t } = useTranslation()
   const [detailsOpen, setDetailsOpen] = useState(false)
-  const [repliesOpen, setRepliesOpen] = useState(false)
   const statusLabel = t(`inbox.task.status.${card.status}`)
   const statusMeta = taskStatusMeta(card.status)
   const StatusIcon = statusMeta.Icon
@@ -362,8 +286,6 @@ function TaskCardView({
   const descriptionMarkdown = useMemo(() => stripTodoItems(card.body), [card.body])
   const doneTodos = todoItems.filter((item) => item.done).length
   const detailPreview = descriptionMarkdown ? plainText(descriptionMarkdown) : ''
-  const replyItems = useMemo(() => taskReplyItems(card, replies), [card, replies])
-  const replyCount = replyItems.length
   const progressLabel =
     todoItems.length > 0
       ? t('inbox.task.todoProgress', { done: doneTodos, total: todoItems.length })
@@ -590,246 +512,18 @@ function TaskCardView({
 
             <button
               type="button"
-              onClick={() => setRepliesOpen(true)}
-              className={cn(
-                'group/reply flex shrink-0 items-center gap-1.5 rounded-full border border-transparent bg-white/[0.03] px-3 py-1.5 transition-all duration-300 hover:border-[#7C4DFF]/30 hover:bg-[#7C4DFF]/20 focus:outline-none focus:ring-2 focus:ring-[#7C4DFF]/50',
-                repliesOpen && 'border-[#7C4DFF]/30 bg-[#7C4DFF]/20',
-              )}
+              onClick={() => onOpenThread?.(messageId)}
+              className="group/reply flex shrink-0 items-center gap-1.5 rounded-full border border-transparent bg-white/[0.03] px-3 py-1.5 transition-all duration-300 hover:border-[#7C4DFF]/30 hover:bg-[#7C4DFF]/20 focus:outline-none focus:ring-2 focus:ring-[#7C4DFF]/50"
               aria-label={t('inbox.task.replies')}
             >
               <MessageSquare
                 size={16}
-                className={cn(
-                  'text-white/50 transition-colors group-hover/reply:text-[#7C4DFF]',
-                  repliesOpen && 'text-[#7C4DFF]',
-                )}
+                className="text-white/50 transition-colors group-hover/reply:text-[#7C4DFF]"
               />
-              <span
-                className={cn(
-                  'pt-px text-[12px] font-bold text-white/70 transition-colors group-hover/reply:text-[#7C4DFF]',
-                  repliesOpen && 'text-[#7C4DFF]',
-                )}
-              >
-                {replyCount}
-              </span>
             </button>
           </div>
         </footer>
       </article>
-      <TaskReplyPanel
-        open={repliesOpen}
-        card={card}
-        messageId={messageId}
-        channelId={channelId}
-        source={source}
-        replyItems={replyItems}
-        replyCount={replyCount}
-        onClose={() => setRepliesOpen(false)}
-      />
-    </>
-  )
-}
-
-function TaskReplyPanel({
-  open,
-  card,
-  messageId,
-  channelId,
-  source,
-  replyItems,
-  replyCount,
-  onClose,
-}: {
-  open: boolean
-  card: TaskMessageCard
-  messageId: string
-  channelId?: string
-  source: ReturnType<typeof sourceMeta>
-  replyItems: ReturnType<typeof taskReplyItems>
-  replyCount: number
-  onClose: () => void
-}) {
-  const { t } = useTranslation()
-  const panelRef = useRef<HTMLElement>(null)
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const descriptionMarkdown = useMemo(() => stripTodoItems(card.body), [card.body])
-  const messageMetadata = useMemo(
-    () => ({
-      custom: {
-        taskCardReply: {
-          kind: 'task_card_reply',
-          messageId,
-          cardId: card.id,
-        },
-      },
-    }),
-    [card.id, messageId],
-  )
-
-  useEffect(() => {
-    if (!open || typeof window === 'undefined') return
-    const focusComposer = () => {
-      const textarea = panelRef.current?.querySelector('textarea')
-      if (!textarea || textarea.disabled) return
-      textarea.focus({ preventScroll: true })
-      const cursor = textarea.value.length
-      textarea.setSelectionRange(cursor, cursor)
-    }
-    const animationFrame = window.requestAnimationFrame(focusComposer)
-    const timers = [80, 220, 520].map((delay) => window.setTimeout(focusComposer, delay))
-    return () => {
-      window.cancelAnimationFrame(animationFrame)
-      for (const timer of timers) window.clearTimeout(timer)
-    }
-  }, [open])
-
-  useEffect(() => {
-    if (!open) return
-    const element = scrollRef.current
-    if (!element) return
-    element.scrollTo({ top: element.scrollHeight, behavior: 'smooth' })
-  }, [open, replyItems.length])
-
-  if (!open) return null
-
-  const panelStyle = {
-    background: 'var(--color-bg-primary)',
-    backdropFilter: 'none',
-    WebkitBackdropFilter: 'none',
-  }
-
-  return (
-    <>
-      <div className="fixed inset-0 z-30 bg-bg-deep/35 backdrop-blur-[2px]" onClick={onClose} />
-      <GlassPanel
-        ref={panelRef}
-        className="fixed inset-2 z-40 flex min-w-0 shrink-0 flex-col overflow-hidden rounded-3xl border border-border-subtle shadow-[0_24px_80px_rgba(0,0,0,0.38)] animate-slide-in-right sm:inset-y-3 sm:left-auto sm:right-3 sm:w-[min(92vw,420px)]"
-        style={panelStyle}
-      >
-        <div className="flex h-14 shrink-0 items-center gap-3 border-b border-border-subtle px-4">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/12 text-primary">
-            <MessageSquare size={17} strokeWidth={2.5} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-black text-text-primary">{card.title}</div>
-            <div className="flex min-w-0 items-center gap-1.5 text-xs font-semibold text-text-muted">
-              {source.label ? (
-                <>
-                  <TaskAppIcon iconUrl={source.iconUrl} />
-                  <span className="truncate">{source.label}</span>
-                </>
-              ) : (
-                <span>{t('inbox.task.replies')}</span>
-              )}
-            </div>
-          </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 rounded-full"
-            onClick={onClose}
-            title={t('common.close')}
-          >
-            <X size={18} />
-          </Button>
-        </div>
-
-        <div ref={scrollRef} className="flex-1 overflow-y-auto overflow-x-hidden py-2">
-          <div className="px-4 pb-3 pt-2">
-            <div className="mb-2 flex items-center gap-2 text-xs font-black text-text-muted">
-              <span className="h-px flex-1 bg-border-subtle" />
-              <span>{t('inbox.task.details')}</span>
-              <span className="h-px flex-1 bg-border-subtle" />
-            </div>
-            <div className="rounded-2xl border border-border-subtle bg-bg-secondary/35 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-              <div className="break-words text-[15px] font-black leading-[1.5] text-text-primary">
-                {card.title}
-              </div>
-              {descriptionMarkdown ? (
-                <div className="mt-2 [&_.msg-markdown]:pt-0 [&_.msg-markdown]:text-sm [&_.msg-markdown]:leading-6 [&_.msg-markdown]:text-text-secondary [&_.msg-markdown_p]:my-1">
-                  <MessageMarkdown
-                    content={descriptionMarkdown}
-                    renderMentions={renderNoMentions}
-                  />
-                </div>
-              ) : (
-                <p className="mt-2 text-sm leading-6 text-text-muted">
-                  {t('inbox.task.noDetails')}
-                </p>
-              )}
-            </div>
-          </div>
-
-          <div className="mx-4 mb-2 flex items-center gap-2 text-xs font-black text-text-muted">
-            <span className="h-px flex-1 bg-border-subtle" />
-            <span>
-              {t('inbox.task.replies')} {replyCount > 0 ? replyCount : ''}
-            </span>
-            <span className="h-px flex-1 bg-border-subtle" />
-          </div>
-
-          {replyItems.length === 0 ? (
-            <div className="flex h-32 flex-col items-center justify-center gap-2 px-6 text-center text-sm text-text-muted">
-              <MessageSquare size={22} className="text-primary/80" />
-              <span>{t('inbox.task.noReplies')}</span>
-            </div>
-          ) : (
-            <div className="space-y-3 px-4 pb-4">
-              {replyItems.map((reply) => {
-                const avatarUrl = resolveImageUrl(reply.authorAvatarUrl)
-                return (
-                  <div
-                    key={reply.key}
-                    className="rounded-2xl border border-border-subtle bg-bg-secondary/35 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
-                  >
-                    <div className="mb-2 flex min-w-0 items-center gap-2">
-                      {avatarUrl ? (
-                        <img
-                          src={avatarUrl}
-                          alt=""
-                          className="h-7 w-7 shrink-0 rounded-full object-cover"
-                        />
-                      ) : (
-                        <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-primary/10 text-xs font-black text-primary">
-                          {(reply.authorLabel ?? '?').slice(0, 1)}
-                        </span>
-                      )}
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-sm font-black text-text-primary">
-                          {reply.authorLabel ?? t('common.unknownUser')}
-                        </div>
-                        <div className="text-xs font-semibold text-text-muted">
-                          {compactDate(reply.createdAt) ?? ''}
-                        </div>
-                      </div>
-                    </div>
-                    <div className="[&_.msg-markdown]:pt-0 [&_.msg-markdown]:text-sm [&_.msg-markdown]:leading-6 [&_.msg-markdown]:text-text-secondary [&_.msg-markdown_p]:my-1">
-                      <MessageMarkdown content={reply.content} renderMentions={renderNoMentions} />
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </div>
-
-        {channelId ? (
-          <MessageInput
-            channelId={channelId}
-            channelName={source.label ?? t('inbox.task.replies')}
-            replyToId={messageId}
-            placeholder={t('inbox.task.replyPlaceholder')}
-            hideReplyIndicator
-            messageMetadata={messageMetadata}
-            onMessageSent={() => {
-              requestAnimationFrame(() => {
-                const element = scrollRef.current
-                element?.scrollTo({ top: element.scrollHeight, behavior: 'smooth' })
-              })
-            }}
-          />
-        ) : null}
-      </GlassPanel>
     </>
   )
 }

--- a/apps/web/src/components/chat/message-bubble/task-card.tsx
+++ b/apps/web/src/components/chat/message-bubble/task-card.tsx
@@ -17,8 +17,10 @@ import {
 } from 'lucide-react'
 import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { fetchApi } from '../../../lib/api'
 import { getApiUrl } from '../../../lib/api-url'
 import { MessageMarkdown } from './markdown'
+import type { ThreadPreview } from './types'
 
 export function isTaskCard(card: MessageCard): card is TaskMessageCard {
   return card.kind === 'task' && typeof card.id === 'string' && typeof card.title === 'string'
@@ -247,33 +249,72 @@ export function TaskCardsView({
   cards,
   messageId,
   onOpenThread,
+  thread,
 }: {
   cards: MessageCard[] | undefined
   messageId: string
   onOpenThread?: (messageId: string) => void
+  thread?: ThreadPreview | null
 }) {
   const taskCards = useMemo(() => cards?.filter(isTaskCard) ?? [], [cards])
   if (taskCards.length === 0) return null
   return (
     <div className="my-2 flex w-full max-w-[min(960px,100%)] flex-col gap-3">
       {taskCards.map((card) => (
-        <TaskCardView key={card.id} card={card} messageId={messageId} onOpenThread={onOpenThread} />
+        <TaskCardView
+          key={card.id}
+          card={card}
+          messageId={messageId}
+          onOpenThread={onOpenThread}
+          thread={thread}
+        />
       ))}
     </div>
   )
+}
+
+function taskCardHasActivity(card: TaskMessageCard) {
+  const progress = Array.isArray(card.progress) ? card.progress : []
+  return card.status !== 'queued' || progress.length > 1
+}
+
+function timeFromValue(value: string | null | undefined) {
+  if (!value) return 0
+  const time = new Date(value).getTime()
+  return Number.isFinite(time) ? time : 0
+}
+
+function latestTaskActivityTime(card: TaskMessageCard, thread?: ThreadPreview | null) {
+  const progress = Array.isArray(card.progress) ? card.progress : []
+  return Math.max(
+    timeFromValue(card.updatedAt),
+    timeFromValue(card.createdAt),
+    timeFromValue(thread?.updatedAt),
+    timeFromValue(thread?.createdAt),
+    ...progress.map((entry) => timeFromValue(entry.at)),
+  )
+}
+
+function taskViewerReadAt(card: TaskMessageCard) {
+  const task = asRecord(card.data?.task)
+  return timeFromValue(stringValue(task?.viewerReadAt))
 }
 
 function TaskCardView({
   card,
   messageId,
   onOpenThread,
+  thread,
 }: {
   card: TaskMessageCard
   messageId: string
   onOpenThread?: (messageId: string) => void
+  thread?: ThreadPreview | null
 }) {
   const { t } = useTranslation()
   const [detailsOpen, setDetailsOpen] = useState(false)
+  const persistedReadAt = taskViewerReadAt(card)
+  const [readActivityAt, setReadActivityAt] = useState(persistedReadAt)
   const statusLabel = t(`inbox.task.status.${card.status}`)
   const statusMeta = taskStatusMeta(card.status)
   const StatusIcon = statusMeta.Icon
@@ -286,11 +327,32 @@ function TaskCardView({
   const descriptionMarkdown = useMemo(() => stripTodoItems(card.body), [card.body])
   const doneTodos = todoItems.filter((item) => item.done).length
   const detailPreview = descriptionMarkdown ? plainText(descriptionMarkdown) : ''
+  const progressEntries = Array.isArray(card.progress) ? card.progress : []
+  const latestProgress =
+    [...progressEntries].reverse().find((entry) => entry.status !== 'queued' || entry.note) ??
+    progressEntries.at(-1)
+  const latestProgressNote = latestProgress?.note ? plainText(latestProgress.note) : ''
+  const latestProgressMeta = latestProgress ? taskStatusMeta(latestProgress.status) : statusMeta
   const progressLabel =
     todoItems.length > 0
       ? t('inbox.task.todoProgress', { done: doneTodos, total: todoItems.length })
-      : t('inbox.task.noProgress')
-  const progressTone = todoItems.length > 0 ? statusMeta.className : 'text-white/45'
+      : latestProgressNote
+        ? latestProgressNote
+        : progressEntries.length > 1 && latestProgress
+          ? t(`inbox.task.status.${latestProgress.status}`)
+          : card.status !== 'queued'
+            ? statusLabel
+            : t('inbox.task.noProgress')
+  const progressTone =
+    todoItems.length > 0 || progressEntries.length > 1 || card.status !== 'queued'
+      ? latestProgressMeta.className
+      : 'text-white/45'
+  const threadMessageCount =
+    typeof thread?.messageCount === 'number' && Number.isFinite(thread.messageCount)
+      ? Math.max(0, thread.messageCount)
+      : null
+  const latestActivityAt = latestTaskActivityTime(card, thread)
+  const hasActivity = taskCardHasActivity(card) && latestActivityAt > readActivityAt
   const priorityDot =
     priority === 'high'
       ? 'bg-[#FF2A55] shadow-[0_0_6px_rgba(255,42,85,0.8)]'
@@ -308,6 +370,10 @@ function TaskCardView({
           ? 'text-[#00F3FF]/90 hover:text-[#00F3FF] hover:drop-shadow-[0_0_8px_rgba(0,243,255,0.35)]'
           : 'text-white/50 hover:text-white/70'
   const expanded = detailsOpen
+
+  useEffect(() => {
+    setReadActivityAt((current) => Math.max(current, persistedReadAt))
+  }, [persistedReadAt])
 
   return (
     <>
@@ -512,14 +578,31 @@ function TaskCardView({
 
             <button
               type="button"
-              onClick={() => onOpenThread?.(messageId)}
-              className="group/reply flex shrink-0 items-center gap-1.5 rounded-full border border-transparent bg-white/[0.03] px-3 py-1.5 transition-all duration-300 hover:border-[#7C4DFF]/30 hover:bg-[#7C4DFF]/20 focus:outline-none focus:ring-2 focus:ring-[#7C4DFF]/50"
+              onClick={() => {
+                setReadActivityAt(Math.max(Date.now(), latestActivityAt))
+                void fetchApi(`/api/messages/${messageId}/cards/${card.id}/read`, {
+                  method: 'POST',
+                }).catch(() => undefined)
+                onOpenThread?.(messageId)
+              }}
+              className="group/reply relative flex shrink-0 items-center gap-1.5 rounded-full border border-transparent bg-white/[0.03] px-3 py-1.5 transition-all duration-300 hover:border-[#7C4DFF]/30 hover:bg-[#7C4DFF]/20 focus:outline-none focus:ring-2 focus:ring-[#7C4DFF]/50"
               aria-label={t('inbox.task.replies')}
             >
               <MessageSquare
                 size={16}
                 className="text-white/50 transition-colors group-hover/reply:text-[#7C4DFF]"
               />
+              {threadMessageCount !== null ? (
+                <span className="min-w-[1ch] pt-px font-mono text-[11px] font-black leading-none text-white/55 transition-colors group-hover/reply:text-[#7C4DFF]">
+                  {threadMessageCount > 99 ? '99+' : threadMessageCount}
+                </span>
+              ) : null}
+              {hasActivity ? (
+                <span
+                  aria-hidden="true"
+                  className="absolute right-2 top-1.5 h-2 w-2 rounded-full bg-[#FF2A55] shadow-[0_0_8px_rgba(255,42,85,0.75)]"
+                />
+              ) : null}
             </button>
           </div>
         </footer>

--- a/apps/web/src/components/chat/message-bubble/types.ts
+++ b/apps/web/src/components/chat/message-bubble/types.ts
@@ -183,7 +183,6 @@ export interface MessageBubbleProps {
   deleteApi?: (messageId: string) => Promise<void>
   highlight?: boolean
   replyToMessage?: Message | null
-  taskReplies?: Message[]
   hasThread?: boolean
   thread?: ThreadPreview | null
   /** Multi-select mode */

--- a/apps/web/src/components/chat/message-bubble/types.ts
+++ b/apps/web/src/components/chat/message-bubble/types.ts
@@ -104,7 +104,9 @@ export interface ThreadPreview {
   id: string
   name: string
   parentMessageId: string
+  messageCount?: number
   createdAt?: string
+  updatedAt?: string
 }
 
 /** Phase 2 interactive block shape — mirrors server schema. */

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -22,6 +22,7 @@ export interface Thread {
   parentMessageId: string
   creatorId: string
   isArchived: boolean
+  messageCount?: number
   createdAt: string
   updatedAt: string
 }
@@ -145,6 +146,8 @@ export function ThreadPanel({
   })
 
   const messages = useMemo(() => sortByCreatedAt(rawMessages), [rawMessages])
+  const visibleMessageCount = messages.length + (parentMessage ? 1 : 0)
+  const messageCount = Math.max(thread.messageCount ?? 0, visibleMessageCount)
   const messageMap = useMemo(() => {
     const map = new Map<string, Message>()
     if (parentMessage) map.set(parentMessage.id, parentMessage)
@@ -169,6 +172,15 @@ export function ThreadPanel({
     if (!el) return
     el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
   }, [messages.length])
+
+  useEffect(() => {
+    if (visibleMessageCount <= (thread.messageCount ?? 0)) return
+    queryClient.setQueryData<Thread[]>(['threads', thread.channelId], (old) =>
+      (old ?? []).map((item) =>
+        item.id === thread.id ? { ...item, messageCount: visibleMessageCount } : item,
+      ),
+    )
+  }, [queryClient, thread.channelId, thread.id, thread.messageCount, visibleMessageCount])
 
   useSocketEvent<Message>(
     'message:new',
@@ -287,6 +299,8 @@ export function ThreadPanel({
             <div className="flex min-w-0 items-center gap-1 text-xs font-semibold text-text-muted">
               <Hash size={12} />
               <span className="truncate">{channelName ?? t('chat.channelFallback')}</span>
+              <span className="shrink-0 text-text-muted/70">·</span>
+              <span className="shrink-0 font-black text-text-secondary">{messageCount}</span>
             </div>
           </div>
           <Button

--- a/apps/web/src/pages/discover.tsx
+++ b/apps/web/src/pages/discover.tsx
@@ -1973,12 +1973,16 @@ function TimelineActionButton({
   label,
   count,
   icon: Icon,
+  showCount = true,
+  showDot = false,
   onClick,
 }: {
   active?: boolean
   label: string
   count?: number
   icon: LucideIcon
+  showCount?: boolean
+  showDot?: boolean
   onClick: () => void
 }) {
   return (
@@ -1991,14 +1995,24 @@ function TimelineActionButton({
         onClick()
       }}
       className={cn(
-        'inline-flex min-w-0 items-center gap-1.5 rounded-full px-2 py-1 text-xs font-bold transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45',
+        'relative inline-flex min-w-0 items-center gap-1.5 rounded-full px-2 py-1 text-xs font-bold transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45',
         active ? 'text-primary' : 'text-text-muted hover:text-text-primary',
       )}
     >
       <Icon size={17} fill={active ? 'currentColor' : 'none'} />
-      {typeof count === 'number' && count > 0 ? <span>{count}</span> : null}
+      {showDot ? (
+        <span
+          aria-hidden="true"
+          className="absolute right-1 top-1 h-2 w-2 rounded-full bg-danger shadow-[0_0_8px_rgba(255,42,85,0.7)]"
+        />
+      ) : null}
+      {showCount && typeof count === 'number' && count > 0 ? <span>{count}</span> : null}
     </button>
   )
+}
+
+function isTaskLikeFeedItem(item: ContentFeedItem) {
+  return item.contentKinds.includes('card') && !firstServerAppCard(item)
 }
 
 function useContentFeedInteractions(item: ContentFeedItem, t: TFunction) {
@@ -2080,6 +2094,7 @@ function FeedInteractionSection({
 }) {
   const { handleShare, interactions, likeMutation, openAuthor, saveMutation } =
     useContentFeedInteractions(item, t)
+  const taskLike = isTaskLikeFeedItem(item)
 
   return (
     <div className={className}>
@@ -2096,6 +2111,8 @@ function FeedInteractionSection({
             label={t('discover.timeline.comment')}
             count={interactions.commentCount}
             icon={MessageCircle}
+            showCount={!taskLike}
+            showDot={taskLike && interactions.commentCount > 0}
             onClick={onOpenThread}
           />
           <TimelineActionButton

--- a/docs/development/buddy-inbox-task-mode-mechanism.zh-CN.md
+++ b/docs/development/buddy-inbox-task-mode-mechanism.zh-CN.md
@@ -775,23 +775,41 @@ sequenceDiagram
 
 ## 实现拆分
 
+### 当前代码状态（2026-06-11）
+
+已落地：
+
+- Web / Mobile 的 Inbox Task mode 不再改变消息列表过滤；Chat / Task 切换只改变输入语义。
+- Task Card 的回复入口已改为打开标准 Thread，不再维护独立 task reply renderer。
+- 普通 Buddy reply / Thread comment 不再自动 complete Task，也不再生成 `taskReplyNotification` 新消息。
+- Task 创建时会生成 `TaskContextPack`，默认包含创建点之前最近 20 条可读顶层消息；如果任务来自已授权 source channel / promoted message，会从 source channel 取上下文。
+- Task 创建后会立即 `ensureThreadForMessage`，并把 `threadId`、`revision=1`、`contextPack` 写入 `card.data.task`。
+- 手动创建 Thread 的 server 方法已改为 parent message 幂等：已有 Thread 时复用，避免客户端漏收 `thread:created` 后重复创建。
+
+仍未落地：
+
+- Runtime Binding 存储、event / ack / heartbeat / terminal update API。
+- TaskRevision / edit history / activity read state。
+- Task comment / requirement update 到 OpenClaw、Hermes、cc-connect 同一个 runtime session 的触达。
+- OpenClaw / Hermes / cc-connect 的完整 live smoke 和跨 runtime 并发 smoke。
+
 ### Phase 1: 协议与旧路径删除
 
 - 保留“一条 Message 一个 Task Card”的创建形态。
-- 明确 Task input 必须生成 `TaskContextPack`，Agent 不能空上下文接收中途创建的任务。
-- 默认注入固定数量最近消息，更多历史由 runtime 通过 `shadowob` CLI / API 主动读取。
-- 删除 Task mode 改变列表过滤的产品假设。
-- 删除 `taskReplyNotification` 作为新机制的一部分。
-- 删除或禁用 `reply_terminal` 自动完成路径。
-- 明确普通聊天永远不直接改任务状态；状态只能由显式 UI、授权 API 或 runtime control-plane 修改。
+- 已落地：Task input 生成 `TaskContextPack`，Agent 不能空上下文接收中途创建的任务。
+- 已落地：默认注入固定数量最近消息，更多历史由 runtime 通过 `shadowob` CLI / API 主动读取。
+- 已落地：删除 Task mode 改变列表过滤的产品假设。
+- 已落地：删除 `taskReplyNotification` 作为新机制的一部分。
+- 已落地：删除或禁用 `reply_terminal` 自动完成路径。
+- 已落地：明确普通聊天永远不直接改任务状态；状态只能由显式 UI、授权 API 或 runtime control-plane 修改。
 
 ### Phase 2: Server Runtime Control Plane
 
 - 新增 Runtime Binding 存储或等价结构。
 - 新增 event / ack / heartbeat / terminal update API。
 - 新增 `revision`、`attempt`、`lastAckRevision` 校验。
-- 新增 Task Thread 创建规则：创建 Task Card 时即创建或确保 Thread。
-- 新增 TaskContextPack 生成、权限过滤、摘要和 token budget 策略。
+- 已落地：新增 Task Thread 创建规则：创建 Task Card 时即创建或确保 Thread。
+- 部分落地：新增 TaskContextPack 生成、权限过滤和 token budget 策略；摘要策略仍待接入。
 - 新增 TaskRevision / edit history，支撑任务日志查阅。
 - 新增 task activity 统一事件模型。
 
@@ -931,12 +949,12 @@ POST /bridge/sessions/fork: API/unit tests pass; child session keeps parent ids 
 13. cc-connect native `shadowob:task` 已可通过源码补丁支持；Bridge adapter 自有 key 仍是生产首选，因为它让 Shadow Task adapter 拥有完整投递语义。
 14. 不修改、不注入 Codex CLI provider；Codex agent 只能使用用户已有 provider 配置，无法满足时直接跳过 Codex runtime smoke。
 15. cc-connect true fork 走 Bridge `POST /bridge/sessions/fork`，不复用 fresh create 语义；reopen 可以按 runtime 能力选择 resume 或 fork。
+16. Hermes / OpenClaw live smoke 可以使用 `.env` 里的非 Codex provider key；Codex provider 不由本方案改写。
 
 ## 需要确认的逻辑
 
 1. Hermes 主接入协议：建议以 TUI Gateway JSON-RPC 为 primary，ACP 为 fallback，API server 只作为 stateless 备选。
 2. cc-connect production key 是否统一使用 `shadow-task:<workspaceId>:<messageId>:<cardId>`，native `shadowob:task` 仅作为 proactive / legacy 回投兼容能力。
-3. Hermes / OpenClaw live smoke 是否允许使用 `.env` 里的非 Codex provider key 启动真实 model session；Codex provider 不由本方案改写。
 
 ## 仍待调研和验证
 

--- a/packages/connector/hermes-shadowob-plugin/adapter.py
+++ b/packages/connector/hermes-shadowob-plugin/adapter.py
@@ -718,6 +718,45 @@ def _message_task_card_for_self(
     return None
 
 
+def _task_card_task_data(card: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(card, dict):
+        return {}
+    data = card.get("data")
+    if not isinstance(data, dict):
+        return {}
+    task = data.get("task")
+    return task if isinstance(task, dict) else {}
+
+
+def _task_card_thread_id(card: dict[str, Any] | None) -> str | None:
+    task = _task_card_task_data(card)
+    value = task.get("threadId") or task.get("thread_id")
+    return str(value).strip() if value else None
+
+
+def _format_task_thread_prompt(text: str, binding: dict[str, Any]) -> str:
+    title = str(binding.get("title") or "Inbox task").strip()
+    task_message_id = str(binding.get("message_id") or "").strip()
+    card_id = str(binding.get("card_id") or "").strip()
+    lines = [
+        "[Shadow Inbox task thread comment]",
+        f"Task title: {title}",
+    ]
+    if task_message_id:
+        lines.append(f"Task message id: {task_message_id}")
+    if card_id:
+        lines.append(f"Task card id: {card_id}")
+    lines.extend(
+        [
+            "Reply as an ordinary discussion message in this same task thread.",
+            "Do not change the task status unless the human explicitly asks you to update it.",
+        ]
+    )
+    if text.strip():
+        lines.extend(["", text.strip()])
+    return "\n".join(lines)
+
+
 def _format_task_card_prompt(
     text: str,
     card: dict[str, Any],
@@ -1148,6 +1187,7 @@ class ShadowOBAdapter(BasePlatformAdapter):
         self._remote_config: dict[str, Any] | None = None
         self._channel_cache: dict[str, dict[str, Any]] = {}
         self._channel_context_cache: dict[str, tuple[datetime, dict[str, Any]]] = {}
+        self._task_thread_bindings: dict[str, dict[str, Any]] = {}
         self._activity_clear_tasks: dict[str, asyncio.Task] = {}
         self._processed_ids: deque[str] = deque(maxlen=2000)
         self._processed_set: set[str] = set()
@@ -2399,6 +2439,30 @@ class ShadowOBAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[Shadow] Failed to update Inbox task card %s/%s completion: %s", message_id, card_id, exc)
 
+    def _remember_task_thread_binding(
+        self,
+        *,
+        channel_id: str,
+        message_id: str | None,
+        card: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        thread_id = _task_card_thread_id(card)
+        card_id = _card_id(card) if card else None
+        if not thread_id or not message_id or not card_id:
+            return None
+        if not isinstance(getattr(self, "_task_thread_bindings", None), dict):
+            self._task_thread_bindings = {}
+        binding = {
+            "channel_id": channel_id,
+            "thread_id": thread_id,
+            "message_id": message_id,
+            "card_id": card_id,
+            "title": str(card.get("title") or "Inbox task").strip() if isinstance(card, dict) else "",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._task_thread_bindings[thread_id] = binding
+        return binding
+
     async def _handle_shadow_message(self, message: dict[str, Any], *, source: str) -> None:
         message_id = _message_id(message)
         if not message_id:
@@ -2431,6 +2495,9 @@ class ShadowOBAdapter(BasePlatformAdapter):
             buddy_user_id=self._buddy_user_id,
             agent_id=self._agent_id,
         )
+        task_thread_binding = (
+            getattr(self, "_task_thread_bindings", {}).get(thread_id) if thread_id and not task_card else None
+        )
         is_author_buddy = bool(author.get("isBot"))
         mentions_self = self._message_mentions_self(message)
         human_mention_override = mentions_self and not is_author_buddy
@@ -2440,6 +2507,7 @@ class ShadowOBAdapter(BasePlatformAdapter):
             and _message_mentions_any_buddy(message)
             and not mentions_self
             and not task_card
+            and not task_thread_binding
         ):
             logger.debug("[Shadow] explicit Buddy mention skipped non-target message %s", message_id)
             return
@@ -2464,7 +2532,12 @@ class ShadowOBAdapter(BasePlatformAdapter):
         if policy and not _policy_bool(policy, "listen", True):
             logger.debug("[Shadow] policy listen=false skipped message %s", message_id)
             return
-        if policy and not _policy_bool(policy, "reply", True) and not human_mention_override:
+        if (
+            policy
+            and not _policy_bool(policy, "reply", True)
+            and not human_mention_override
+            and not task_thread_binding
+        ):
             logger.debug("[Shadow] policy reply=false skipped message %s", message_id)
             return
         trigger_user_ids = policy_config.get("allowedTriggerUserIds") or policy_config.get("triggerUserIds")
@@ -2473,6 +2546,7 @@ class ShadowOBAdapter(BasePlatformAdapter):
             if (
                 allowed
                 and not task_card
+                and not task_thread_binding
                 and not human_mention_override
                 and not is_processing_buddy_message
                 and (not author_id or author_id not in allowed)
@@ -2493,7 +2567,13 @@ class ShadowOBAdapter(BasePlatformAdapter):
             logger.debug("[Shadow] runtime status notice skipped message %s", message_id)
             return
         mention_only = self._mention_only or _policy_bool(policy, "mentionOnly", False)
-        if mention_only and not mentions_self and not task_card and not is_processing_buddy_message:
+        if (
+            mention_only
+            and not mentions_self
+            and not task_card
+            and not task_thread_binding
+            and not is_processing_buddy_message
+        ):
             # DMs are allowed even in mention-only mode.
             channel = self._channel_cache.get(channel_id, {})
             kind = str(channel.get("kind") or channel.get("type") or "").lower()
@@ -2510,7 +2590,7 @@ class ShadowOBAdapter(BasePlatformAdapter):
                 agent_id=self._agent_id,
                 max_turns=_policy_int(policy_config, "maxBuddyTurns", 4),
                 is_processing_buddy_message=is_processing_buddy_message,
-                has_task_card=bool(task_card),
+                has_task_card=bool(task_card or task_thread_binding),
             )
             if not collaboration_claim.get("ok"):
                 mode = str(collaboration_claim.get("mode") or "")
@@ -2584,7 +2664,14 @@ class ShadowOBAdapter(BasePlatformAdapter):
             task_card = await self._activate_task_card(message, task_card)
             if not task_card:
                 return
+            self._remember_task_thread_binding(
+                channel_id=channel_id,
+                message_id=message_id,
+                card=task_card,
+            )
             text = _format_task_card_prompt(text, task_card, message_id=message_id)
+        elif task_thread_binding:
+            text = _format_task_thread_prompt(text, task_thread_binding)
 
         media_paths, media_types, message_type, media_metadata = await self._resolve_inbound_media(message)
         voice_metadata = media_metadata.get("voice") if isinstance(media_metadata, dict) else None

--- a/packages/connector/hermes-shadowob-plugin/tests/test_adapter_env.py
+++ b/packages/connector/hermes-shadowob-plugin/tests/test_adapter_env.py
@@ -3,6 +3,7 @@ import sys
 import asyncio
 import os
 import json
+from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -713,6 +714,84 @@ def test_task_card_failure_is_terminal():
             'note': 'boom',
         }
     ]
+
+
+def test_hermes_task_thread_comment_dispatches_from_binding(monkeypatch):
+    claim_calls = []
+    completed = []
+    events = []
+
+    async def fake_claim(**kwargs):
+        claim_calls.append(kwargs)
+        return {'ok': True, 'claimed': False}
+
+    monkeypatch.setattr(adapter, 'claim_buddy_collaboration_for_runtime', fake_claim)
+    monkeypatch.setattr(adapter, 'MessageEvent', lambda **kwargs: SimpleNamespace(**kwargs))
+
+    instance = adapter.ShadowOBAdapter.__new__(adapter.ShadowOBAdapter)
+    instance.client = object()
+    instance.config = SimpleNamespace(extra={})
+    instance._processed_set = set()
+    instance._remember_processed = lambda message_id: None
+    instance._channel_ids = []
+    instance._channel_cache = {'channel-1': {'id': 'channel-1', 'kind': 'channel', 'name': 'Inbox'}}
+    instance._channel_policies = {
+        'channel-1': {'listen': True, 'reply': False, 'config': {}, 'mentionOnly': True}
+    }
+    instance._buddy_user_id = 'bot-1'
+    instance._buddy_username = 'buddy'
+    instance._agent_id = 'agent-1'
+    instance._mention_only = True
+    instance._slash_commands = []
+    instance._task_thread_bindings = {
+        'thread-1': {
+            'channel_id': 'channel-1',
+            'thread_id': 'thread-1',
+            'message_id': 'root-1',
+            'card_id': 'card-1',
+            'title': 'Bound task',
+        }
+    }
+    instance._message_mentions_self = lambda message: False
+    instance._set_runtime_current_channel = lambda *args, **kwargs: None
+    instance._set_runtime_home_channel = lambda *args, **kwargs: None
+    instance._resolve_inbound_media = lambda message: asyncio.sleep(
+        0, result=([], [], 'text', {})
+    )
+    instance._shadow_channel_context = lambda channel_id, thread_id: asyncio.sleep(0, result={})
+    instance._handle_shadow_control_command = lambda *args, **kwargs: asyncio.sleep(0, result=False)
+    instance.build_source = lambda **kwargs: kwargs
+
+    async def fake_complete(*args, **kwargs):
+        completed.append((args, kwargs))
+
+    async def fake_handle(event):
+        events.append(event)
+
+    instance._complete_task_card = fake_complete
+    instance.handle_message = fake_handle
+
+    asyncio.run(
+        instance._handle_shadow_message(
+            {
+                'id': 'comment-1',
+                'channelId': 'channel-1',
+                'threadId': 'thread-1',
+                'authorId': 'user-1',
+                'content': 'Please answer the follow-up.',
+                'author': {'id': 'user-1', 'username': 'admin', 'isBot': False},
+            },
+            source='test',
+        )
+    )
+
+    assert len(claim_calls) == 1
+    assert claim_calls[0]['has_task_card'] is True
+    assert events
+    assert '[Shadow Inbox task thread comment]' in events[0].text
+    assert 'Please answer the follow-up.' in events[0].text
+    assert events[0].source['thread_id'] == 'thread-1'
+    assert completed == []
 
 
 def test_hermes_buddy_message_defaults_to_collaboration_claim(monkeypatch):

--- a/packages/openclaw-shadowob/__tests__/plugin.test.ts
+++ b/packages/openclaw-shadowob/__tests__/plugin.test.ts
@@ -494,6 +494,384 @@ describe('Slash Commands', () => {
     })
   })
 
+  it('should bind runtime task cards to their task thread id', async () => {
+    const { mkdtemp, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const { ShadowClient } = await import('@shadowob/sdk')
+    const { processShadowMessage } = await import('../src/monitor/channel-message.js')
+    const { loadShadowThreadBindings } = await import('../src/monitor/thread-bindings.js')
+    const dataDir = await mkdtemp(join(tmpdir(), 'shadow-openclaw-task-binding-'))
+    const updateTaskCard = vi
+      .spyOn(ShadowClient.prototype, 'updateTaskCard')
+      .mockResolvedValue({ metadata: { cards: [] } } as never)
+    const dispatch = vi.fn(async () => undefined)
+    const runtime = { log: vi.fn(), error: vi.fn() }
+    const core = {
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn(() => ({
+            agentId: 'agent-1',
+            sessionKey: 'shadowob:channel:ch-1',
+            accountId: 'default',
+          })),
+        },
+        reply: {
+          formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+          resolveEnvelopeFormatOptions: vi.fn(() => ({})),
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        },
+        session: {
+          resolveStorePath: vi.fn(() => '/tmp/openclaw-shadowob-test-store'),
+          recordInboundSession: vi.fn(async () => undefined),
+        },
+      },
+    } as never
+
+    try {
+      vi.stubEnv('OPENCLAW_DATA_DIR', dataDir)
+      await processShadowMessage({
+        message: {
+          id: 'task-msg-1',
+          content: 'Render this task',
+          channelId: 'ch-1',
+          authorId: 'user-1',
+          threadId: null,
+          createdAt: '2026-05-08T09:07:40.000Z',
+          updatedAt: '2026-05-08T09:07:40.000Z',
+          author: {
+            id: 'user-1',
+            username: 'admin',
+            displayName: 'Admin',
+            isBot: false,
+          },
+          metadata: {
+            cards: [
+              {
+                id: 'card-1',
+                kind: 'task',
+                title: 'Render task',
+                status: 'running',
+                assignee: { userId: 'bot-1' },
+                claim: { expiresAt: '2099-01-01T00:00:00.000Z' },
+                data: { task: { threadId: 'thread-1' } },
+              },
+            ],
+          },
+        } as never,
+        account: { token: 'tok', serverUrl: 'http://localhost:3002' },
+        accountId: 'default',
+        config: {},
+        runtime,
+        core,
+        buddyUserId: 'bot-1',
+        buddyUsername: 'task-bot',
+        agentId: null,
+        channelPolicies: new Map(),
+        channelServerMap: new Map(),
+        slashCommands: [],
+        socket: {
+          sendTyping: vi.fn(),
+          updateActivity: vi.fn(),
+        } as never,
+      })
+
+      expect(dispatch).toHaveBeenCalled()
+      expect(updateTaskCard).toHaveBeenCalled()
+      const bindings = await loadShadowThreadBindings('default')
+      expect(bindings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            agentId: 'agent-1',
+            sessionKey: 'shadowob:channel:ch-1:task:card-1',
+            channelId: 'ch-1',
+            threadId: 'thread-1',
+            messageId: 'task-msg-1',
+          }),
+        ]),
+      )
+    } finally {
+      updateTaskCard.mockRestore()
+      vi.unstubAllEnvs()
+      await rm(dataDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should route bound task thread follow-ups through the existing task session', async () => {
+    const { mkdtemp, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const { ShadowClient } = await import('@shadowob/sdk')
+    const { processShadowMessage } = await import('../src/monitor/channel-message.js')
+    const { upsertShadowThreadBinding } = await import('../src/monitor/thread-bindings.js')
+    const dataDir = await mkdtemp(join(tmpdir(), 'shadow-openclaw-task-followup-'))
+    const sendMessage = vi.spyOn(ShadowClient.prototype, 'sendMessage').mockResolvedValue({
+      id: 'wrong-target',
+    } as never)
+    const sendToThread = vi.spyOn(ShadowClient.prototype, 'sendToThread').mockResolvedValue({
+      id: 'thread-reply-1',
+      content: 'Bound thread reply',
+      channelId: 'ch-1',
+      threadId: 'thread-1',
+      authorId: 'bot-1',
+      createdAt: '2026-05-08T09:08:40.000Z',
+      updatedAt: '2026-05-08T09:08:40.000Z',
+    } as never)
+    const dispatch = vi.fn(
+      async (input: {
+        ctx: Record<string, unknown>
+        dispatcherOptions: { deliver: (payload: { text: string }) => Promise<void> }
+      }) => {
+        await input.dispatcherOptions.deliver({ text: 'Bound thread reply' })
+      },
+    )
+    const core = {
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn(() => ({
+            agentId: 'agent-1',
+            sessionKey: 'shadowob:channel:ch-1',
+            accountId: 'default',
+          })),
+        },
+        reply: {
+          formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+          resolveEnvelopeFormatOptions: vi.fn(() => ({})),
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        },
+        session: {
+          resolveStorePath: vi.fn(() => '/tmp/openclaw-shadowob-test-store'),
+          recordInboundSession: vi.fn(async () => undefined),
+        },
+      },
+    } as never
+
+    try {
+      vi.stubEnv('OPENCLAW_DATA_DIR', dataDir)
+      await upsertShadowThreadBinding({
+        accountId: 'default',
+        agentId: 'agent-1',
+        sessionKey: 'shadowob:channel:ch-1:task:card-1',
+        channelId: 'ch-1',
+        threadId: 'thread-1',
+        messageId: 'task-msg-1',
+      })
+
+      await processShadowMessage({
+        message: {
+          id: 'followup-msg-1',
+          content: '你的设定是什么？',
+          channelId: 'ch-1',
+          authorId: 'user-1',
+          threadId: 'thread-1',
+          replyToId: 'task-msg-1',
+          createdAt: '2026-05-08T09:08:40.000Z',
+          updatedAt: '2026-05-08T09:08:40.000Z',
+          author: {
+            id: 'user-1',
+            username: 'admin',
+            displayName: 'Admin',
+            isBot: false,
+          },
+        } as never,
+        account: { token: 'tok', serverUrl: 'http://localhost:3002' },
+        accountId: 'default',
+        config: {},
+        runtime: {},
+        core,
+        buddyUserId: 'bot-1',
+        buddyUsername: 'task-bot',
+        agentId: null,
+        channelPolicies: new Map([
+          ['ch-1', { listen: true, reply: true, mentionOnly: true }],
+        ]) as never,
+        channelServerMap: new Map(),
+        slashCommands: [],
+        socket: {
+          sendTyping: vi.fn(),
+          updateActivity: vi.fn(),
+        } as never,
+      })
+
+      expect(claimBuddyReply).not.toHaveBeenCalled()
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({
+            ChatType: 'thread',
+            SessionKey: 'shadowob:channel:ch-1:task:card-1',
+            ThreadId: 'thread-1',
+            WasMentioned: true,
+          }),
+        }),
+      )
+      expect(sendMessage).not.toHaveBeenCalled()
+      expect(sendToThread).toHaveBeenCalledWith(
+        'thread-1',
+        'Bound thread reply',
+        expect.objectContaining({
+          replyToId: 'followup-msg-1',
+        }),
+      )
+    } finally {
+      sendMessage.mockRestore()
+      sendToThread.mockRestore()
+      vi.unstubAllEnvs()
+      await rm(dataDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should recover unbound task thread follow-ups from the parent task card', async () => {
+    const { mkdtemp, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const { ShadowClient } = await import('@shadowob/sdk')
+    const { processShadowMessage } = await import('../src/monitor/channel-message.js')
+    const { loadShadowThreadBindings } = await import('../src/monitor/thread-bindings.js')
+    const dataDir = await mkdtemp(join(tmpdir(), 'shadow-openclaw-task-recover-'))
+    const getThread = vi.spyOn(ShadowClient.prototype, 'getThread').mockResolvedValue({
+      id: 'thread-1',
+      name: 'Recovered task thread',
+      channelId: 'ch-1',
+      parentMessageId: 'task-msg-1',
+      createdAt: '2026-05-08T09:07:40.000Z',
+    } as never)
+    const getMessage = vi.spyOn(ShadowClient.prototype, 'getMessage').mockResolvedValue({
+      id: 'task-msg-1',
+      content: 'Original task',
+      channelId: 'ch-1',
+      authorId: 'user-1',
+      threadId: null,
+      createdAt: '2026-05-08T09:07:40.000Z',
+      updatedAt: '2026-05-08T09:07:40.000Z',
+      metadata: {
+        cards: [
+          {
+            id: 'card-1',
+            kind: 'task',
+            title: 'Recovered task',
+            status: 'running',
+            assignee: { userId: 'bot-1' },
+            claim: { expiresAt: '2099-01-01T00:00:00.000Z' },
+            data: { task: { threadId: 'thread-1' } },
+          },
+        ],
+      },
+    } as never)
+    const sendToThread = vi.spyOn(ShadowClient.prototype, 'sendToThread').mockResolvedValue({
+      id: 'thread-reply-1',
+      content: 'Recovered thread reply',
+      channelId: 'ch-1',
+      threadId: 'thread-1',
+      authorId: 'bot-1',
+      createdAt: '2026-05-08T09:08:40.000Z',
+      updatedAt: '2026-05-08T09:08:40.000Z',
+    } as never)
+    const dispatch = vi.fn(
+      async (input: {
+        ctx: Record<string, unknown>
+        dispatcherOptions: { deliver: (payload: { text: string }) => Promise<void> }
+      }) => {
+        await input.dispatcherOptions.deliver({ text: 'Recovered thread reply' })
+      },
+    )
+    const core = {
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn(() => ({
+            agentId: 'agent-1',
+            sessionKey: 'shadowob:channel:ch-1',
+            accountId: 'default',
+          })),
+        },
+        reply: {
+          formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+          resolveEnvelopeFormatOptions: vi.fn(() => ({})),
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        },
+        session: {
+          resolveStorePath: vi.fn(() => '/tmp/openclaw-shadowob-test-store'),
+          recordInboundSession: vi.fn(async () => undefined),
+        },
+      },
+    } as never
+
+    try {
+      vi.stubEnv('OPENCLAW_DATA_DIR', dataDir)
+      await processShadowMessage({
+        message: {
+          id: 'followup-msg-2',
+          content: '继续解释一下',
+          channelId: 'ch-1',
+          authorId: 'user-1',
+          threadId: 'thread-1',
+          replyToId: 'task-msg-1',
+          createdAt: '2026-05-08T09:08:40.000Z',
+          updatedAt: '2026-05-08T09:08:40.000Z',
+          author: {
+            id: 'user-1',
+            username: 'admin',
+            displayName: 'Admin',
+            isBot: false,
+          },
+        } as never,
+        account: { token: 'tok', serverUrl: 'http://localhost:3002' },
+        accountId: 'default',
+        config: {},
+        runtime: {},
+        core,
+        buddyUserId: 'bot-1',
+        buddyUsername: 'task-bot',
+        agentId: null,
+        channelPolicies: new Map([
+          ['ch-1', { listen: true, reply: true, mentionOnly: true }],
+        ]) as never,
+        channelServerMap: new Map(),
+        slashCommands: [],
+        socket: {
+          sendTyping: vi.fn(),
+          updateActivity: vi.fn(),
+        } as never,
+      })
+
+      expect(getThread).toHaveBeenCalledWith('thread-1')
+      expect(getMessage).toHaveBeenCalledWith('task-msg-1')
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({
+            SessionKey: 'shadowob:channel:ch-1:task:card-1',
+            ThreadId: 'thread-1',
+            WasMentioned: true,
+          }),
+        }),
+      )
+      expect(sendToThread).toHaveBeenCalledWith(
+        'thread-1',
+        'Recovered thread reply',
+        expect.objectContaining({
+          replyToId: 'followup-msg-2',
+        }),
+      )
+      expect(await loadShadowThreadBindings('default')).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sessionKey: 'shadowob:channel:ch-1:task:card-1',
+            threadId: 'thread-1',
+            messageId: 'followup-msg-2',
+          }),
+        ]),
+      )
+    } finally {
+      getThread.mockRestore()
+      getMessage.mockRestore()
+      sendToThread.mockRestore()
+      vi.unstubAllEnvs()
+      await rm(dataDir, { recursive: true, force: true })
+    }
+  })
+
   it('should inject installed server app context for natural-language channel tasks', async () => {
     vi.useFakeTimers()
     const fetchMock = vi.fn(async (url: string | URL | Request) => {

--- a/packages/openclaw-shadowob/src/monitor/channel-message.ts
+++ b/packages/openclaw-shadowob/src/monitor/channel-message.ts
@@ -45,7 +45,11 @@ import {
   sendSlashCommandInteractivePrompt,
 } from './slash-commands.js'
 import { taskCardTargetsBuddy } from './task-card-routing.js'
-import { upsertShadowThreadBinding } from './thread-bindings.js'
+import {
+  loadShadowThreadBindings,
+  resolveShadowThreadBinding,
+  upsertShadowThreadBinding,
+} from './thread-bindings.js'
 import { createTypingCallbacks } from './typing.js'
 import { reportShadowUsageSnapshot } from './usage-reporting.js'
 
@@ -70,7 +74,7 @@ type RuntimeTaskCard = ShadowMessageCard & {
   }
   source?: Record<string, unknown>
   data?: Record<string, unknown> & {
-    task?: {
+    task?: Record<string, unknown> & {
       workspaceId?: string
     }
   }
@@ -108,6 +112,14 @@ function buildChannelContextForAgent(info: ChannelServerInfo | undefined, channe
 function normalizeStringList(value: unknown): string[] {
   if (!Array.isArray(value)) return []
   return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
 }
 
 function isRuntimeTaskCard(card: ShadowMessageCard): card is RuntimeTaskCard {
@@ -158,11 +170,110 @@ function findTaskCardById(message: ShadowMessage | null, cardId: string) {
   )
 }
 
+function taskData(card: RuntimeTaskCard) {
+  return isRecord(card.data?.task) ? card.data.task : null
+}
+
+function taskReplyThreadId(card: RuntimeTaskCard) {
+  return stringValue(taskData(card)?.threadId)
+}
+
+async function recoverRuntimeTaskCardForThread(params: {
+  client: ShadowClient
+  message: ShadowMessage
+  buddyUserId: string
+  buddyId?: string | null
+  runtime: ShadowRuntimeLogger
+}) {
+  const { client, message, buddyUserId, buddyId, runtime } = params
+  if (!message.threadId) return null
+
+  try {
+    const thread = await client.getThread(message.threadId)
+    if (thread.channelId !== message.channelId) return null
+    const parentMessage = await client.getMessage(thread.parentMessageId)
+    const card = findRuntimeTaskCard(parentMessage, { buddyUserId, buddyId })
+    if (!card || taskReplyThreadId(card) !== message.threadId) return null
+    return { message: parentMessage, card }
+  } catch (err) {
+    runtime.log?.(
+      `[task] Could not recover task context for thread ${message.threadId}: ${String(err)}`,
+    )
+    return null
+  }
+}
+
+function formatTaskContextPack(task: Record<string, unknown> | null) {
+  const contextPack = isRecord(task?.contextPack) ? task.contextPack : null
+  const items = Array.isArray(contextPack?.items) ? contextPack.items : []
+  const lines = items
+    .slice(-12)
+    .map((item, index) => {
+      if (!isRecord(item)) return null
+      const text = stringValue(item.text) ?? stringValue(item.summary)
+      if (!text) return null
+      const fields = [
+        `${index + 1}. ${stringValue(item.kind) ?? 'context'}`,
+        stringValue(item.messageId) ? `message=${stringValue(item.messageId)}` : '',
+        stringValue(item.authorId) ? `author=${stringValue(item.authorId)}` : '',
+        stringValue(item.createdAt) ? `at=${stringValue(item.createdAt)}` : '',
+      ].filter(Boolean)
+      return `${fields.join(' ')}\n${text}`
+    })
+    .filter((line): line is string => Boolean(line))
+  if (lines.length === 0) return ''
+
+  const omitted = Array.isArray(contextPack?.omitted)
+    ? contextPack.omitted
+        .map((item) => (isRecord(item) ? stringValue(item.reason) : undefined))
+        .filter((reason): reason is string => Boolean(reason))
+    : []
+
+  return [
+    'Task context pack (recent conversation before task creation):',
+    ...lines,
+    omitted.length > 0 ? `Omitted context: ${omitted.join('; ')}` : '',
+    'Use the context pack when answering the task. Do not claim the task has no prior context unless the context pack is empty.',
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function formatTaskStatusControl(message: ShadowMessage, card: RuntimeTaskCard) {
+  const task = taskData(card)
+  const binding = isRecord(task?.runtimeBinding) ? task.runtimeBinding : null
+  const runningCommand =
+    stringValue(binding?.runningCommand) ??
+    `shadowob inbox update ${message.id} ${card.id} --status running --note "Started" --json`
+  const completedCommand =
+    stringValue(binding?.completedCommand) ??
+    `shadowob inbox update ${message.id} ${card.id} --status completed --note "<short result>" --json`
+  const failedCommand =
+    stringValue(binding?.failedCommand) ??
+    `shadowob inbox update ${message.id} ${card.id} --status failed --note "<reason>" --json`
+  const threadId = stringValue(task?.threadId) ?? stringValue(binding?.threadId)
+
+  return [
+    'Shadow Task status control:',
+    stringValue(binding?.instruction) ??
+      'Update Shadow task status with shadowob inbox update. Send ordinary discussion to the task thread.',
+    'The Shadow Task Card status is controlled only by Shadow Inbox task APIs/CLI/UI.',
+    'Do not use Kanban or any other Server App command to mark this Shadow Task Card running, completed, failed, canceled, or transferred.',
+    'Server Apps may be used only for the domain work requested by the task body, not for Shadow Task Card status.',
+    'Task replies and comments alone do not complete or reopen the task card.',
+    threadId ? `Send ordinary task discussion replies to Shadow thread id: ${threadId}.` : '',
+    `When starting work, update the task card: ${runningCommand}`,
+    `When the work is complete, update the task card: ${completedCommand}`,
+    `If the work cannot be completed, update the task card: ${failedCommand}`,
+    'After updating status, reply with the concrete result and any next action.',
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
 function taskCardPrompt(message: ShadowMessage, card: RuntimeTaskCard) {
-  const workspaceId =
-    card.data?.task && typeof card.data.task.workspaceId === 'string'
-      ? card.data.task.workspaceId
-      : undefined
+  const task = taskData(card)
+  const workspaceId = stringValue(task?.workspaceId)
   const claimId = typeof card.claim?.id === 'string' ? card.claim.id : undefined
   return [
     'Shadow Inbox task:',
@@ -181,10 +292,8 @@ function taskCardPrompt(message: ShadowMessage, card: RuntimeTaskCard) {
           `--task-message-id ${message.id} --task-card-id ${card.id} --task-claim-id ${claimId}`,
         ].join('\n')
       : '',
-    'Task replies alone do not complete the task card.',
-    `When the work is complete, update the task card: shadowob inbox update ${message.id} ${card.id} --status completed --note "<short result>" --json`,
-    `If the work cannot be completed, update the task card: shadowob inbox update ${message.id} ${card.id} --status failed --note "<reason>" --json`,
-    'Then reply with the concrete result and any next action.',
+    formatTaskContextPack(task),
+    formatTaskStatusControl(message, card),
   ]
     .filter(Boolean)
     .join('\n')
@@ -581,6 +690,28 @@ export async function processShadowMessage(params: {
     socket,
   } = params
   const cfg = config as OpenClawConfig
+  const channelId = message.channelId
+  const mediaClient = new ShadowClient(account.serverUrl, account.token)
+  const boundThreadBinding = message.threadId
+    ? resolveShadowThreadBinding(await loadShadowThreadBindings(accountId), {
+        agentId,
+        threadId: message.threadId,
+      })
+    : null
+  const boundTaskSessionKey =
+    boundThreadBinding?.sessionKey.includes(':task:') === true
+      ? boundThreadBinding.sessionKey
+      : undefined
+  const recoveredTaskContext =
+    message.threadId && !boundTaskSessionKey && message.authorId !== buddyUserId
+      ? await recoverRuntimeTaskCardForThread({
+          client: mediaClient,
+          message,
+          buddyUserId,
+          buddyId: agentId,
+          runtime,
+        })
+      : null
 
   const preflight = evaluateShadowMessagePreflight({
     message,
@@ -589,6 +720,7 @@ export async function processShadowMessage(params: {
     buddyUsername,
     channelPolicies,
     runtime,
+    isRuntimeTaskThread: Boolean(boundTaskSessionKey || recoveredTaskContext),
   })
   if (!preflight.ok) {
     runtime.log?.(preflight.reason)
@@ -596,7 +728,6 @@ export async function processShadowMessage(params: {
   }
 
   const { senderLabel } = preflight
-  const channelId = message.channelId
 
   runtime.log?.(
     `[msg] Processing message from ${senderLabel}: "${message.content.slice(0, 80)}" (${message.id})`,
@@ -618,7 +749,6 @@ export async function processShadowMessage(params: {
 
   runtime.log?.(`[routing] Resolved agent: ${route.agentId} (account ${accountId})`)
 
-  const mediaClient = new ShadowClient(account.serverUrl, account.token)
   let runtimeTaskCard = findRuntimeTaskCard(message, { buddyUserId, buddyId: agentId })
   if (
     runtimeTaskCard &&
@@ -689,7 +819,8 @@ export async function processShadowMessage(params: {
     agentId,
     maxTurns: preflight.policyConfig?.maxBuddyTurns,
     isProcessingBuddyMessage: preflight.isProcessingBuddyMessage,
-    hasRuntimeTaskCard: Boolean(runtimeTaskCard),
+    hasRuntimeTaskCard:
+      Boolean(runtimeTaskCard) || Boolean(boundTaskSessionKey || recoveredTaskContext),
   })
   if (!collaborationClaim.ok) {
     if (collaborationClaim.error) {
@@ -787,6 +918,13 @@ export async function processShadowMessage(params: {
     '- Do not recap or summarize the exchange unless the user explicitly asks for a recap.',
     '- Use tools only when the user asks for work that truly requires a tool, server app, file, code, or external operation.',
   ].join('\n')
+  const boundTaskThreadPrompt = boundTaskSessionKey
+    ? [
+        'Shadow Inbox task follow-up:',
+        `Task thread id: ${message.threadId}`,
+        'Continue the existing task session for this thread. Ordinary replies should stay in this task thread.',
+      ].join('\n')
+    : ''
   const bodyForAgent = [
     buildChannelContextForAgent(serverInfo, channelId),
     channelConversationGuard,
@@ -798,6 +936,10 @@ export async function processShadowMessage(params: {
     buddyInboxContext.prompt,
     serverAppContext.prompt,
     runtimeTaskCard ? taskCardPrompt(message, runtimeTaskCard) : '',
+    recoveredTaskContext
+      ? taskCardPrompt(recoveredTaskContext.message, recoveredTaskContext.card)
+      : '',
+    boundTaskThreadPrompt,
     messageBodyForAgent,
   ]
     .filter(Boolean)
@@ -813,14 +955,25 @@ export async function processShadowMessage(params: {
   const escapedBuddyUsername = buddyUsername.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   const mentionRegex = new RegExp(`@${escapedBuddyUsername}(?:\\s|$)`, 'i')
   const wasMentioned =
+    Boolean(runtimeTaskCard) ||
+    Boolean(boundTaskSessionKey) ||
+    Boolean(recoveredTaskContext) ||
     mentionTargetsBuddy({ mentions: structuredMentions, buddyUserId, buddyUsername }) ||
     mentionsTargetServerApp(structuredMentions) ||
     Boolean(slashCommandMatch) ||
     mentionRegex.test(message.content)
 
+  const runtimeTaskThreadId = runtimeTaskCard
+    ? taskReplyThreadId(runtimeTaskCard)
+    : boundTaskSessionKey || recoveredTaskContext
+      ? (message.threadId ?? undefined)
+      : undefined
   const taskSessionKey = runtimeTaskCard
     ? `${route.sessionKey}:task:${runtimeTaskCard.id}`
-    : route.sessionKey
+    : (boundTaskSessionKey ??
+      (recoveredTaskContext
+        ? `${route.sessionKey}:task:${recoveredTaskContext.card.id}`
+        : route.sessionKey))
   const ctxPayload = core.channel.reply.finalizeInboundContext({
     Body: body,
     BodyForAgent: bodyForAgent,
@@ -916,13 +1069,14 @@ export async function processShadowMessage(params: {
 
   const bindingSessionKey =
     typeof ctxPayload.SessionKey === 'string' ? ctxPayload.SessionKey : route.sessionKey
+  const bindingThreadId = message.threadId ?? runtimeTaskThreadId
   if (route.agentId && bindingSessionKey) {
     await upsertShadowThreadBinding({
       accountId,
       agentId: route.agentId,
       sessionKey: bindingSessionKey,
       channelId,
-      ...(message.threadId ? { threadId: message.threadId } : {}),
+      ...(bindingThreadId ? { threadId: bindingThreadId } : {}),
       messageId: message.id,
     }).catch((err) => {
       runtime.error?.(`[session] Failed updating thread binding: ${String(err)}`)
@@ -981,9 +1135,9 @@ export async function processShadowMessage(params: {
           await deliverShadowReply({
             payload,
             channelId,
-            threadId: collaborationThreadId ?? message.threadId ?? undefined,
+            threadId: collaborationThreadId ?? runtimeTaskThreadId ?? message.threadId ?? undefined,
             replyToId: collaborationReplyToId ?? message.id,
-            target: collaboration ? collaborationTarget : 'main',
+            target: collaboration ? collaborationTarget : runtimeTaskThreadId ? 'thread' : 'main',
             client,
             runtime,
             collaboration,

--- a/packages/openclaw-shadowob/src/monitor/preflight.ts
+++ b/packages/openclaw-shadowob/src/monitor/preflight.ts
@@ -42,8 +42,17 @@ export function evaluateShadowMessagePreflight(params: {
   buddyUsername: string
   channelPolicies: Map<string, ShadowChannelPolicy>
   runtime: ShadowRuntimeLogger
+  isRuntimeTaskThread?: boolean
 }): ShadowMessagePreflightResult {
-  const { message, buddyUserId, buddyId, buddyUsername, channelPolicies, runtime } = params
+  const {
+    message,
+    buddyUserId,
+    buddyId,
+    buddyUsername,
+    channelPolicies,
+    runtime,
+    isRuntimeTaskThread = false,
+  } = params
   const senderLabel = message.author?.username ?? message.authorId
 
   if (message.authorId === buddyUserId) {
@@ -53,13 +62,14 @@ export function evaluateShadowMessagePreflight(params: {
   const policy = channelPolicies.get(message.channelId)
   const policyConfig = policy?.config as ShadowPolicyConfig | undefined
   const hasActiveTaskForBuddy = messageHasActiveTaskForBuddy(message, { buddyUserId, buddyId })
+  const hasRuntimeTaskContext = hasActiveTaskForBuddy || isRuntimeTaskThread
   const structuredMentions = getShadowMessageMentions(message)
   const hasExplicitBuddyMention = mentionedBuddyIds(structuredMentions).length > 0
   const escapedBuddyUsername = buddyUsername.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   const mentionRegex = new RegExp(`@${escapedBuddyUsername}(?:\\s|$)`, 'i')
   const wasBuddyMentionedExplicitly =
     mentionTargetsBuddy({ mentions: structuredMentions, buddyUserId, buddyUsername }) ||
-    hasActiveTaskForBuddy ||
+    hasRuntimeTaskContext ||
     mentionRegex.test(message.content)
   const wasMentionedExplicitly =
     wasBuddyMentionedExplicitly || mentionsTargetServerApp(structuredMentions)
@@ -74,7 +84,7 @@ export function evaluateShadowMessagePreflight(params: {
   }
 
   if (message.author?.isBot) {
-    if (policyConfig?.replyToBuddy === false && !hasActiveTaskForBuddy) {
+    if (policyConfig?.replyToBuddy === false && !hasRuntimeTaskContext) {
       return {
         ok: false,
         reason: `[msg] Skipping Buddy message from ${senderLabel} (replyToBuddy=false) (${message.id})`,
@@ -103,7 +113,7 @@ export function evaluateShadowMessagePreflight(params: {
     }
 
     isProcessingBuddyMessage = true
-    const triggerReason = hasActiveTaskForBuddy ? 'active task-card' : 'replyToBuddy=true'
+    const triggerReason = hasRuntimeTaskContext ? 'active task-card' : 'replyToBuddy=true'
     runtime.log?.(
       `[msg] Processing Buddy message from ${senderLabel} (${triggerReason}) (${message.id})`,
     )
@@ -127,7 +137,7 @@ export function evaluateShadowMessagePreflight(params: {
   if (
     triggerUserIds &&
     !triggerUserIds.includes(message.authorId) &&
-    !hasActiveTaskForBuddy &&
+    !hasRuntimeTaskContext &&
     !isHumanMentionOverride &&
     !isProcessingBuddyMessage
   ) {

--- a/packages/openclaw-shadowob/src/monitor/thread-bindings.ts
+++ b/packages/openclaw-shadowob/src/monitor/thread-bindings.ts
@@ -79,10 +79,15 @@ export function resolveShadowThreadBinding(
   bindings: ShadowThreadBinding[],
   params: { agentId?: string | null; sessionKey?: string | null; threadId?: string | null },
 ): ShadowThreadBinding | null {
-  if (params.threadId) {
-    return bindings.find((binding) => binding.threadId === params.threadId) ?? null
-  }
   const agentId = params.agentId?.trim()
+  if (params.threadId) {
+    return (
+      bindings.find(
+        (binding) =>
+          binding.threadId === params.threadId && (!agentId || binding.agentId === agentId),
+      ) ?? null
+    )
+  }
   const sessionKey = params.sessionKey?.trim()
   if (!agentId || !sessionKey) return null
   return (

--- a/packages/shared/__tests__/inbox.test.ts
+++ b/packages/shared/__tests__/inbox.test.ts
@@ -2,15 +2,12 @@ import { describe, expect, it } from 'vitest'
 import {
   BUDDY_INBOX_DELIVERY_PERMISSION,
   type BuddyInboxViewMessage,
-  buddyInboxMessageMatchesTaskFilter,
   buildBuddyInboxViewMessages,
   buildMessageAgentChainMetadata,
   buildMessageCopilotContextMetadata,
   getBuddyInboxTaskCards,
-  getBuddyInboxTaskMessageIds,
   hasBuddyInboxTaskCard,
   isBuddyInboxPlatformPermission,
-  isBuddyInboxTaskReply,
   isMessageAgentChainMetadata,
   isMessageCopilotContext,
   isMessageReferenceCard,
@@ -82,20 +79,15 @@ describe('Buddy Inbox view helpers', () => {
     expect(isBuddyInboxPlatformPermission('demo.tickets:write')).toBe(false)
   })
 
-  it('identifies task card messages and their replies', () => {
+  it('identifies task card messages', () => {
     const task = taskMessage('task-1', 'running')
-    const reply = { id: 'reply-1', replyToId: 'task-1' } satisfies BuddyInboxViewMessage
     const chat = { id: 'chat-1', metadata: { cards: [{ kind: 'note', id: 'n-1' }] } }
-
-    const taskIds = getBuddyInboxTaskMessageIds([task, reply, chat])
 
     expect(hasBuddyInboxTaskCard(task)).toBe(true)
     expect(hasBuddyInboxTaskCard(chat)).toBe(false)
-    expect(taskIds).toEqual(new Set(['task-1']))
-    expect(isBuddyInboxTaskReply(reply, taskIds)).toBe(true)
   })
 
-  it('does not treat legacy reply notification task cards as Inbox tasks', () => {
+  it('does not apply legacy reply notification compatibility', () => {
     const notification = {
       id: 'notification-1',
       metadata: {
@@ -113,14 +105,14 @@ describe('Buddy Inbox view helpers', () => {
       },
     } satisfies BuddyInboxViewMessage
 
-    expect(getBuddyInboxTaskCards(notification)).toEqual([])
-    expect(hasBuddyInboxTaskCard(notification)).toBe(false)
+    expect(getBuddyInboxTaskCards(notification)).toHaveLength(1)
+    expect(hasBuddyInboxTaskCard(notification)).toBe(true)
     expect(
       buildBuddyInboxViewMessages([notification], {
         isInboxChannel: true,
         mode: 'tasks',
       }),
-    ).toEqual([])
+    ).toEqual([notification])
   })
 
   it('identifies message reference cards for cross-Inbox reply notifications', () => {
@@ -171,7 +163,7 @@ describe('Buddy Inbox view helpers', () => {
     expect(card?.privacy?.dataClass).toBe('server-private')
   })
 
-  it('keeps Inbox display independent of composer mode and folds task replies', () => {
+  it('keeps Inbox display independent of composer mode without folding task replies', () => {
     const messages = [
       taskMessage('task-1', 'running'),
       { id: 'reply-1', replyToId: 'task-1' },
@@ -183,16 +175,16 @@ describe('Buddy Inbox view helpers', () => {
         isInboxChannel: true,
         mode: 'chat',
       }).map((message) => message.id),
-    ).toEqual(['task-1', 'chat-1'])
+    ).toEqual(['task-1', 'reply-1', 'chat-1'])
     expect(
       buildBuddyInboxViewMessages(messages, {
         isInboxChannel: true,
         mode: 'tasks',
       }).map((message) => message.id),
-    ).toEqual(['task-1', 'chat-1'])
+    ).toEqual(['task-1', 'reply-1', 'chat-1'])
   })
 
-  it('filters task cards while preserving ordinary chat messages in the all filter', () => {
+  it('does not filter task cards by task state', () => {
     const messages = [
       taskMessage('task-1', 'running'),
       { id: 'reply-1', replyToId: 'task-1' },
@@ -205,62 +197,12 @@ describe('Buddy Inbox view helpers', () => {
         isInboxChannel: true,
         mode: 'tasks',
       }).map((message) => message.id),
-    ).toEqual(['task-1', 'chat-1', 'task-2'])
+    ).toEqual(['task-1', 'reply-1', 'chat-1', 'task-2'])
     expect(
       buildBuddyInboxViewMessages(messages, {
         isInboxChannel: true,
         mode: 'chat',
-        taskFilter: 'open',
       }).map((message) => message.id),
-    ).toEqual(['task-1'])
-    expect(
-      buildBuddyInboxViewMessages(messages, {
-        isInboxChannel: true,
-        mode: 'tasks',
-        taskFilter: 'open',
-      }).map((message) => message.id),
-    ).toEqual(['task-1'])
-    expect(
-      buildBuddyInboxViewMessages(messages, {
-        isInboxChannel: true,
-        mode: 'tasks',
-        taskFilter: 'done',
-      }).map((message) => message.id),
-    ).toEqual(['task-2'])
-  })
-
-  it('filters open and terminal task cards', () => {
-    const running = taskMessage('task-running', 'running')
-    const completed = taskMessage('task-completed', 'completed')
-    const mixed = {
-      id: 'task-mixed',
-      metadata: {
-        cards: [
-          {
-            id: 'card-running',
-            kind: 'task',
-            version: 1,
-            title: 'Running',
-            status: 'running',
-            createdAt: '2026-01-01T00:00:00.000Z',
-          },
-          {
-            id: 'card-failed',
-            kind: 'task',
-            version: 1,
-            title: 'Failed',
-            status: 'failed',
-            createdAt: '2026-01-01T00:00:00.000Z',
-          },
-        ],
-      },
-    } satisfies BuddyInboxViewMessage
-
-    expect(buddyInboxMessageMatchesTaskFilter(running, 'open')).toBe(true)
-    expect(buddyInboxMessageMatchesTaskFilter(running, 'done')).toBe(false)
-    expect(buddyInboxMessageMatchesTaskFilter(completed, 'open')).toBe(false)
-    expect(buddyInboxMessageMatchesTaskFilter(completed, 'done')).toBe(true)
-    expect(buddyInboxMessageMatchesTaskFilter(mixed, 'open')).toBe(true)
-    expect(buddyInboxMessageMatchesTaskFilter(mixed, 'done')).toBe(false)
+    ).toEqual(['task-1', 'reply-1', 'chat-1', 'task-2'])
   })
 })

--- a/packages/shared/src/types/inbox.types.ts
+++ b/packages/shared/src/types/inbox.types.ts
@@ -85,7 +85,6 @@ export function canTransitionTaskMessageCardStatus(from: MessageCardStatus, to: 
 }
 
 export type BuddyInboxViewMode = 'chat' | 'tasks'
-export type BuddyInboxTaskFilter = 'all' | 'open' | 'done'
 
 export interface BuddyInboxViewMessage {
   id: string
@@ -95,10 +94,6 @@ export interface BuddyInboxViewMessage {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
-}
-
-export function isTaskReplyNotificationCard(card: MessageCard) {
-  return isRecord(card.data) && card.data.taskReplyNotification === true
 }
 
 export function isMessageReferenceCard(card: MessageCard): card is MessageReferenceCard {
@@ -116,10 +111,7 @@ export function getBuddyInboxTaskCards(message: BuddyInboxViewMessage): TaskMess
   if (!Array.isArray(cards)) return []
   return cards.filter(
     (card): card is TaskMessageCard =>
-      card?.kind === 'task' &&
-      typeof card.id === 'string' &&
-      isTaskMessageCardStatus(card.status) &&
-      !isTaskReplyNotificationCard(card),
+      card?.kind === 'task' && typeof card.id === 'string' && isTaskMessageCardStatus(card.status),
   )
 }
 
@@ -127,39 +119,8 @@ export function hasBuddyInboxTaskCard(message: BuddyInboxViewMessage) {
   return getBuddyInboxTaskCards(message).length > 0
 }
 
-function hasBuddyInboxTaskReplyNotificationCard(message: BuddyInboxViewMessage) {
-  const cards = message.metadata?.cards
-  return Array.isArray(cards) && cards.some(isTaskReplyNotificationCard)
-}
-
 export function getBuddyInboxTaskStatuses(message: BuddyInboxViewMessage): MessageCardStatus[] {
   return getBuddyInboxTaskCards(message).map((card) => card.status)
-}
-
-export function buddyInboxMessageMatchesTaskFilter(
-  message: BuddyInboxViewMessage,
-  filter: BuddyInboxTaskFilter,
-) {
-  const statuses = getBuddyInboxTaskStatuses(message)
-  if (statuses.length === 0) return false
-  if (filter === 'all') return true
-  if (filter === 'done') return statuses.every((status) => isTerminalTaskMessageCardStatus(status))
-  return statuses.some((status) => !isTerminalTaskMessageCardStatus(status))
-}
-
-export function getBuddyInboxTaskMessageIds(messages: readonly BuddyInboxViewMessage[]) {
-  const ids = new Set<string>()
-  for (const message of messages) {
-    if (hasBuddyInboxTaskCard(message)) ids.add(message.id)
-  }
-  return ids
-}
-
-export function isBuddyInboxTaskReply(
-  message: BuddyInboxViewMessage,
-  taskMessageIds: ReadonlySet<string>,
-) {
-  return Boolean(message.replyToId && taskMessageIds.has(message.replyToId))
 }
 
 export function buildBuddyInboxViewMessages<TMessage extends BuddyInboxViewMessage>(
@@ -167,20 +128,10 @@ export function buildBuddyInboxViewMessages<TMessage extends BuddyInboxViewMessa
   options: {
     isInboxChannel: boolean
     mode?: BuddyInboxViewMode
-    taskFilter?: BuddyInboxTaskFilter
   },
 ) {
-  if (!options.isInboxChannel) return [...messages]
-
-  const taskMessageIds = getBuddyInboxTaskMessageIds(messages)
-  const taskFilter = options.taskFilter ?? 'all'
-  return messages.filter((message) => {
-    if (isBuddyInboxTaskReply(message, taskMessageIds)) return false
-    if (hasBuddyInboxTaskReplyNotificationCard(message)) return false
-    const hasTaskCard = hasBuddyInboxTaskCard(message)
-    if (!hasTaskCard) return taskFilter === 'all'
-    return buddyInboxMessageMatchesTaskFilter(message, taskFilter)
-  })
+  void options
+  return [...messages]
 }
 
 export type BuddyInboxAdmissionMode = 'allow' | 'deny' | 'first_time' | 'every_time'

--- a/packages/shared/src/types/message.types.ts
+++ b/packages/shared/src/types/message.types.ts
@@ -168,6 +168,8 @@ export interface MessageMetadata {
   interactive?: Record<string, unknown>
   interactiveResponse?: Record<string, unknown>
   interactiveState?: Record<string, unknown>
+  ccConnectDelivery?: Record<string, unknown>
+  shadowDelivery?: Record<string, unknown>
   /** Unified card protocol. New card-like message surfaces must use this field. */
   cards?: MessageCard[]
   /**

--- a/packages/shared/src/types/message.types.ts
+++ b/packages/shared/src/types/message.types.ts
@@ -332,6 +332,42 @@ export interface TaskMessagePrivacy {
   [key: string]: unknown
 }
 
+export interface TaskContextPack {
+  snapshotAtMessageId: string | null
+  sourceSurface: 'channel' | 'thread' | 'task-thread' | 'app'
+  policy: 'auto_recent' | 'explicit_refs' | 'thread_context' | 'manual'
+  summary: string | null
+  items: Array<
+    | {
+        kind: 'message'
+        messageId: string
+        threadId?: string | null
+        authorId: string
+        createdAt: string
+        text: string
+      }
+    | {
+        kind: 'resource'
+        resourceType: string
+        resourceId: string
+        title?: string
+        summary?: string
+      }
+    | {
+        kind: 'task_result'
+        messageId: string
+        cardId: string
+        title: string
+        summary: string
+      }
+  >
+  omitted: Array<{
+    messageCount: number
+    reason: 'token_budget' | 'permission' | 'privacy' | 'not_relevant'
+  }>
+  tokenEstimate: number
+}
+
 export interface TaskMessageCard {
   id: string
   kind: 'task'
@@ -367,6 +403,9 @@ export interface TaskMessageCard {
   data?: Record<string, unknown> & {
     task?: {
       workspaceId?: string
+      threadId?: string
+      revision?: number
+      contextPack?: TaskContextPack
       [key: string]: unknown
     }
   }


### PR DESCRIPTION
## Summary

- Remove Inbox Task mode timeline filtering and legacy standalone task reply rendering across web/mobile/shared.
- Keep Task Card replies in the standard Thread surface and prevent ordinary Buddy replies/comments from changing task status automatically.
- Bind newly created Inbox Task cards to a standard Thread and persist a TaskContextPack under card.data.task for runtime startup context.
- Update the task mechanism document with current implementation status and remaining runtime binding work.

## Validation

- `rtk pnpm --filter @shadowob/shared exec vitest run __tests__/inbox.test.ts`
- `rtk env JWT_SECRET=ci-test-secret-do-not-use-in-prod pnpm --filter @shadowob/server exec vitest run __tests__/buddy-inbox-service.test.ts __tests__/services.test.ts`
- `rtk pnpm --dir apps/server typecheck`
- Earlier focused checks on this branch: web task-card test, web/mobile typecheck, server cloud-saas e2e fix, connector/desktop focused tests.

## Notes

- This PR is not merged by this flow.
- Runtime Binding storage and OpenClaw/Hermes/cc-connect live steering remain as follow-up implementation work.