### PR TITLE
Fix server app standalone and OS regressions

### DIFF
--- a/apps/server/__tests__/app-integration-service.test.ts
+++ b/apps/server/__tests__/app-integration-service.test.ts
@@ -1128,7 +1128,7 @@ describe('AppIntegrationService', () => {
             id: 'bot-1',
             username: 'demo-buddy',
             displayName: 'Demo Buddy',
-            avatarUrl: '/api/media/signed/avatar-token',
+            avatarUrl: 'http://localhost:3000/api/media/signed/avatar-token',
           },
         },
         permission: 'demo.tickets:read',

--- a/apps/server/src/services/app-integration.service.ts
+++ b/apps/server/src/services/app-integration.service.ts
@@ -71,6 +71,15 @@ const DEFAULT_COMMAND_AUTHORIZATION_MAX_WAIT_MS = 60_000
 const DEFAULT_INSTALLED_MANIFEST_REFRESH_TTL_MS = 5 * 60 * 1000
 const DEFAULT_CATALOG_MANIFEST_REFRESH_TTL_MS = 15 * 60 * 1000
 
+function shadowPublicBaseUrl() {
+  return (process.env.OAUTH_BASE_URL ?? 'http://localhost:3000').replace(/\/+$/, '')
+}
+
+function absoluteShadowUrl(value: string | null): string | null {
+  if (!value || !value.startsWith('/')) return value
+  return `${shadowPublicBaseUrl()}${value}`
+}
+
 interface CommandAuthorizationWaitOptions {
   waitMs?: number
   pollMs?: number
@@ -1471,6 +1480,7 @@ export class AppIntegrationService {
   async introspectLaunchToken(serverIdOrSlug: string, appKey: string, token: string) {
     try {
       const { app, payload } = await this.getEventStreamContext(serverIdOrSlug, appKey, token)
+      const actorProfile = payload.userId ? await this.commandActorProfile(payload.userId) : null
       return {
         active: true,
         token_type: 'Bearer',
@@ -1486,6 +1496,7 @@ export class AppIntegrationService {
             userId: payload.userId ?? null,
             buddyAgentId: payload.buddyAgentId ?? null,
             ownerId: payload.ownerId ?? null,
+            ...(actorProfile ? { profile: actorProfile } : {}),
           },
         },
       }
@@ -2786,9 +2797,11 @@ export class AppIntegrationService {
       id: user.id,
       username: user.username,
       displayName: user.displayName,
-      avatarUrl: this.deps.mediaService.resolveMediaUrl(user.avatarUrl, 'image/png', {
-        variant: 'avatar',
-      }),
+      avatarUrl: absoluteShadowUrl(
+        this.deps.mediaService.resolveMediaUrl(user.avatarUrl, 'image/png', {
+          variant: 'avatar',
+        }),
+      ),
     }
   }
 

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -4,6 +4,10 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+types {
+    application/javascript mjs;
+}
+
 # ── Main Web App ──
 server {
     listen 3000 default_server;
@@ -174,7 +178,7 @@ server {
     }
 
     # Static assets cache
-    location ~* \.(js|css|png|jpg|jpeg|gif|webp|ico|svg|woff2?)$ {
+    location ~* \.(js|mjs|css|png|jpg|jpeg|gif|webp|ico|svg|woff2?)$ {
         expires 30d;
         add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://js.stripe.com; connect-src 'self' http: https: ws: wss: https://api.stripe.com https://*.stripe.com; frame-src 'self' http: https: https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:;" always;
         add_header X-Content-Type-Options "nosniff" always;

--- a/apps/web/src/components/server/server-settings-modal.tsx
+++ b/apps/web/src/components/server/server-settings-modal.tsx
@@ -29,7 +29,7 @@ import {
   ShoppingBag,
   Trash2,
 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { fetchApi } from '../../lib/api'
 import { copyToClipboard } from '../../lib/clipboard'
@@ -96,6 +96,7 @@ export function ServerSettingsModal({
   const queryClient = useQueryClient()
   const currentUser = useAuthStore((s) => s.user)
   const [activeTab, setActiveTab] = useState<ModalTab>(initialTab)
+  const activeTabResetKeyRef = useRef<string | null>(null)
   const isOwner = !!currentUser && !!server && currentUser.id === server.ownerId
 
   // Draft state
@@ -136,9 +137,20 @@ export function ServerSettingsModal({
         iconUrl: server.iconUrl,
         bannerUrl: server.bannerUrl,
       })
-      setActiveTab(initialTab)
     }
-  }, [open, server, initialTab])
+  }, [open, server])
+
+  useEffect(() => {
+    if (!open) {
+      activeTabResetKeyRef.current = null
+      return
+    }
+    if (!server) return
+    const resetKey = `${server.id}:${initialTab}`
+    if (activeTabResetKeyRef.current === resetKey) return
+    activeTabResetKeyRef.current = resetKey
+    setActiveTab(initialTab)
+  }, [initialTab, open, server])
 
   const updateDraftField = <K extends keyof typeof formDraft>(
     field: K,

--- a/apps/web/src/components/workspace/workspace-page.tsx
+++ b/apps/web/src/components/workspace/workspace-page.tsx
@@ -65,6 +65,22 @@ function findWorkspaceTargetNode(
   return path ? findNodeByPath(nodes, path) : null
 }
 
+function ancestorIdsForNode(
+  nodes: WorkspaceNode[],
+  targetId: string,
+  ancestors: string[] = [],
+): string[] | null {
+  for (const node of nodes) {
+    if (node.id === targetId) return ancestors
+    const childAncestors = ancestorIdsForNode(node.children ?? [], targetId, [
+      ...ancestors,
+      node.id,
+    ])
+    if (childAncestors) return childAncestors
+  }
+  return null
+}
+
 /* --- WorkspacePage --- */
 
 export function WorkspacePage({
@@ -89,6 +105,7 @@ export function WorkspacePage({
     clearSelection,
     toggleSelected,
     expandedIds,
+    setExpanded,
     activeFileId,
     setActiveFileId,
     contextMenu,
@@ -129,15 +146,20 @@ export function WorkspacePage({
       uri: initialUri,
     })
     if (!target) return
+    for (const id of ancestorIdsForNode(tree, target.id) ?? []) setExpanded(id, true)
+    if (target.kind === 'dir') setExpanded(target.id, true)
     setSelectedNodeId(target.id)
     clearSelection()
+    selectMultiple([target.id])
     if (target.kind === 'file') setActiveFileId(target.id)
   }, [
     clearSelection,
     initialNodeId,
     initialPath,
     initialUri,
+    selectMultiple,
     setActiveFileId,
+    setExpanded,
     setSelectedNodeId,
     tree,
   ])

--- a/apps/web/src/pages/os-experiment.tsx
+++ b/apps/web/src/pages/os-experiment.tsx
@@ -208,6 +208,8 @@ export function OsExperimentPage() {
   const [localMessageUnread, setLocalMessageUnread] = useState<Record<string, number>>({})
   const windowsRef = useRef(windows)
   const focusedWindowIdRef = useRef(focusedWindowId)
+  const openChannelTabsRef = useRef(openChannelTabs)
+  const activeChannelTabIdRef = useRef(activeChannelTabId)
   const selectedServerIdRef = useRef<string | null>(null)
   const resizeSessionRef = useRef<{ id: string; windows: OsWindowState[] } | null>(null)
   const localUnreadEventIdsRef = useRef<Set<string>>(new Set())
@@ -375,6 +377,14 @@ export function OsExperimentPage() {
   }, [windows])
 
   useEffect(() => {
+    openChannelTabsRef.current = openChannelTabs
+  }, [openChannelTabs])
+
+  useEffect(() => {
+    activeChannelTabIdRef.current = activeChannelTabId
+  }, [activeChannelTabId])
+
+  useEffect(() => {
     if (typeof window === 'undefined') return
     window.localStorage.setItem(OS_DOCK_ICON_STATE_STORAGE_KEY, JSON.stringify(dockIconState))
   }, [dockIconState])
@@ -393,12 +403,16 @@ export function OsExperimentPage() {
   useSocketEvent('notification:new', () => {
     queryClient.invalidateQueries({ queryKey: ['notification-scoped-unread'] })
     queryClient.invalidateQueries({ queryKey: ['notifications-unread-count'] })
+    queryClient.invalidateQueries({ queryKey: ['os-server-inboxes', selectedServerSlug] })
+    queryClient.invalidateQueries({ queryKey: ['buddy-inboxes', selectedServerSlug] })
   })
 
   const recordOsMessageActivity = useCallback(
     (event: { id?: string; channelId?: string }) => {
       queryClient.invalidateQueries({ queryKey: ['notification-scoped-unread'] })
       queryClient.invalidateQueries({ queryKey: ['notifications-unread-count'] })
+      queryClient.invalidateQueries({ queryKey: ['os-server-inboxes', selectedServerSlug] })
+      queryClient.invalidateQueries({ queryKey: ['buddy-inboxes', selectedServerSlug] })
       const channelId = event.channelId
       if (!channelId) return
       const activeChannelId = openChannelTabs.find(
@@ -417,7 +431,7 @@ export function OsExperimentPage() {
         [channelId]: (current[channelId] ?? 0) + 1,
       }))
     },
-    [activeChannelTabId, openChannelTabs, queryClient],
+    [activeChannelTabId, openChannelTabs, queryClient, selectedServerSlug],
   )
 
   useSocketEvent<{ id?: string; channelId?: string }>('message:new', recordOsMessageActivity)
@@ -448,6 +462,8 @@ export function OsExperimentPage() {
       saveOsServerWindowState(previousServerId, {
         windows: windowsRef.current,
         focusedWindowId: focusedWindowIdRef.current,
+        channelTabs: openChannelTabsRef.current,
+        activeChannelTabId: activeChannelTabIdRef.current,
       })
     }
     selectedServerIdRef.current = selectedServerId
@@ -472,11 +488,23 @@ export function OsExperimentPage() {
       })
       .map((item) =>
         item.kind === 'builtin' && item.builtinKey === 'server-settings'
-          ? { ...item, maximized: true, minimized: false }
+          ? { ...item, maximized: item.minimized ? item.maximized : true }
           : item,
       )
-    setOpenChannelTabs([])
-    setActiveChannelTabId(null)
+    const restoredTabs = (restored?.channelTabs ?? []).filter(
+      (tab) =>
+        tab &&
+        typeof tab.id === 'string' &&
+        typeof tab.channelId === 'string' &&
+        typeof tab.title === 'string',
+    )
+    const visibleRestoredTabs = restoredTabs.slice(-8)
+    setOpenChannelTabs(visibleRestoredTabs)
+    setActiveChannelTabId(
+      visibleRestoredTabs.some((tab) => tab.id === restored?.activeChannelTabId)
+        ? (restored?.activeChannelTabId ?? null)
+        : (visibleRestoredTabs.at(-1)?.id ?? null),
+    )
     setChannelBubbleRequest(null)
     setLocalMessageUnread({})
     isRestoringDesktopRef.current = true
@@ -510,8 +538,13 @@ export function OsExperimentPage() {
       isRestoringWindowsRef.current = false
       return
     }
-    saveOsServerWindowState(selectedServerId, { windows, focusedWindowId })
-  }, [focusedWindowId, selectedServerId, windows])
+    saveOsServerWindowState(selectedServerId, {
+      windows,
+      focusedWindowId,
+      channelTabs: openChannelTabs,
+      activeChannelTabId,
+    })
+  }, [activeChannelTabId, focusedWindowId, openChannelTabs, selectedServerId, windows])
 
   const exitOs = useCallback(() => {
     if (!selectedServerSlug) {
@@ -683,6 +716,15 @@ export function OsExperimentPage() {
       const id = windowKey(input.kind, input.targetId)
       const existingWindow = findSemanticWindow(windowsRef.current, id, input)
       if (existingWindow) {
+        if (input.kind === 'builtin' && input.builtinKey === 'workspace' && input.workspaceNode) {
+          setWindows((current) =>
+            current.map((item) =>
+              item.id === existingWindow.id
+                ? { ...item, workspaceNode: input.workspaceNode }
+                : item,
+            ),
+          )
+        }
         focusWindow(existingWindow.id)
         return
       }
@@ -694,6 +736,10 @@ export function OsExperimentPage() {
             item.id === existing.id
               ? {
                   ...item,
+                  workspaceNode:
+                    input.kind === 'builtin' && input.builtinKey === 'workspace'
+                      ? input.workspaceNode
+                      : item.workspaceNode,
                   minimized: false,
                   z: topZ,
                   maximized:
@@ -742,6 +788,7 @@ export function OsExperimentPage() {
             channelId: input.channelId,
             appKey: input.appKey,
             builtinKey: input.builtinKey,
+            appPath: input.kind === 'app' ? '/' : undefined,
             workspaceNode: input.workspaceNode,
             attachment: input.attachment,
             profileUserId: input.profileUserId,
@@ -821,8 +868,14 @@ export function OsExperimentPage() {
     [openWindow, t],
   )
 
+  const updateAppWindowRoute = useCallback((id: string, appPath: string) => {
+    setWindows((current) =>
+      current.map((item) => (item.id === id && item.kind === 'app' ? { ...item, appPath } : item)),
+    )
+  }, [])
+
   const openBuiltinWindow = useCallback(
-    (key: OsBuiltinAppKey) => {
+    (key: OsBuiltinAppKey, options: { workspaceNode?: WorkspaceNode } = {}) => {
       const titleKey =
         key === 'workspace'
           ? 'os.workspaceApp'
@@ -845,6 +898,7 @@ export function OsExperimentPage() {
         kind: 'builtin',
         targetId: key,
         builtinKey: key,
+        workspaceNode: options.workspaceNode,
         title: t(titleKey),
         subtitle: t('os.applicationWindow'),
       })
@@ -895,7 +949,7 @@ export function OsExperimentPage() {
         openWorkspaceFileWindow(node)
         return
       }
-      openBuiltinWindow('workspace')
+      openBuiltinWindow('workspace', { workspaceNode: node })
     },
     [openBuiltinWindow, openWorkspaceFileWindow],
   )
@@ -1469,6 +1523,7 @@ export function OsExperimentPage() {
             onMove={moveWindow}
             onResize={resizeWindow}
             onPreviewFile={openChatFileWindow}
+            onAppRouteChange={updateAppWindowRoute}
             siblingWindows={windows}
           >
             {item.kind === 'builtin' ? (
@@ -1555,11 +1610,9 @@ export function OsExperimentPage() {
               key={app.id}
               active={topAppWindows.includes(app.appKey)}
               label={app.name}
-              icon={<AppIcon iconUrl={app.iconUrl} className="h-full w-full rounded-xl" />}
+              icon={<AppIcon iconUrl={app.iconUrl} className="rounded-xl" />}
               onClick={() => openAppWindow(app)}
               onContextMenu={(event) => openDockIconContextMenu(event, appDockIconKey(app.appKey))}
-              surface="bare"
-              wrapIcon={false}
             />
           ))
         )}

--- a/apps/web/src/pages/os-experiment/app-store.tsx
+++ b/apps/web/src/pages/os-experiment/app-store.tsx
@@ -125,11 +125,12 @@ export function OsAppStoreContent({
           manifest: discovery?.manifest,
         }),
       }),
-    onSuccess: () => {
+    onSuccess: (result) => {
       setManifestUrl('')
       setDiscovery(null)
       setTab('installed')
       invalidateApps()
+      onOpenApp(result)
       showToast(t('serverApps.installSuccess'), 'success')
     },
     onError: (error) => showToast(appStoreErrorMessage(error, t), 'error'),
@@ -144,9 +145,10 @@ export function OsAppStoreContent({
           body: JSON.stringify({}),
         },
       ),
-    onSuccess: () => {
+    onSuccess: (result) => {
       setTab('installed')
       invalidateApps()
+      onOpenApp(result)
       showToast(t('serverApps.installSuccess'), 'success')
     },
     onError: (error) => showToast(appStoreErrorMessage(error, t), 'error'),

--- a/apps/web/src/pages/os-experiment/components.tsx
+++ b/apps/web/src/pages/os-experiment/components.tsx
@@ -1,3 +1,4 @@
+import { ShadowBridge } from '@shadowob/sdk/bridge'
 import { cn } from '@shadowob/ui'
 import { useQuery } from '@tanstack/react-query'
 import {
@@ -20,7 +21,9 @@ import {
   forwardRef,
   type ReactNode,
   type PointerEvent as ReactPointerEvent,
+  useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -55,6 +58,59 @@ export type ResizeMode =
 
 type WindowRect = Pick<OsWindowState, 'x' | 'y' | 'width' | 'height'>
 type DockStackKey = 'apps' | 'files' | 'minimized'
+
+function normalizeOsServerAppRoutePath(value: unknown) {
+  if (typeof value !== 'string') return null
+  const input = value.trim()
+  if (!input) return null
+  const withoutHash = input.startsWith('#') ? input.slice(1) : input
+  const prefixed = withoutHash.startsWith('/') ? withoutHash : `/${withoutHash}`
+  return prefixed.replace(/\/{2,}/g, '/') || '/'
+}
+
+function routeRequestId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}:${Math.random()}`
+}
+
+function osAppRouteState(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const route = (value as { shadowOsAppRoute?: unknown }).shadowOsAppRoute
+  if (!route || typeof route !== 'object' || Array.isArray(route)) return null
+  const record = route as { appKey?: unknown; path?: unknown; windowId?: unknown }
+  if (
+    typeof record.appKey !== 'string' ||
+    typeof record.path !== 'string' ||
+    typeof record.windowId !== 'string'
+  ) {
+    return null
+  }
+  return {
+    appKey: record.appKey,
+    path: normalizeOsServerAppRoutePath(record.path) ?? '/',
+    windowId: record.windowId,
+  }
+}
+
+function pushOsAppRouteHistory(windowId: string, appKey: string, path: string) {
+  if (typeof window === 'undefined') return
+  const currentState =
+    window.history.state &&
+    typeof window.history.state === 'object' &&
+    !Array.isArray(window.history.state)
+      ? window.history.state
+      : {}
+  window.history.pushState(
+    {
+      ...currentState,
+      shadowOsAppRoute: { windowId, appKey, path },
+    },
+    '',
+    window.location.href,
+  )
+}
 
 export function osBuiltinIconToneClassName(key: OsBuiltinAppKey | null | undefined) {
   if (key === 'workspace') return 'text-cyan-200'
@@ -373,12 +429,23 @@ function OsWindowTitleIcon({ item }: { item: OsWindowState }) {
 
 function OsAppWindowContent({
   app,
+  appPath,
+  focused,
   serverSlug,
+  windowId,
+  onRouteChange,
 }: {
   app: ServerAppIntegration | null
+  appPath?: string | null
+  focused: boolean
   serverSlug: string
+  windowId: string
+  onRouteChange?: (id: string, path: string) => void
 }) {
   const { t } = useTranslation()
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+  const initialAppPathRef = useRef(appPath)
+  const lastRouteRef = useRef(normalizeOsServerAppRoutePath(appPath) ?? '/')
   const { data: launch, isLoading } = useQuery({
     queryKey: ['os-server-app-launch', serverSlug, app?.appKey],
     queryFn: () =>
@@ -390,6 +457,76 @@ function OsAppWindowContent({
     gcTime: OS_GC_MS,
   })
 
+  const entry = app ? (launch?.iframeEntry ?? app.iframeEntry) : null
+  const iframeSrc = entry ? withLaunchParams(entry, launch, initialAppPathRef.current) : null
+  const iframeOrigin = useMemo(() => {
+    if (!iframeSrc) return '*'
+    try {
+      return new URL(iframeSrc).origin
+    } catch {
+      return '*'
+    }
+  }, [iframeSrc])
+
+  useEffect(() => {
+    lastRouteRef.current = normalizeOsServerAppRoutePath(appPath) ?? '/'
+  }, [appPath])
+
+  const postRouteNavigate = useCallback(
+    (path: string) => {
+      if (!app?.appKey) return
+      const normalized = normalizeOsServerAppRoutePath(path) ?? '/'
+      iframeRef.current?.contentWindow?.postMessage(
+        {
+          type: ShadowBridge.routeNavigateType,
+          requestId: routeRequestId(),
+          appKey: app.appKey,
+          path: normalized,
+        },
+        iframeOrigin,
+      )
+      lastRouteRef.current = normalized
+      onRouteChange?.(windowId, normalized)
+    },
+    [app?.appKey, iframeOrigin, onRouteChange, windowId],
+  )
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (!app?.appKey || event.source !== iframeRef.current?.contentWindow) return
+      if (iframeOrigin !== '*' && event.origin !== iframeOrigin) return
+      const data =
+        event.data && typeof event.data === 'object' && !Array.isArray(event.data)
+          ? (event.data as Record<string, unknown>)
+          : null
+      if (!data) return
+      if (data.appKey && data.appKey !== app.appKey) return
+      if (data.type !== ShadowBridge.routeChangedType) return
+      const normalized = normalizeOsServerAppRoutePath(data.path)
+      if (!normalized || normalized === lastRouteRef.current) return
+      lastRouteRef.current = normalized
+      onRouteChange?.(windowId, normalized)
+      if (focused) pushOsAppRouteHistory(windowId, app.appKey, normalized)
+    }
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [app?.appKey, focused, iframeOrigin, onRouteChange, windowId])
+
+  useEffect(() => {
+    const handlePopState = (event: PopStateEvent) => {
+      if (!focused || !app?.appKey) return
+      const routeState = osAppRouteState(event.state)
+      if (routeState && (routeState.windowId !== windowId || routeState.appKey !== app.appKey)) {
+        return
+      }
+      const nextPath = routeState?.path ?? '/'
+      if (nextPath === lastRouteRef.current) return
+      postRouteNavigate(nextPath)
+    }
+    window.addEventListener('popstate', handlePopState)
+    return () => window.removeEventListener('popstate', handlePopState)
+  }, [app?.appKey, focused, postRouteNavigate, windowId])
+
   if (!app) {
     return (
       <div className="grid h-full place-items-center px-6 text-center text-sm font-bold text-text-muted">
@@ -397,9 +534,6 @@ function OsAppWindowContent({
       </div>
     )
   }
-
-  const entry = launch?.iframeEntry ?? app.iframeEntry
-  const iframeSrc = entry ? withLaunchParams(entry, launch) : null
 
   if (!app.iframeEntry) {
     return (
@@ -417,7 +551,7 @@ function OsAppWindowContent({
 
   if (isLoading || !iframeSrc) {
     return (
-      <div className="grid h-full place-items-center text-text-muted">
+      <div className="flex h-full min-h-0 flex-1 items-center justify-center text-text-muted">
         <Loader2 size={20} className="animate-spin" />
       </div>
     )
@@ -425,6 +559,7 @@ function OsAppWindowContent({
 
   return (
     <iframe
+      ref={iframeRef}
       key={iframeSrc}
       src={iframeSrc}
       title={app.name}
@@ -448,6 +583,7 @@ export function OsWindowFrame({
   onMove,
   onResize,
   onPreviewFile,
+  onAppRouteChange,
   siblingWindows,
   children,
 }: {
@@ -468,6 +604,7 @@ export function OsWindowFrame({
     phase: 'preview' | 'commit',
   ) => void
   onPreviewFile?: (attachment: Attachment) => void
+  onAppRouteChange?: (id: string, path: string) => void
   siblingWindows: OsWindowState[]
   children?: ReactNode
 }) {
@@ -1029,7 +1166,14 @@ export function OsWindowFrame({
           item.kind === 'chat-file' ? (
             children
           ) : item.kind === 'app' ? (
-            <OsAppWindowContent app={app} serverSlug={serverSlug} />
+            <OsAppWindowContent
+              app={app}
+              appPath={item.appPath}
+              focused={focused}
+              serverSlug={serverSlug}
+              windowId={item.id}
+              onRouteChange={onAppRouteChange}
+            />
           ) : item.channelId ? (
             <ChannelView
               key={`${item.kind}:${item.channelId}`}

--- a/apps/web/src/pages/os-experiment/dock-stacks.tsx
+++ b/apps/web/src/pages/os-experiment/dock-stacks.tsx
@@ -74,7 +74,7 @@ export function OsDockAppStack({
         align="center"
         side="top"
         sideOffset={12}
-        className="z-[520] w-72 border-white/12 bg-bg-secondary p-2 text-text-primary shadow-[0_22px_70px_rgba(0,0,0,0.42)]"
+        className="z-[520] max-h-[min(420px,calc(100vh-72px))] w-72 overflow-y-auto overscroll-contain border-white/12 bg-bg-secondary p-2 text-text-primary shadow-[0_22px_70px_rgba(0,0,0,0.42)]"
       >
         {entries.map((item) => (
           <DropdownMenuItem
@@ -137,7 +137,7 @@ export function OsDockWindowStack({
         align="center"
         side="top"
         sideOffset={12}
-        className="z-[520] w-64 border-white/12 bg-bg-secondary p-2 text-text-primary shadow-[0_22px_70px_rgba(0,0,0,0.42)]"
+        className="z-[520] max-h-[min(420px,calc(100vh-72px))] w-64 overflow-y-auto overscroll-contain border-white/12 bg-bg-secondary p-2 text-text-primary shadow-[0_22px_70px_rgba(0,0,0,0.42)]"
       >
         {windows.map((item) => (
           <DropdownMenuItem

--- a/apps/web/src/pages/os-experiment/shell.tsx
+++ b/apps/web/src/pages/os-experiment/shell.tsx
@@ -32,7 +32,6 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Attachment } from '../../components/chat/message-bubble/types'
-import { UserAvatar } from '../../components/common/avatar'
 import { PresenceAvatar } from '../../components/common/presence-avatar'
 import { MemberList } from '../../components/member/member-list'
 import { NotificationBell } from '../../components/notification/notification-bell'
@@ -138,10 +137,11 @@ export function OsAvatarMenu({
           aria-label={t('settings.avatarMenuLabel')}
           className="grid h-8 w-8 place-items-center rounded-full p-0 text-white transition hover:scale-[1.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
         >
-          <UserAvatar
+          <PresenceAvatar
             userId={user?.id}
             avatarUrl={user?.avatarUrl}
             displayName={displayName}
+            status={user?.status}
             size="sm"
             className="shadow-[0_8px_24px_rgba(0,0,0,0.24)]"
             loading="eager"
@@ -155,10 +155,11 @@ export function OsAvatarMenu({
         className="z-[520] w-64 border-white/12 bg-bg-secondary p-2 text-text-primary shadow-[0_22px_70px_rgba(0,0,0,0.42)]"
       >
         <div className="flex items-center gap-3 rounded-2xl p-3">
-          <UserAvatar
+          <PresenceAvatar
             userId={user?.id}
             avatarUrl={user?.avatarUrl}
             displayName={displayName}
+            status={user?.status}
             size="lg"
             loading="eager"
           />

--- a/apps/web/src/pages/os-experiment/types.ts
+++ b/apps/web/src/pages/os-experiment/types.ts
@@ -112,6 +112,7 @@ export interface OsWindowState {
   attachment?: PreviewAttachment
   profileUserId?: string
   iconUrl?: string | null
+  appPath?: string | null
   x: number
   y: number
   width: number

--- a/apps/web/src/pages/os-experiment/utils.ts
+++ b/apps/web/src/pages/os-experiment/utils.ts
@@ -2,6 +2,7 @@ import type {
   BuddyInboxEntry,
   ChannelMeta,
   LaunchContext,
+  OsChannelTab,
   OsDesktopFile,
   OsWindowKind,
   OsWindowState,
@@ -29,7 +30,7 @@ export function windowKey(kind: OsWindowKind, id: string) {
   return `${kind}:${id}`
 }
 
-const OS_WINDOW_STORAGE_KEY = 'shadow:os-windows:v1'
+const OS_WINDOW_STORAGE_KEY = 'shadow:os-windows:v2'
 const OS_DESKTOP_STORAGE_KEY = 'shadow:os-desktop-files:v1'
 export const OS_WORKSPACE_NODE_DRAG_TYPE = 'application/x-shadow-workspace-node'
 export const OS_SNAP_DWELL_MS = 120
@@ -37,6 +38,8 @@ export const OS_SNAP_DWELL_MS = 120
 interface StoredOsServerWindowState {
   windows: OsWindowState[]
   focusedWindowId: string | null
+  channelTabs: Array<Omit<OsChannelTab, 'active'>>
+  activeChannelTabId: string | null
 }
 
 function readWindowStorage() {
@@ -77,7 +80,7 @@ export function saveOsDesktopFiles(serverId: string, files: OsDesktopFile[]) {
 
 export function loadOsServerWindowState(serverId: string): StoredOsServerWindowState | null {
   const state = readWindowStorage()[serverId]
-  return state && Array.isArray(state.windows) ? state : null
+  return state && Array.isArray(state.windows) && Array.isArray(state.channelTabs) ? state : null
 }
 
 export function saveOsServerWindowState(serverId: string, state: StoredOsServerWindowState) {
@@ -91,7 +94,19 @@ export function saveOsServerWindowState(serverId: string, state: StoredOsServerW
   }
 }
 
-export function withLaunchParams(entry: string, launch: LaunchContext | undefined) {
+function normalizeAppPath(value: string | null | undefined) {
+  if (typeof value !== 'string') return null
+  const input = value.trim()
+  if (!input) return null
+  const prefixed = input.startsWith('/') ? input : `/${input}`
+  return prefixed.replace(/\/{2,}/g, '/')
+}
+
+export function withLaunchParams(
+  entry: string,
+  launch: LaunchContext | undefined,
+  appPath?: string | null,
+) {
   if (!launch?.launchToken) return entry
   const url = new URL(entry, window.location.origin)
   url.searchParams.set('shadow_launch', launch.launchToken)
@@ -101,6 +116,8 @@ export function withLaunchParams(entry: string, launch: LaunchContext | undefine
       new URL(launch.eventStreamPath, window.location.origin).toString(),
     )
   }
+  const normalizedAppPath = normalizeAppPath(appPath)
+  if (normalizedAppPath && normalizedAppPath !== '/') url.hash = normalizedAppPath
   return url.toString()
 }
 
@@ -114,7 +131,10 @@ export function clampWindowPosition(next: Pick<OsWindowState, 'x' | 'y' | 'width
   const width = Math.min(Math.max(MIN_WINDOW_WIDTH, next.width), maxWidth)
   const height = Math.min(Math.max(MIN_WINDOW_HEIGHT, next.height), maxHeight)
   const maxX = Math.max(DESKTOP_EDGE_PADDING, window.innerWidth - width - DESKTOP_EDGE_PADDING)
-  const maxY = Math.max(OS_TOP_BAR_HEIGHT, window.innerHeight - OS_TOP_BAR_HEIGHT)
+  const maxY = Math.max(
+    OS_TOP_BAR_HEIGHT,
+    window.innerHeight - height - DOCK_RESERVED_HEIGHT - DESKTOP_EDGE_PADDING,
+  )
   return {
     width,
     height,

--- a/apps/web/src/pages/os-experiment/window-content.tsx
+++ b/apps/web/src/pages/os-experiment/window-content.tsx
@@ -123,6 +123,8 @@ export function OsBuiltinWindowContent({
         embedded
         collapsibleSidebar
         hideFooter
+        initialNodeId={item.workspaceNode?.id}
+        initialPath={item.workspaceNode?.path}
         onOpenFile={onOpenWorkspaceFile}
         onPinFileToDesktop={onPinWorkspaceFile}
       />

--- a/integrations/flash/src/client/api.ts
+++ b/integrations/flash/src/client/api.ts
@@ -48,6 +48,7 @@ const shadowApp = createShadowServerAppRuntimeClient({ appKey: shadowServerAppMa
 
 export interface FlashOAuthSession {
   configured: boolean
+  required: boolean
   authenticated: boolean
   profile: {
     id: string
@@ -391,7 +392,6 @@ export function subscribeBoard(
   options: SubscribeBoardOptions = {},
 ) {
   const launchToken = shadowLaunchToken()
-  if (!isLocalDevMode() && !launchToken) return () => undefined
 
   const reconnect = options.reconnect !== false
   const retryMs = Math.max(250, options.retryMs ?? 1200)

--- a/integrations/flash/src/client/app.tsx
+++ b/integrations/flash/src/client/app.tsx
@@ -274,14 +274,15 @@ function useBoardSnapshot(enabled: boolean) {
 export function FlashApp() {
   const queryClient = useQueryClient()
   const accessMode = flashAccessMode()
-  const oauthRequired = accessMode !== 'local-dev'
+  const oauthGateEnabled = accessMode !== 'local-dev'
   const { data: oauthSession, isLoading: oauthLoading } = useQuery({
     queryKey: ['flash-oauth-session', accessMode],
     queryFn: getOAuthSession,
-    enabled: oauthRequired,
+    enabled: oauthGateEnabled,
     retry: false,
   })
-  const oauthReady = !oauthRequired || oauthSession?.authenticated === true
+  const oauthRequired = oauthGateEnabled && oauthSession?.required !== false
+  const oauthReady = !oauthGateEnabled || oauthSession?.authenticated === true
   const authorized = accessMode !== 'unauthorized' && oauthReady
   const { snapshot, isLoading, error, refetch } = useBoardSnapshot(authorized)
   const snapshotRef = useRef<FlashBoardSnapshot | null>(null)
@@ -862,7 +863,7 @@ export function FlashApp() {
     return () => window.removeEventListener('keydown', handler)
   }, [commandOpen, runCardCommand])
 
-  if (oauthRequired && oauthLoading) {
+  if (oauthGateEnabled && oauthLoading) {
     return <main className="flash-canvas-shell flash-center">Checking authorization...</main>
   }
 

--- a/integrations/flash/src/server/app.ts
+++ b/integrations/flash/src/server/app.ts
@@ -7,6 +7,7 @@ import {
   hasShadowServerAppPendingOutbox,
   introspectShadowServerAppLaunchToken,
   resolveShadowServerAppLaunchCommandContext,
+  type ShadowServerAppCommandContext,
 } from '@shadowob/sdk'
 import { type Context, Hono } from 'hono'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
@@ -30,6 +31,7 @@ import { FlashScriptEngine } from '../service/script-engine.js'
 import { shellPage } from '../ui.js'
 
 const FLASH_OAUTH_SESSION_COOKIE = 'flash_oauth_session'
+const iconCacheControl = 'public, max-age=3600'
 
 interface FlashOAuthSession {
   profile: {
@@ -99,9 +101,69 @@ function runtimeError(status: number, message: string) {
   return Object.assign(new Error(message), { status })
 }
 
+function commandDefinition(command: string) {
+  return manifest().commands.find((item) => item.name === command)
+}
+
+function standaloneOwnerUserId(session: FlashOAuthSession | null) {
+  return session?.profile.id ?? 'flash-local'
+}
+
+function standaloneRuntimeContext(
+  command: string,
+  session: FlashOAuthSession | null,
+): ShadowServerAppCommandContext {
+  const definition = commandDefinition(command)
+  const profile = session?.profile
+  return {
+    protocol: 'shadow.app/1',
+    serverId: 'local',
+    serverAppId: 'flash-standalone',
+    appKey: manifest().appKey,
+    command,
+    actor: profile
+      ? {
+          kind: 'user',
+          userId: profile.id,
+          ownerId: profile.id,
+          profile: {
+            id: profile.id,
+            username: profile.username ?? null,
+            displayName: profile.displayName ?? profile.username ?? profile.id,
+            avatarUrl: profile.avatarUrl ?? null,
+          },
+        }
+      : {
+          kind: 'local',
+          userId: null,
+          ownerId: 'flash-local',
+          profile: {
+            id: 'flash-local',
+            displayName: 'Local Flash',
+            avatarUrl: null,
+          },
+        },
+    permission: definition?.permission ?? 'flash.boards:read',
+    action: definition?.action ?? 'read',
+    dataClass: definition?.dataClass ?? 'server-private',
+  }
+}
+
+function requireStandaloneRuntimeContext(command: string, c: Context) {
+  const config = oauthConfig()
+  const session = config.configured
+    ? readOauthSession(getCookie(c, FLASH_OAUTH_SESSION_COOKIE))
+    : null
+  if (flashOAuthRequired()) {
+    if (!config.configured) throw runtimeError(503, 'oauth_not_configured')
+    if (!session) throw runtimeError(401, 'oauth_required')
+  }
+  return standaloneRuntimeContext(command, session)
+}
+
 async function runtimeContext(command: string, c: Context) {
   const launchToken = shadowLaunchToken(c)
-  if (!launchToken) throw runtimeError(401, 'launch_required')
+  if (!launchToken) return requireStandaloneRuntimeContext(command, c)
   const context = await resolveShadowServerAppLaunchCommandContext({
     launchToken,
     commandName: command,
@@ -145,6 +207,10 @@ function cookieSecret() {
     process.env.FLASH_OAUTH_CLIENT_SECRET ??
     'flash-local-oauth-cookie-secret'
   )
+}
+
+function flashOAuthRequired() {
+  return process.env.FLASH_REQUIRE_OAUTH === 'true'
 }
 
 function base64Url(input: string | Buffer) {
@@ -298,7 +364,12 @@ export async function createFlashApp() {
 
   app.use('*', errorMiddleware)
   app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
-  app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
+  app.get('/assets/icon.svg', (c) =>
+    c.text(iconSvg(), 200, {
+      'Content-Type': 'image/svg+xml',
+      'Cache-Control': iconCacheControl,
+    }),
+  )
   app.get('/assets/cover.png', serveStatic({ root: './public' }))
   app.get('/assets/*', serveStatic({ root: './dist/client' }))
   app.get('/uploads/:name', async (c) => {
@@ -314,13 +385,16 @@ export async function createFlashApp() {
   app.get('/api/oauth/session', (c) => {
     const returnTo = safeReturnTo(c.req.query('return_to'))
     const popup = c.req.query('popup') === '1'
+    const config = oauthConfig()
+    const required = flashOAuthRequired()
     const session = readOauthSession(getCookie(c, FLASH_OAUTH_SESSION_COOKIE))
     if (!session) deleteCookie(c, FLASH_OAUTH_SESSION_COOKIE, { path: '/' })
     return c.json({
-      configured: oauthConfig().configured,
-      authenticated: Boolean(session),
+      configured: config.configured,
+      required,
+      authenticated: Boolean(session) || !required,
       profile: session?.profile ?? null,
-      authorizeUrl: session ? null : oauthAuthorizeUrl(returnTo, { popup }),
+      authorizeUrl: session || !config.configured ? null : oauthAuthorizeUrl(returnTo, { popup }),
     })
   })
 
@@ -403,16 +477,29 @@ export async function createFlashApp() {
     const afterCursor = Number.isFinite(after) && after > 0 ? after : 0
     if (!localCommandsEnabled) {
       const launchToken = c.req.query('shadow_launch') ?? ''
+      const config = oauthConfig()
+      const session = config.configured
+        ? readOauthSession(getCookie(c, FLASH_OAUTH_SESSION_COOKIE))
+        : null
       const launch = launchToken
         ? await introspectShadowServerAppLaunchToken({
             launchToken,
             shadowApiBaseUrl: shadowApiBaseUrl(),
           })
         : null
-      const actorOwner = launch?.shadow?.actor.ownerId ?? launch?.shadow?.actor.userId ?? null
+      if (launchToken && !launch?.shadow) {
+        return c.json({ ok: false, error: 'invalid_launch_token' }, 401)
+      }
       const board = await boards.findById(boardId)
-      if (!launch || !board || !actorOwner) return c.json({ ok: false, error: 'unauthorized' }, 401)
-      if (board.serverId !== launch.shadow!.serverId || board.ownerUserId !== actorOwner) {
+      const actorOwner = launch?.shadow
+        ? (launch.shadow.actor.ownerId ?? launch.shadow.actor.userId ?? null)
+        : standaloneOwnerUserId(session)
+      const serverId = launch?.shadow?.serverId ?? 'local'
+      if (flashOAuthRequired() && (!config.configured || !session) && !launch?.shadow) {
+        return c.json({ ok: false, error: 'unauthorized' }, 401)
+      }
+      if (!board || !actorOwner) return c.json({ ok: false, error: 'unauthorized' }, 401)
+      if (board.serverId !== serverId || board.ownerUserId !== actorOwner) {
         return c.json({ ok: false, error: 'forbidden' }, 403)
       }
     }

--- a/integrations/kanban/src/client/auth-gate.test.tsx
+++ b/integrations/kanban/src/client/auth-gate.test.tsx
@@ -40,21 +40,21 @@ describe('AuthGate', () => {
     ).toBe(true)
   })
 
-  it('does not grant board access when the launch context is missing', () => {
+  it('grants standalone board access when OAuth is optional and launch is missing', () => {
     expect(
       hasKanbanBoardAccess({
         configured: false,
         required: false,
-        authenticated: false,
+        authenticated: true,
         launchAuthenticated: false,
         oauthAuthenticated: false,
-        reason: 'launch_required',
+        reason: null,
         subject: null,
         profile: null,
         authorizeUrl: null,
         launch: null,
       }),
-    ).toBe(false)
+    ).toBe(true)
   })
 
   it('does not grant board access without an authenticated OAuth session', () => {
@@ -138,14 +138,14 @@ describe('AuthGate', () => {
     expect(html).not.toContain('Connect Shadow')
   })
 
-  it('does not offer OAuth when the launch context is missing', () => {
+  it('offers OAuth when standalone access requires a user session', () => {
     const session: KanbanOAuthSession = {
       configured: true,
       required: true,
       authenticated: false,
       launchAuthenticated: false,
       oauthAuthenticated: false,
-      reason: 'launch_required',
+      reason: 'oauth_required',
       subject: null,
       profile: null,
       authorizeUrl: 'https://shadow.test/oauth',
@@ -163,9 +163,8 @@ describe('AuthGate', () => {
       />,
     )
 
-    expect(canAuthorizeKanbanOAuth(session)).toBe(false)
-    expect(html).toContain('Refresh Shadow to reopen Kanban')
-    expect(html).not.toContain('Connect Shadow')
+    expect(canAuthorizeKanbanOAuth(session)).toBe(true)
+    expect(html).toContain('Connect Shadow')
   })
 
   it('renders the Buddy owner mismatch gate with a retry action', () => {

--- a/integrations/kanban/src/client/components/auth-gate.tsx
+++ b/integrations/kanban/src/client/components/auth-gate.tsx
@@ -9,7 +9,6 @@ export function hasKanbanBoardAccess(session: KanbanOAuthSession | null | undefi
 export function canAuthorizeKanbanOAuth(session: KanbanOAuthSession | null | undefined) {
   return (
     Boolean(session?.authorizeUrl) &&
-    session?.launchAuthenticated === true &&
     session?.oauthAuthenticated !== true &&
     (session?.reason === 'oauth_required' ||
       session?.reason === 'oauth_identity_mismatch' ||

--- a/integrations/kanban/src/oauth-access.test.ts
+++ b/integrations/kanban/src/oauth-access.test.ts
@@ -106,7 +106,7 @@ describe('Kanban OAuth access model', () => {
     })
   })
 
-  it('still requires a Shadow launch when local commands are disabled', () => {
+  it('allows standalone runtime access when OAuth is optional and no launch exists', () => {
     const status = kanbanOAuthAccessStatus({
       configured: false,
       required: false,
@@ -115,10 +115,31 @@ describe('Kanban OAuth access model', () => {
     })
 
     expect(status).toMatchObject({
-      authenticated: false,
+      authenticated: true,
       launchAuthenticated: false,
       oauthAuthenticated: false,
-      reason: 'launch_required',
+      reason: null,
+    })
+  })
+
+  it('allows standalone OAuth access when OAuth is required and the session is valid', () => {
+    const status = kanbanOAuthAccessStatus({
+      configured: true,
+      required: true,
+      launch: null,
+      session: {
+        profile: { id: 'owner-user', displayName: 'Owner User' },
+        scope: 'user:read',
+        expiresAt: 9_999_999_999_999,
+      },
+    })
+
+    expect(status).toMatchObject({
+      authenticated: true,
+      launchAuthenticated: false,
+      oauthAuthenticated: true,
+      reason: null,
+      subject: 'owner-user',
     })
   })
 

--- a/integrations/kanban/src/oauth-access.ts
+++ b/integrations/kanban/src/oauth-access.ts
@@ -130,14 +130,48 @@ export function kanbanOAuthAccessStatus(input: {
   const subject = launchOAuthSubject(input.launch)
   const launchAuthenticated = Boolean(input.launch?.shadow)
   if (!launchAuthenticated) {
+    const oauthAuthenticated = Boolean(input.configured && input.session)
+    if (!input.required) {
+      return {
+        configured: input.configured,
+        required: false,
+        authenticated: true,
+        launchAuthenticated: false,
+        oauthAuthenticated,
+        reason: null,
+        subject: input.session?.profile.id ?? null,
+      }
+    }
+    if (!input.configured) {
+      return {
+        configured: false,
+        required: true,
+        authenticated: false,
+        launchAuthenticated: false,
+        oauthAuthenticated: false,
+        reason: 'oauth_not_configured',
+        subject: null,
+      }
+    }
+    if (!input.session) {
+      return {
+        configured: true,
+        required: true,
+        authenticated: false,
+        launchAuthenticated: false,
+        oauthAuthenticated: false,
+        reason: 'oauth_required',
+        subject: null,
+      }
+    }
     return {
       configured: input.configured,
       required: input.required,
-      authenticated: false,
+      authenticated: true,
       launchAuthenticated: false,
-      oauthAuthenticated: false,
-      reason: 'launch_required',
-      subject: null,
+      oauthAuthenticated: true,
+      reason: null,
+      subject: input.session.profile.id,
     }
   }
   const oauthAuthenticated = Boolean(

--- a/integrations/kanban/src/server.ts
+++ b/integrations/kanban/src/server.ts
@@ -259,6 +259,60 @@ function boardPerson(actor: ShadowServerAppActorRef): BoardPerson {
   return shadowServerAppIdentitySnapshot(actor)
 }
 
+function commandDefinition(command: KanbanCommandName) {
+  return shadowServerAppManifest.commands.find((item) => item.name === command)
+}
+
+function standaloneRuntimeContext(
+  command: KanbanCommandName,
+  session: KanbanOAuthSession | null,
+): ShadowServerAppCommandContext {
+  const definition = commandDefinition(command)
+  const profile = session?.profile
+  return {
+    protocol: 'shadow.app/1',
+    serverId: 'local',
+    serverAppId: 'kanban-standalone',
+    appKey: shadowServerAppManifest.appKey,
+    command,
+    actor: profile
+      ? {
+          kind: 'user',
+          userId: profile.id,
+          ownerId: profile.id,
+          profile: {
+            id: profile.id,
+            username: profile.username ?? null,
+            displayName: profile.displayName ?? profile.username ?? profile.id,
+            avatarUrl: profile.avatarUrl ?? null,
+          },
+        }
+      : {
+          kind: 'local',
+          userId: null,
+          ownerId: 'kanban-local',
+          profile: {
+            id: 'kanban-local',
+            displayName: 'Local Kanban',
+            avatarUrl: null,
+          },
+        },
+    permission: definition?.permission ?? 'kanban.boards:read',
+    action: definition?.action ?? 'read',
+    dataClass: definition?.dataClass ?? 'server-private',
+  }
+}
+
+function requireStandaloneRuntimeContext(command: KanbanCommandName, c: Context) {
+  const config = oauthConfig()
+  const session = config.configured ? readRuntimeOAuthSession(c) : null
+  if (runtimeOAuthRequired) {
+    if (!config.configured) throw runtimeHttpError(503, 'oauth_not_configured')
+    if (!session) throw runtimeHttpError(401, 'oauth_required')
+  }
+  return standaloneRuntimeContext(command, session)
+}
+
 async function launchInboxes(c: Context) {
   const token = shadowLaunchToken(c)
   if (!token) {
@@ -302,6 +356,7 @@ const runtimeOAuthRequired = process.env.KANBAN_REQUIRE_OAUTH === 'true'
 const commandNames = new Set<string>(
   shadowServerAppManifest.commands.map((command) => command.name),
 )
+const iconCacheControl = 'public, max-age=3600'
 
 const commands = shadowApp.defineCommands({
   'boards.get': (input, runtime) => ({
@@ -476,7 +531,7 @@ async function runtimeContext(command: KanbanCommandName, c: Context) {
     if (runtimeOAuthRequired) requireRuntimeOAuthSession(c, launchFromContext(context))
     return context
   }
-  throw runtimeHttpError(401, 'launch_required', 'launch_required')
+  return requireStandaloneRuntimeContext(command, c)
 }
 
 function iconSvg() {
@@ -490,7 +545,9 @@ function iconSvg() {
 }
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
-app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
+app.get('/assets/icon.svg', (c) =>
+  c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml', 'Cache-Control': iconCacheControl }),
+)
 app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
 app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 app.get('/artifacts/*', serveStatic({ root: fromAppRoot('data') }))
@@ -516,7 +573,7 @@ app.get('/api/oauth/session', async (c) => {
     session = null
   }
   const canAuthorize =
-    Boolean(config.configured && launch?.shadow) &&
+    Boolean(config.configured) &&
     !access.oauthAuthenticated &&
     (access.reason === 'oauth_required' ||
       access.reason === 'oauth_identity_mismatch' ||

--- a/integrations/qna/src/client/main.tsx
+++ b/integrations/qna/src/client/main.tsx
@@ -1,5 +1,8 @@
 import './styles.css'
-import { shadowServerAppMountedPath } from '@shadowob/sdk/bridge'
+import {
+  createShadowServerAppRuntimeClient,
+  shadowServerAppMountedPath,
+} from '@shadowob/sdk/bridge'
 import {
   QueryClient,
   QueryClientProvider,
@@ -77,6 +80,7 @@ import {
 marked.setOptions({ breaks: true, gfm: true })
 
 const queryClient = new QueryClient()
+const shadowApp = createShadowServerAppRuntimeClient()
 
 declare global {
   interface Window {
@@ -172,12 +176,41 @@ function isSearchablePathname(pathname: string) {
   return isFeedPathname(pathname) && !isReadingOverviewPathname(pathname)
 }
 
+function normalizeServerAppRoutePath(value: string) {
+  const input = value.trim()
+  if (!input) return '/'
+  const withoutHash = input.startsWith('#') ? input.slice(1) : input
+  return withoutHash.startsWith('/') ? withoutHash : `/${withoutHash}`
+}
+
+function ServerAppRouteBridge() {
+  const navigate = useNavigate()
+  const pathname = useRouterState({ select: (state) => state.location.pathname })
+
+  useEffect(() => {
+    shadowApp.routeChanged(pathname || '/')
+  }, [pathname])
+
+  useEffect(
+    () =>
+      shadowApp.onRouteNavigate((path) => {
+        const nextPath = normalizeServerAppRoutePath(path)
+        if (nextPath === pathname) return
+        void navigate({ to: nextPath as never })
+      }),
+    [navigate, pathname],
+  )
+
+  return null
+}
+
 function RootLayout() {
   const pathname = useRouterState({ select: (state) => state.location.pathname })
   const feedRoute = isFeedPathname(pathname)
   useRouteScrollRestoration(pathname)
   return (
     <div className={feedRoute ? 'app appFeed' : 'app appDetail'}>
+      <ServerAppRouteBridge />
       <Header />
       <Outlet />
     </div>

--- a/integrations/qna/src/data.ts
+++ b/integrations/qna/src/data.ts
@@ -98,6 +98,23 @@ function dataFilePath() {
   return resolve(process.env.QNA_DATA_FILE ?? './data/qna.json')
 }
 
+function shadowWebBaseUrl() {
+  return (
+    process.env.SHADOW_WEB_BASE_URL ??
+    process.env.OAUTH_BASE_URL ??
+    process.env.SHADOW_SERVER_URL ??
+    'http://localhost:3000'
+  ).replace(/\/+$/u, '')
+}
+
+function normalizeAvatarUrl(value: unknown) {
+  if (typeof value !== 'string') return null
+  const avatarUrl = value.trim()
+  if (!avatarUrl) return null
+  if (!avatarUrl.startsWith('/')) return avatarUrl
+  return `${shadowWebBaseUrl()}${avatarUrl}`
+}
+
 function isState(value: unknown): value is QnaState {
   return (
     !!value &&
@@ -148,7 +165,7 @@ function normalizePerson(value: unknown, fallback = 'Unknown'): QnaPerson {
     buddyAgentId: typeof candidate.buddyAgentId === 'string' ? candidate.buddyAgentId : null,
     ownerId: typeof candidate.ownerId === 'string' ? candidate.ownerId : null,
     displayName,
-    avatarUrl: typeof candidate.avatarUrl === 'string' ? candidate.avatarUrl : null,
+    avatarUrl: normalizeAvatarUrl(candidate.avatarUrl),
   }
 }
 

--- a/integrations/qna/src/server.test.ts
+++ b/integrations/qna/src/server.test.ts
@@ -6,15 +6,37 @@ describe('QnA runtime auth boundary', () => {
     vi.resetModules()
   })
 
-  it('blocks runtime commands without a launch token', async () => {
+  it('allows public read runtime commands without a launch token', async () => {
+    vi.resetModules()
+    vi.stubEnv('QNA_DATA_FILE', `.tmp/qna-public-read-${Date.now()}.json`)
+
+    const { app } = await import('./server.js')
+    const response = await app.request('/api/runtime/commands/questions.get', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input: { questionId: 'q_server_app_patterns' } }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        question: {
+          id: 'q_server_app_patterns',
+        },
+      },
+    })
+  })
+
+  it('blocks write runtime commands without a launch token', async () => {
     vi.resetModules()
     vi.stubEnv('QNA_DATA_FILE', `.tmp/qna-auth-${Date.now()}.json`)
 
     const { app } = await import('./server.js')
-    const response = await app.request('/api/runtime/commands/questions.list', {
+    const response = await app.request('/api/runtime/commands/questions.ask', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ input: {} }),
+      body: JSON.stringify({ input: { title: 'Who can write?', body: 'launch required' } }),
     })
 
     expect(response.status).toBe(401)

--- a/integrations/qna/src/server.ts
+++ b/integrations/qna/src/server.ts
@@ -10,6 +10,7 @@ import {
   hasShadowServerAppPendingOutbox,
   resolveShadowServerAppLaunchCommandContext,
   type ShadowServerAppActorRef,
+  type ShadowServerAppCommandContext,
   type ShadowServerAppCommandName,
   shadowServerAppIdentitySnapshot,
 } from '@shadowob/sdk'
@@ -52,6 +53,16 @@ const supportedImageTypes = new Set(['image/png', 'image/jpeg', 'image/webp', 'i
 const commandNames = new Set<string>(
   shadowServerAppManifest.commands.map((command) => command.name),
 )
+const publicRuntimeCommands = new Set<QnaCommandName>([
+  'questions.list',
+  'questions.get',
+  'articles.list',
+  'articles.get',
+  'tags.list',
+  'lists.list',
+  'reading.batches',
+])
+const iconCacheControl = 'public, max-age=3600'
 
 const imageId = () => `img_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`
 
@@ -92,7 +103,43 @@ function assetPath(asset: QnaImageAsset) {
 }
 
 function qnaPerson(actor: ShadowServerAppActorRef): QnaPerson {
-  return shadowServerAppIdentitySnapshot(actor)
+  const snapshot = shadowServerAppIdentitySnapshot(actor)
+  if (!snapshot.avatarUrl?.startsWith('/')) return snapshot
+  const shadowWebBaseUrl = (
+    process.env.SHADOW_WEB_BASE_URL ??
+    process.env.OAUTH_BASE_URL ??
+    process.env.SHADOW_SERVER_URL ??
+    'http://localhost:3000'
+  ).replace(/\/+$/u, '')
+  return { ...snapshot, avatarUrl: `${shadowWebBaseUrl}${snapshot.avatarUrl}` }
+}
+
+function commandDefinition(command: QnaCommandName) {
+  return shadowServerAppManifest.commands.find((item) => item.name === command)
+}
+
+function publicRuntimeContext(command: QnaCommandName): ShadowServerAppCommandContext {
+  const definition = commandDefinition(command)
+  return {
+    protocol: 'shadow.app/1',
+    serverId: 'public',
+    serverAppId: 'answers-public',
+    appKey: shadowServerAppManifest.appKey,
+    command,
+    actor: {
+      kind: 'local',
+      userId: null,
+      ownerId: 'qna-public',
+      profile: {
+        id: 'qna-public',
+        displayName: 'Public reader',
+        avatarUrl: null,
+      },
+    },
+    permission: definition?.permission ?? 'qna.questions:read',
+    action: definition?.action ?? 'read',
+    dataClass: definition?.dataClass ?? 'public',
+  }
 }
 
 async function runtimeContext(command: QnaCommandName, c: Context) {
@@ -107,6 +154,7 @@ async function runtimeContext(command: QnaCommandName, c: Context) {
     if (!context) throw Object.assign(new Error('invalid_launch_token'), { status: 401 })
     return context
   }
+  if (publicRuntimeCommands.has(command)) return publicRuntimeContext(command)
   throw Object.assign(new Error('launch_required'), { status: 401 })
 }
 
@@ -257,7 +305,9 @@ const commands = shadowApp.defineCommands({
 })
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
-app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
+app.get('/assets/icon.svg', (c) =>
+  c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml', 'Cache-Control': iconCacheControl }),
+)
 app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
 app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 app.get('/shadow/server', (c) => c.html(shellPage()))

--- a/integrations/quiz/src/server.ts
+++ b/integrations/quiz/src/server.ts
@@ -32,6 +32,7 @@ const port = Number(process.env.PORT ?? 4211)
 const commandNames = new Set<string>(
   shadowServerAppManifest.commands.map((command) => command.name),
 )
+const iconCacheControl = 'public, max-age=3600'
 
 function shadowApiBaseUrl() {
   return (process.env.SHADOW_SERVER_URL ?? 'http://localhost:3002').replace(/\/+$/u, '')
@@ -110,7 +111,9 @@ function iconSvg() {
 }
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
-app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
+app.get('/assets/icon.svg', (c) =>
+  c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml', 'Cache-Control': iconCacheControl }),
+)
 app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
 app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 app.get('/shadow/server', (c) => c.html(shellPage()))

--- a/integrations/runtime/src/server.ts
+++ b/integrations/runtime/src/server.ts
@@ -324,7 +324,10 @@ function withRuntimeCacheHeaders(request: Request, response: Response) {
   if (!isHtml && !isAppAsset) return response
 
   const headers = new Headers(response.headers)
-  headers.set('cache-control', 'no-store')
+  headers.set(
+    'cache-control',
+    isAppAsset ? 'public, max-age=300, stale-while-revalidate=86400' : 'no-store',
+  )
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/integrations/skills/src/server.ts
+++ b/integrations/skills/src/server.ts
@@ -34,6 +34,7 @@ type SkillsCommandName = ShadowServerAppCommandName<typeof shadowServerAppManife
 
 const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+const iconCacheControl = 'public, max-age=3600'
 
 function shadowApiBaseUrl() {
   return (process.env.SHADOW_SERVER_URL ?? 'http://localhost:3002').replace(/\/$/, '')
@@ -321,7 +322,9 @@ function iconSvg() {
 }
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
-app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
+app.get('/assets/icon.svg', (c) =>
+  c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml', 'Cache-Control': iconCacheControl }),
+)
 app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
 app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 app.get('/shadow/server', (c) => c.html(shellPage()))

--- a/integrations/space/src/server.ts
+++ b/integrations/space/src/server.ts
@@ -39,6 +39,7 @@ const dao = new SpaceDao(database.db)
 const commandNames = new Set<string>(
   shadowServerAppManifest.commands.map((command) => command.name),
 )
+const iconCacheControl = 'public, max-age=3600'
 
 function shadowApiBaseUrl() {
   return (process.env.SHADOW_SERVER_URL ?? 'http://localhost:3002').replace(/\/+$/u, '')
@@ -334,7 +335,9 @@ async function servePreview(c: Context) {
 }
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
-app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
+app.get('/assets/icon.svg', (c) =>
+  c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml', 'Cache-Control': iconCacheControl }),
+)
 app.get('/assets/cover.png', serveStatic({ root: './public' }))
 app.get('/assets/*', serveStatic({ root: './dist/client' }))
 app.get('/api/oauth/session', (c) => c.json(oauthSessionPayload(c)))

--- a/integrations/trainer/src/server.ts
+++ b/integrations/trainer/src/server.ts
@@ -56,6 +56,7 @@ type TrainerCommandName = ShadowServerAppCommandName<typeof shadowServerAppManif
 
 const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+const iconCacheControl = 'public, max-age=3600'
 
 function shadowApiBaseUrl() {
   return (process.env.SHADOW_SERVER_URL ?? 'http://localhost:3002').replace(/\/$/, '')
@@ -763,7 +764,9 @@ async function proxyViteDevAsset(requestUrl: string) {
 }
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
-app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
+app.get('/assets/icon.svg', (c) =>
+  c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml', 'Cache-Control': iconCacheControl }),
+)
 app.get('/@fs/*', async (c) => (await proxyViteDevAsset(c.req.url)) ?? c.notFound())
 app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
 app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))

--- a/integrations/warbuddy/src/server.ts
+++ b/integrations/warbuddy/src/server.ts
@@ -48,6 +48,7 @@ type WarbuddyCommandName = ShadowServerAppCommandName<typeof shadowServerAppMani
 
 const appRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const fromAppRoot = (...segments: string[]) => resolve(appRoot, ...segments)
+const iconCacheControl = 'public, max-age=3600'
 
 function shadowApiBaseUrl() {
   return (process.env.SHADOW_SERVER_URL ?? 'http://localhost:3002').replace(/\/$/, '')
@@ -356,7 +357,9 @@ function errorResponse(c: Context, error: unknown) {
 }
 
 app.get('/.well-known/shadow-app.json', (c) => c.json(manifest()))
-app.get('/assets/icon.svg', (c) => c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml' }))
+app.get('/assets/icon.svg', (c) =>
+  c.text(iconSvg(), 200, { 'Content-Type': 'image/svg+xml', 'Cache-Control': iconCacheControl }),
+)
 app.get('/assets/cover.png', serveStatic({ root: fromAppRoot('public') }))
 app.get('/assets/*', serveStatic({ root: fromAppRoot('dist/client') }))
 if (process.env.WARBUDDY_VITE_DEV_SERVER_URL) {

--- a/website/env.d.ts
+++ b/website/env.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const classes: Record<string, string>
+  export default classes
+}

--- a/website/package.json
+++ b/website/package.json
@@ -7,6 +7,7 @@
     "dev:frontend": "rspress dev --port 3010",
     "build": "rspress build",
     "preview": "rspress preview",
+    "typecheck": "tsc --noEmit",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -31,6 +31,11 @@ function configuredAppBase() {
   )
 }
 
+function configuredAppOrigin() {
+  if (typeof window === 'undefined') return ''
+  return new URL(configuredAppBase() || window.location.origin, window.location.origin).origin
+}
+
 function formatI18n(template: string, values: Record<string, string | number>) {
   return template.replace(/\{(\w+)\}/g, (match, key) => String(values[key] ?? match))
 }

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -7,5 +7,13 @@
     "esModuleInterop": true,
     "jsx": "react-jsx"
   },
-  "include": ["rspress.config.ts"]
+  "include": [
+    "env.d.ts",
+    "rspress.config.ts",
+    "components/**/*.ts",
+    "components/**/*.tsx",
+    "lib/**/*.ts",
+    "theme/**/*.ts",
+    "theme/**/*.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary

Fixes the post-deploy Server App and OS-mode regressions reported on June 24:

- restore standalone Server App behavior for QnA, Kanban, and Flash without forcing Shadow-authenticated entry points for public/read-only flows
- keep Server Apps iframe-first: app data continues to use each integration's own APIs; the Shadow bridge is used only for launch, profile context, and OS navigation/back behavior
- fix OS window persistence issues, including channel tabs, minimized windows, app routes, app install/open flow, centered iframe loading state, dock/stack sizing, workspace folder targeting, and global presence state
- fix PDF worker delivery by serving `.mjs` assets as JavaScript from the web Nginx config
- remove duplicated per-integration static cache middleware and keep only centralized/runtime fallback cache headers
- add website TypeScript coverage for the Rspress theme/components/lib entry points so missing runtime symbols are caught by workspace typecheck

## Reported Issues Review

- Website React error after deploy: fixed missing website app-origin helper; current production still serves the old `index.b646ec1d.js` bundle until this PR is deployed.
- Public QnA links returning 401: fixed public read runtime context; writes still require authorization.
- Kanban OAuth/authorization unavailable: fixed optional standalone OAuth/session handling.
- Flash blocked by missing OAuth config: OAuth is now opt-in via `FLASH_REQUIRE_OAUTH=true`.
- OS app iframe loading spinner: centered in the app window.
- OS stack menu overflow: capped height with scrolling.
- Dock server-app icon size: normalized to the dock icon frame.
- Integration static cache: removed redundant app-level cache code; see ops note below.
- Workspace folder open: workspace window now opens/expands to the target folder.
- OS online status: now follows global presence state.
- OS windows crossing Dock: clamped against the Dock reserved area.
- OS tabs not remembered: persisted/restored with server OS window state v2.
- PDF preview worker failure: `.mjs` now receives JavaScript MIME from web Nginx.
- Server settings jumping back to Basic: fixed tab reset behavior while installing apps.
- Installed app should open: install success now opens the app window.
- App-window back shortcut: added OS route bridge and QnA route integration.
- Inbox realtime freshness: invalidates inbox queries on notification/message socket events.
- Hidden/minimized windows reappearing: minimized state is preserved on restore.
- QnA Buddy avatar: launch/profile avatar URLs are normalized to absolute Shadow URLs.
- Server App independent iframe principle: app data APIs remain integration-local; only bridge concerns cross into Shadow.

## Why Typecheck/Biome Missed the Website Crash

`@shadowob/website` previously had no `typecheck` script, and its `tsconfig.json` only included `rspress.config.ts`. That meant `website/theme/index.tsx` was linted/formatted but not TypeScript-checked as part of `pnpm typecheck`. Biome does not perform TypeScript symbol resolution, so an undefined runtime symbol could pass Biome. This PR adds website theme/components/lib TS coverage to close that gap.

## Ops Note

Integration asset caching is currently controlled by the host Nginx on `root@8.219.68.2`, not by this repository's deployment workflow. The existing integration deploy script only updates compose config/images and does not sync Nginx config, so any production change to integration asset cache policy must either be applied manually on the host or added to the ops deployment pipeline in a separate change.

## Validation

- GitHub PR checks are the source of truth for this submission.
- Branch was rebased against the current `origin/main` before opening the PR.
