### PR TITLE
ci: allow main mobile releases after daily tag

### DIFF
--- a/.github/workflows/release-mobile-testflight.yml
+++ b/.github/workflows/release-mobile-testflight.yml
@@ -82,7 +82,9 @@ jobs:
             exit 0
           fi
 
-          if [ "$force" != "true" ] && git rev-parse -q --verify "refs/tags/${daily_tag}" >/dev/null; then
+          if [ "$force" != "true" ] &&
+            [ "${GITHUB_EVENT_NAME}" != "workflow_run" ] &&
+            git rev-parse -q --verify "refs/tags/${daily_tag}" >/dev/null; then
             {
               echo "should_release=false"
               echo "tag=${daily_tag}"
@@ -94,7 +96,8 @@ jobs:
             exit 0
           fi
 
-          if [ "$force" = "true" ] && git rev-parse -q --verify "refs/tags/${daily_tag}" >/dev/null; then
+          if { [ "$force" = "true" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; } &&
+            git rev-parse -q --verify "refs/tags/${daily_tag}" >/dev/null; then
             tag="${daily_tag}-${GITHUB_RUN_NUMBER}"
           fi
 


### PR DESCRIPTION
## Summary
- allow workflow_run mobile TestFlight releases to continue even when the daily mobile-testflight-YYYYMMDD tag already exists
- use a run-specific tag suffix for those main-branch releases when the daily tag is taken
- keep the daily-tag skip behavior for scheduled and non-force manual runs

## Why
Run https://github.com/buggyblues/shadow/actions/runs/27826297655 stopped after the gate because mobile-testflight-20260619 already existed from an earlier release, even though the main head had mobile-relevant changes.

## Verification
- YAML parsed successfully
- git diff --check passed
- confirmed mobile-testflight-20260619..4ff26248 contains mobile-relevant changes