### PR TITLE
fix(cloud): isolate provisioned buddies and runner image defaults

### DIFF
--- a/apps/cloud/__tests__/clients/kubectl-runtime.test.ts
+++ b/apps/cloud/__tests__/clients/kubectl-runtime.test.ts
@@ -19,6 +19,7 @@ vi.mock('node:child_process', async () => {
 
 import { getAgentSandboxDeployments } from '../../src/clients/kubectl-client'
 import {
+  checkAgentSandboxPreflight,
   getPvcVolumeSnapshotCapability,
   isPvcBackedByCsiProvisioner,
   isVolumeSnapshotApiAvailable,
@@ -368,6 +369,48 @@ users:
     mockAsyncKubectl('')
 
     await expect(isVolumeSnapshotApiAvailable()).resolves.toBe(false)
+  })
+
+  it('accepts fully-qualified agent sandbox api resource names during preflight', () => {
+    execFileSyncMock
+      .mockReturnValueOnce(
+        'sandboxclaims.extensions.agents.x-k8s.io\nsandboxtemplates.extensions.agents.x-k8s.io\n',
+      )
+      .mockReturnValueOnce('sandboxes.agents.x-k8s.io\n')
+      .mockReturnValueOnce(JSON.stringify({ status: { availableReplicas: 1 } }))
+      .mockReturnValueOnce(JSON.stringify({ items: [{ metadata: { name: 'gvisor' } }] }))
+
+    expect(checkAgentSandboxPreflight({ runtimeClassName: 'gvisor' })).toEqual({
+      ok: true,
+      missing: [],
+      warnings: [],
+      runtimeClassName: 'gvisor',
+      runtimeClassNames: ['gvisor'],
+    })
+  })
+
+  it('falls back to CRD lookup when api resource discovery omits agent sandbox resources', () => {
+    execFileSyncMock
+      .mockReturnValueOnce('')
+      .mockReturnValueOnce('sandboxtemplates.extensions.agents.x-k8s.io')
+      .mockReturnValueOnce('sandboxclaims.extensions.agents.x-k8s.io')
+      .mockReturnValueOnce('')
+      .mockReturnValueOnce('sandboxes.agents.x-k8s.io')
+      .mockReturnValueOnce(JSON.stringify({ status: { availableReplicas: 1 } }))
+      .mockReturnValueOnce('runtimeclass.node.k8s.io/gvisor')
+      .mockReturnValueOnce('node/shadow-worker-1')
+
+    expect(checkAgentSandboxPreflight({ runtimeClassName: 'gvisor' })).toMatchObject({
+      ok: true,
+      missing: [],
+      warnings: [],
+      runtimeClassName: 'gvisor',
+    })
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'kubectl',
+      expect.arrayContaining(['get', 'crd', 'sandboxtemplates.extensions.agents.x-k8s.io']),
+      expect.anything(),
+    )
   })
 
   it('detects PVCs backed by CSI storage classes', async () => {

--- a/apps/cloud/__tests__/provisioning/provisioning.test.ts
+++ b/apps/cloud/__tests__/provisioning/provisioning.test.ts
@@ -121,6 +121,88 @@ describe('provisioning', () => {
       })
     })
 
+    it('does not reuse same-name buddies from another deployment scope', async () => {
+      const config: CloudConfig = {
+        version: '1',
+        use: [
+          {
+            plugin: 'shadowob',
+            options: {
+              buddies: [{ id: 'strategy-buddy', name: 'Strategy Buddy' }],
+            },
+          },
+        ],
+      }
+
+      shadowClientMocks.listAgents.mockResolvedValue([
+        {
+          id: 'old-scoped-agent',
+          name: 'Strategy Buddy',
+          status: 'running',
+          botUser: {
+            username: 'strategy-buddy',
+            displayName: 'Strategy Buddy',
+          },
+          config: {
+            shadowob: {
+              buddyId: 'strategy-buddy',
+              scopeKey: 'deployment:old-deployment',
+              deploymentId: 'old-deployment',
+            },
+          },
+        },
+      ])
+      shadowClientMocks.createAgent.mockResolvedValue({
+        id: 'new-scoped-agent',
+        userId: 'new-scoped-user',
+      })
+      shadowClientMocks.generateAgentToken.mockResolvedValue({ token: 'new-scoped-token' })
+
+      const result = await provisionShadowResources(config, {
+        serverUrl: 'http://shadow.local',
+        userToken: 'user-token',
+        scope: {
+          deploymentId: 'new-deployment',
+          namespace: 'buddy-cloud-strategy-new',
+        },
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          success: vi.fn(),
+          step: vi.fn(),
+          dim: vi.fn(),
+        },
+      })
+
+      expect(shadowClientMocks.updateAgent).not.toHaveBeenCalledWith(
+        'old-scoped-agent',
+        expect.anything(),
+      )
+      expect(shadowClientMocks.createAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Strategy Buddy',
+          username: expect.stringMatching(/^strategy-buddy-[a-f0-9]{8}$/),
+          config: {
+            shadowob: {
+              buddyId: 'strategy-buddy',
+              scopeKey: 'deployment:new-deployment',
+              deploymentId: 'new-deployment',
+              namespace: 'buddy-cloud-strategy-new',
+            },
+          },
+        }),
+      )
+      expect(result.buddies.get('strategy-buddy')).toEqual({
+        agentId: 'new-scoped-agent',
+        userId: 'new-scoped-user',
+        token: 'new-scoped-token',
+        scopeKey: 'deployment:new-deployment',
+        deploymentId: 'new-deployment',
+        namespace: 'buddy-cloud-strategy-new',
+      })
+    })
+
     it('installs catalog Server Apps and grants them to provisioned buddies', async () => {
       const config: CloudConfig = {
         version: '1',
@@ -702,6 +784,7 @@ describe('provisioning', () => {
       )
 
       expect(env.SHADOWOB_SERVER_URL).toBe('https://shadow.example.com')
+      expect(env.SHADOWOB_AGENT_ID).toBe('real-agent-id')
       expect(env.SHADOWOB_TOKEN_BOT_1).toBe('token-abc123')
     })
 

--- a/apps/cloud/__tests__/runtimes/runtimes.test.ts
+++ b/apps/cloud/__tests__/runtimes/runtimes.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import '../../src/runtimes/loader.js'
 import { DEFAULT_RUNNER_IMAGE_TAG } from '../../src/runtimes/images.js'
 import { getAllRuntimes, getRuntime, getRuntimeIds } from '../../src/runtimes/index.js'
@@ -65,6 +65,50 @@ describe('Runtime registry', () => {
       expect(shape.packages).toBeUndefined()
       expect(shape.requiresGit).toBeUndefined()
       expect(typeof adapter.buildPackage).toBe('function')
+    }
+  })
+})
+
+describe('Runner image defaults', () => {
+  it('ignores blank per-runtime image overrides', async () => {
+    const originalHermesRunnerImage = process.env.SHADOWOB_HERMES_RUNNER_IMAGE
+    const originalRunnerImageTag = process.env.SHADOWOB_RUNNER_IMAGE_TAG
+    const originalImageTag = process.env.SHADOWOB_IMAGE_TAG
+
+    try {
+      process.env.SHADOWOB_HERMES_RUNNER_IMAGE = ''
+      process.env.SHADOWOB_RUNNER_IMAGE_TAG = 'sha-runner-test'
+      delete process.env.SHADOWOB_IMAGE_TAG
+      vi.resetModules()
+
+      const { defaultRunnerImage } = await import('../../src/runtimes/images.js')
+
+      expect(
+        defaultRunnerImage({
+          runner: 'hermes-runner',
+          env: 'SHADOWOB_HERMES_RUNNER_IMAGE',
+        }),
+      ).toBe('ghcr.io/buggyblues/hermes-runner:sha-runner-test')
+    } finally {
+      if (originalHermesRunnerImage === undefined) {
+        delete process.env.SHADOWOB_HERMES_RUNNER_IMAGE
+      } else {
+        process.env.SHADOWOB_HERMES_RUNNER_IMAGE = originalHermesRunnerImage
+      }
+
+      if (originalRunnerImageTag === undefined) {
+        delete process.env.SHADOWOB_RUNNER_IMAGE_TAG
+      } else {
+        process.env.SHADOWOB_RUNNER_IMAGE_TAG = originalRunnerImageTag
+      }
+
+      if (originalImageTag === undefined) {
+        delete process.env.SHADOWOB_IMAGE_TAG
+      } else {
+        process.env.SHADOWOB_IMAGE_TAG = originalImageTag
+      }
+
+      vi.resetModules()
     }
   })
 })

--- a/apps/cloud/__tests__/services/deploy.service.test.ts
+++ b/apps/cloud/__tests__/services/deploy.service.test.ts
@@ -290,6 +290,7 @@ describe('DeployService', () => {
     } as CloudConfig
     const deploymentCalls: string[] = []
     const agentCalls: string[] = []
+    const deploymentProvisionContexts: Array<{ deploymentId?: string; namespace?: string }> = []
 
     const deploymentPlugin = defineSkillPlugin(
       makeProvisionPluginManifest('deployment-provision'),
@@ -297,6 +298,10 @@ describe('DeployService', () => {
       (api) => {
         api.onProvision(async (ctx) => {
           deploymentCalls.push(ctx.agent.id)
+          deploymentProvisionContexts.push({
+            deploymentId: ctx.secrets.SHADOWOB_CLOUD_DEPLOYMENT_ID,
+            namespace: ctx.secrets.SHADOWOB_CLOUD_NAMESPACE,
+          })
           return {
             state: { ok: true },
             secrets: { SHARED_TOKEN: 'shared-token' },
@@ -355,10 +360,19 @@ describe('DeployService', () => {
       filePath,
       shadowUrl: 'http://server:3002',
       shadowToken: 'pat_test',
+      runtimeEnvVars: {
+        SHADOWOB_CLOUD_DEPLOYMENT_ID: '00000000-0000-4000-8000-000000000001',
+      },
     })
 
     const [agentA, agentB] = config.deployments!.agents
     expect(deploymentCalls).toEqual(['agent-a'])
+    expect(deploymentProvisionContexts).toEqual([
+      {
+        deploymentId: '00000000-0000-4000-8000-000000000001',
+        namespace: 'scoped-provision',
+      },
+    ])
     expect(agentCalls).toEqual(['agent-a', 'agent-b'])
     expect(agentA!.env).toMatchObject({
       SHARED_TOKEN: 'shared-token',

--- a/apps/cloud/__tests__/utils/state.test.ts
+++ b/apps/cloud/__tests__/utils/state.test.ts
@@ -177,7 +177,19 @@ describe('State Utilities', () => {
       const result: ProvisionResult = {
         servers: new Map([['srv-config', 'srv_real']]),
         channels: new Map([['ch-config', 'ch_real']]),
-        buddies: new Map([['buddy-config', { agentId: 'ag1', userId: 'u1', token: 't1' }]]),
+        buddies: new Map([
+          [
+            'buddy-config',
+            {
+              agentId: 'ag1',
+              userId: 'u1',
+              token: 't1',
+              scopeKey: 'deployment:dep1',
+              deploymentId: 'dep1',
+              namespace: 'shadowob-cloud',
+            },
+          ],
+        ]),
       }
 
       const state = provisionResultToState(result, 'https://shadow.example.com', {
@@ -189,13 +201,26 @@ describe('State Utilities', () => {
         shadowServerUrl?: string
         servers?: Record<string, string>
         channels?: Record<string, string>
-        buddies?: Record<string, { agentId: string; userId: string; token?: string }>
+        buddies?: Record<
+          string,
+          {
+            agentId: string
+            userId: string
+            token?: string
+            scopeKey?: string
+            deploymentId?: string
+            namespace?: string
+          }
+        >
       }
       expect(shadowob.servers).toEqual({ 'srv-config': 'srv_real' })
       expect(shadowob.channels).toEqual({ 'ch-config': 'ch_real' })
       expect(shadowob.buddies?.['buddy-config']).toEqual({
         agentId: 'ag1',
         userId: 'u1',
+        scopeKey: 'deployment:dep1',
+        deploymentId: 'dep1',
+        namespace: 'shadowob-cloud',
       })
       expect(JSON.stringify(state)).not.toContain('t1')
       expect(shadowob.shadowServerUrl).toBe('https://shadow.example.com')
@@ -208,7 +233,19 @@ describe('State Utilities', () => {
       const original: ProvisionResult = {
         servers: new Map([['s1', 'real_s1']]),
         channels: new Map([['c1', 'real_c1']]),
-        buddies: new Map([['b1', { agentId: 'a', userId: 'u', token: 't' }]]),
+        buddies: new Map([
+          [
+            'b1',
+            {
+              agentId: 'a',
+              userId: 'u',
+              token: 't',
+              scopeKey: 'deployment:dep1',
+              deploymentId: 'dep1',
+              namespace: 'ns1',
+            },
+          ],
+        ]),
       }
 
       const state = provisionResultToState(original, 'https://example.com')
@@ -220,6 +257,9 @@ describe('State Utilities', () => {
         agentId: 'a',
         userId: 'u',
         token: '',
+        scopeKey: 'deployment:dep1',
+        deploymentId: 'dep1',
+        namespace: 'ns1',
       })
     })
   })

--- a/apps/cloud/src/clients/kubectl-runtime.ts
+++ b/apps/cloud/src/clients/kubectl-runtime.ts
@@ -222,7 +222,19 @@ function resourceOutputHas(output: string | null, resourceName: string): boolean
     output
       ?.split(/\s+/)
       .map((item) => item.trim())
-      .some((item) => item === resourceName),
+      .some((item) => item === resourceName || item.startsWith(`${resourceName}.`)),
+  )
+}
+
+function apiResourceOrCrdExists(
+  output: string | null,
+  resourceName: string,
+  crdName: string,
+  kubeconfig?: string,
+): boolean {
+  return (
+    resourceOutputHas(output, resourceName) ||
+    Boolean(tryExecKubectl(['get', 'crd', crdName], kubeconfig))
   )
 }
 
@@ -239,10 +251,24 @@ export function checkAgentSandboxPreflight(options?: {
     ['api-resources', '--api-group', 'extensions.agents.x-k8s.io', '-o', 'name'],
     kubeconfig,
   )
-  if (!resourceOutputHas(extensionResources, 'sandboxtemplates')) {
+  if (
+    !apiResourceOrCrdExists(
+      extensionResources,
+      'sandboxtemplates',
+      'sandboxtemplates.extensions.agents.x-k8s.io',
+      kubeconfig,
+    )
+  ) {
     missing.push('CRD sandboxtemplates.extensions.agents.x-k8s.io')
   }
-  if (!resourceOutputHas(extensionResources, 'sandboxclaims')) {
+  if (
+    !apiResourceOrCrdExists(
+      extensionResources,
+      'sandboxclaims',
+      'sandboxclaims.extensions.agents.x-k8s.io',
+      kubeconfig,
+    )
+  ) {
     missing.push('CRD sandboxclaims.extensions.agents.x-k8s.io')
   }
 
@@ -250,7 +276,9 @@ export function checkAgentSandboxPreflight(options?: {
     ['api-resources', '--api-group', 'agents.x-k8s.io', '-o', 'name'],
     kubeconfig,
   )
-  if (!resourceOutputHas(coreResources, 'sandboxes')) {
+  if (
+    !apiResourceOrCrdExists(coreResources, 'sandboxes', 'sandboxes.agents.x-k8s.io', kubeconfig)
+  ) {
     missing.push('CRD sandboxes.agents.x-k8s.io')
   }
 

--- a/apps/cloud/src/infra/agent-pod.test.ts
+++ b/apps/cloud/src/infra/agent-pod.test.ts
@@ -158,6 +158,7 @@ describe('buildAgentPodSpec', () => {
       configMapName: 'app-buddy-config',
       secretName: 'app-buddy-secrets',
       extraEnv: {
+        SHADOWOB_AGENT_ID: '00000000-0000-4000-8000-000000000010',
         SHADOWOB_CLOUD_DEPLOYMENT_ID: '00000000-0000-0000-0000-000000000001',
         SHADOWOB_SERVER_URL: 'https://shadow.example.com',
       },
@@ -170,7 +171,7 @@ describe('buildAgentPodSpec', () => {
     )
     expect(runtime?.env).toEqual(
       expect.arrayContaining([
-        { name: 'SHADOWOB_AGENT_ID', value: 'app-buddy' },
+        { name: 'SHADOWOB_AGENT_ID', value: '00000000-0000-4000-8000-000000000010' },
         { name: 'SHADOWOB_WORKSPACE', value: '/workspace' },
         { name: 'SHADOWOB_EXPOSURE_CONFIG', value: SHADOWOB_EXPOSURE_CONFIG_PATH },
         { name: 'SHADOWOB_EXPOSURE_STATUS', value: SHADOWOB_EXPOSURE_STATUS_PATH },
@@ -187,7 +188,7 @@ describe('buildAgentPodSpec', () => {
     ])
     expect(sidecar?.env).toEqual(
       expect.arrayContaining([
-        { name: 'SHADOWOB_AGENT_ID', value: 'app-buddy' },
+        { name: 'SHADOWOB_AGENT_ID', value: '00000000-0000-4000-8000-000000000010' },
         {
           name: 'SHADOWOB_CLOUD_DEPLOYMENT_ID',
           value: '00000000-0000-0000-0000-000000000001',

--- a/apps/cloud/src/infra/agent-pod.ts
+++ b/apps/cloud/src/infra/agent-pod.ts
@@ -165,7 +165,10 @@ function exposureSidecar(options: {
     command: ['shadowob'],
     args: ['app', 'watch-exposures'],
     env: dedupeEnvVars([
-      { name: 'SHADOWOB_AGENT_ID', value: options.agentName },
+      {
+        name: 'SHADOWOB_AGENT_ID',
+        value: options.extraEnv?.SHADOWOB_AGENT_ID ?? options.agentName,
+      },
       {
         name: 'SHADOWOB_CLOUD_DEPLOYMENT_ID',
         value: options.extraEnv?.SHADOWOB_CLOUD_DEPLOYMENT_ID ?? '',

--- a/apps/cloud/src/plugins/shadowob/index.ts
+++ b/apps/cloud/src/plugins/shadowob/index.ts
@@ -586,7 +586,16 @@ const shadowobPlugin = defineChannelPlugin(manifest as PluginManifest, buildShad
       existingState: context.previousState as {
         servers?: Record<string, string>
         channels?: Record<string, string>
-        buddies?: Record<string, { agentId: string; userId: string }>
+        buddies?: Record<
+          string,
+          {
+            agentId: string
+            userId: string
+            scopeKey?: string
+            deploymentId?: string
+            namespace?: string
+          }
+        >
         serverApps?: Record<string, { serverAppId: string; appKey: string; serverId: string }>
         listings?: Record<string, string>
         commerce?: Record<
@@ -601,6 +610,10 @@ const shadowobPlugin = defineChannelPlugin(manifest as PluginManifest, buildShad
         >
         shadowServerUrl?: string
       } | null,
+      scope: {
+        deploymentId: context.secrets.SHADOWOB_CLOUD_DEPLOYMENT_ID,
+        namespace: context.namespace,
+      },
       logger: context.logger as import('../../utils/logger.js').Logger,
     })
 
@@ -647,7 +660,13 @@ const shadowobPlugin = defineChannelPlugin(manifest as PluginManifest, buildShad
         buddies: Object.fromEntries(
           [...result.buddies.entries()].map(([k, v]) => [
             k,
-            { agentId: v.agentId, userId: v.userId },
+            {
+              agentId: v.agentId,
+              userId: v.userId,
+              ...(v.scopeKey ? { scopeKey: v.scopeKey } : {}),
+              ...(v.deploymentId ? { deploymentId: v.deploymentId } : {}),
+              ...(v.namespace ? { namespace: v.namespace } : {}),
+            },
           ]),
         ),
         ...(result.listings.size > 0 ? { listings: Object.fromEntries(result.listings) } : {}),

--- a/apps/cloud/src/plugins/shadowob/provisioning.ts
+++ b/apps/cloud/src/plugins/shadowob/provisioning.ts
@@ -9,6 +9,7 @@
  * New resources are created and state is merged on each run.
  */
 
+import { createHash } from 'node:crypto'
 import { ShadowClient } from '@shadowob/sdk'
 import type {
   CloudConfig,
@@ -35,11 +36,28 @@ type AccessibleShadowChannel = {
   name?: string | null
 }
 
+type ShadowProvisionScope = {
+  deploymentId?: string
+  namespace?: string
+  scopeKey?: string
+}
+
+type ProvisionedBuddyInfo = {
+  agentId: string
+  token: string
+  userId: string
+  scopeKey?: string
+  deploymentId?: string
+  namespace?: string
+}
+
+type PersistedBuddyInfo = Omit<ProvisionedBuddyInfo, 'token'> & { token?: string }
+
 // The shadowob plugin's per-plugin state blob (stored under plugins.shadowob in ProvisionState)
 type ShadowobState = {
   servers?: Record<string, string>
   channels?: Record<string, string>
-  buddies?: Record<string, { agentId: string; userId: string }>
+  buddies?: Record<string, PersistedBuddyInfo>
   /** buddyId → listingId on the marketplace */
   listings?: Record<string, string>
   /** app config id → provisioned app ids */
@@ -68,10 +86,103 @@ function shadowEnvKey(prefix: string, id: string) {
   return `${prefix}_${id.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}`
 }
 
+function normalizedOptionalText(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed || undefined
+}
+
+function normalizeProvisionScope(scope: ShadowProvisionScope | undefined): ShadowProvisionScope {
+  const deploymentId = normalizedOptionalText(scope?.deploymentId)
+  const namespace = normalizedOptionalText(scope?.namespace)
+  return {
+    ...(deploymentId ? { deploymentId } : {}),
+    ...(namespace ? { namespace } : {}),
+    scopeKey:
+      normalizedOptionalText(scope?.scopeKey) ??
+      (deploymentId
+        ? `deployment:${deploymentId}`
+        : namespace
+          ? `namespace:${namespace}`
+          : undefined),
+  }
+}
+
+function scopedHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 8)
+}
+
+function usernameBase(id: string): string {
+  return (
+    id
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/, '') || 'buddy'
+  )
+}
+
+function usernameForBuddy(buddyDef: ShadowBuddy, scope: ShadowProvisionScope): string {
+  const base = usernameBase(buddyDef.id)
+  if (!scope.scopeKey) return base.slice(0, 30)
+  const suffix = scopedHash(`${scope.scopeKey}:${buddyDef.id}`)
+  return `${base.slice(0, 23)}-${suffix}`.replace(/^-|-$/g, '')
+}
+
+function scopedBuddyMetadata(
+  buddyDef: ShadowBuddy,
+  scope: ShadowProvisionScope,
+): Record<string, string> {
+  return {
+    buddyId: buddyDef.id,
+    ...(scope.scopeKey ? { scopeKey: scope.scopeKey } : {}),
+    ...(scope.deploymentId ? { deploymentId: scope.deploymentId } : {}),
+    ...(scope.namespace ? { namespace: scope.namespace } : {}),
+  }
+}
+
+function shadowobMetadata(agent: unknown): Record<string, unknown> {
+  const config = (agent as { config?: Record<string, unknown> })?.config
+  const shadowob = config?.shadowob
+  return shadowob && typeof shadowob === 'object' && !Array.isArray(shadowob)
+    ? (shadowob as Record<string, unknown>)
+    : {}
+}
+
+function buddyMatchesScope(
+  agent: unknown,
+  buddyDef: ShadowBuddy,
+  scope: ShadowProvisionScope,
+): boolean {
+  const metadata = shadowobMetadata(agent)
+  if (metadata.buddyId !== buddyDef.id) return false
+  if (scope.scopeKey) return metadata.scopeKey === scope.scopeKey
+  return metadata.scopeKey === undefined && metadata.deploymentId === undefined
+}
+
+function persistedBuddyMatchesScope(
+  buddy: PersistedBuddyInfo,
+  scope: ShadowProvisionScope,
+): boolean {
+  if (scope.scopeKey) return buddy.scopeKey === scope.scopeKey
+  return buddy.scopeKey === undefined && buddy.deploymentId === undefined
+}
+
+function withBuddyScope<T extends { agentId: string; userId: string; token: string }>(
+  info: T,
+  scope: ShadowProvisionScope,
+): ProvisionedBuddyInfo {
+  return {
+    ...info,
+    ...(scope.scopeKey ? { scopeKey: scope.scopeKey } : {}),
+    ...(scope.deploymentId ? { deploymentId: scope.deploymentId } : {}),
+    ...(scope.namespace ? { namespace: scope.namespace } : {}),
+  }
+}
+
 export interface ProvisionResult {
   servers: Map<string, string> // config id → real server id
   channels: Map<string, string> // config id → real channel id
-  buddies: Map<string, { agentId: string; token: string; userId: string }>
+  buddies: Map<string, ProvisionedBuddyInfo>
   /** buddyId → listingId on the marketplace */
   listings: Map<string, string>
   serverApps: Map<string, { serverAppId: string; appKey: string; serverId: string }>
@@ -95,6 +206,8 @@ export interface ProvisionOptions {
   force?: boolean
   /** Existing shadowob plugin state for dedup (if available) */
   existingState?: ShadowobState | null
+  /** Deployment scope used to isolate provisioned Buddy identities. */
+  scope?: ShadowProvisionScope
   /** Optional logger — defaults to the global console logger */
   logger?: Logger
 }
@@ -161,6 +274,7 @@ export async function provisionShadowResources(
   }
 
   const state = options.force ? null : (options.existingState ?? null)
+  const scope = normalizeProvisionScope(options.scope)
 
   // Detect orphaned resources (in state but not in current config)
   if (state) {
@@ -192,6 +306,7 @@ export async function provisionShadowResources(
         buddyDef,
         state,
         buddyAllowedServerIds.get(buddyDef.id) ?? [],
+        scope,
       )
       result.buddies.set(buddyDef.id, buddyInfo)
     }
@@ -595,40 +710,43 @@ async function provisionBuddy(
   buddyDef: ShadowBuddy,
   state: ShadowobState | null,
   allowedServerIds: string[],
-): Promise<{ agentId: string; token: string; userId: string }> {
+  scope: ShadowProvisionScope,
+): Promise<ProvisionedBuddyInfo> {
   // Check state first, but mint a fresh token so restarted/community servers
   // do not keep handing old runtimes an expired JWT.
   const existingBuddy = state?.buddies?.[buddyDef.id]
   if (existingBuddy?.agentId) {
-    log.dim(`  Buddy "${buddyDef.name}" found in state (agent: ${existingBuddy.agentId})`)
-    try {
-      await ensureBuddyServerAccess(client, existingBuddy.agentId, allowedServerIds)
-      const tokenResult = await client.generateAgentToken(existingBuddy.agentId)
-      return {
-        agentId: existingBuddy.agentId,
-        token: tokenResult.token,
-        userId: existingBuddy.userId,
+    if (persistedBuddyMatchesScope(existingBuddy, scope)) {
+      log.dim(`  Buddy "${buddyDef.name}" found in state (agent: ${existingBuddy.agentId})`)
+      try {
+        await ensureBuddyServerAccess(client, existingBuddy.agentId, allowedServerIds)
+        const tokenResult = await client.generateAgentToken(existingBuddy.agentId)
+        return withBuddyScope(
+          {
+            agentId: existingBuddy.agentId,
+            token: tokenResult.token,
+            userId: existingBuddy.userId,
+          },
+          scope,
+        )
+      } catch (err) {
+        log.dim(
+          `  Buddy "${
+            buddyDef.name
+          }" in state could not mint a fresh token, recreating or looking up existing scoped buddy: ${formatErrorMessage(
+            err,
+          )}`,
+        )
       }
-    } catch (err) {
-      log.dim(
-        `  Buddy "${
-          buddyDef.name
-        }" in state could not mint a fresh token, recreating or looking up existing buddy: ${formatErrorMessage(
-          err,
-        )}`,
-      )
+    } else {
+      log.dim(`  Ignoring legacy or out-of-scope Buddy state for "${buddyDef.name}"`)
     }
   }
 
   log.step(`Provisioning buddy: ${buddyDef.name}`)
 
-  // Generate a URL-safe username from the buddy id
-  const username = buddyDef.id
-    .toLowerCase()
-    .replace(/[^a-z0-9-]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/, '')
-    .slice(0, 30)
+  const username = usernameForBuddy(buddyDef, scope)
+  const buddyConfig = { shadowob: scopedBuddyMetadata(buddyDef, scope) }
 
   let agentId: string
   let token: string
@@ -641,21 +759,7 @@ async function provisionBuddy(
     agents = []
   }
   const existing = agents.find((agent) => {
-    const botUser = (
-      agent as { botUser?: { username?: string | null; displayName?: string | null } }
-    ).botUser
-    const config = (agent as { config?: Record<string, unknown> }).config
-    const shadowob = config?.shadowob
-    const shadowobBuddyId =
-      shadowob && typeof shadowob === 'object' && !Array.isArray(shadowob)
-        ? (shadowob as Record<string, unknown>).buddyId
-        : null
-    return (
-      shadowobBuddyId === buddyDef.id ||
-      botUser?.username === username ||
-      ((agent as { name?: string }).name === buddyDef.name &&
-        botUser?.displayName === buddyDef.name)
-    )
+    return buddyMatchesScope(agent, buddyDef, scope)
   })
   if (existing) {
     agentId = existing.id
@@ -672,7 +776,7 @@ async function provisionBuddy(
       (existing as { botUser?: { id?: string } }).botUser?.id ??
       ''
     log.dim(`  Reusing buddy: ${buddyDef.name} (agent: ${agentId})`)
-    return { agentId, token, userId }
+    return withBuddyScope({ agentId, token, userId }, scope)
   }
 
   try {
@@ -683,7 +787,7 @@ async function provisionBuddy(
       avatarUrl: buddyDef.avatarUrl,
       buddyMode: 'private',
       allowedServerIds,
-      config: { shadowob: { buddyId: buddyDef.id } },
+      config: buddyConfig,
     })
     agentId = agent.id
     userId = agent.userId
@@ -693,12 +797,16 @@ async function provisionBuddy(
     log.success(`  Created buddy: ${buddyDef.name} (agent: ${agentId})`)
   } catch (err) {
     const msg = (err as Error).message ?? ''
-    // Handle "already exists" — list agents and find by name
+    // Handle "already exists" only when the existing agent is in the same scoped
+    // provisioning identity. Display names are not identity and must not be used
+    // for cross-deployment reuse.
     if (/already|conflict|duplicate|unique/i.test(msg)) {
-      log.dim(`  Buddy "${buddyDef.name}" already exists, looking up...`)
+      log.dim(`  Buddy "${buddyDef.name}" already exists, looking up scoped identity...`)
       const fallbackAgents = await client.listAgents()
-      const fallback = fallbackAgents.find((a) => a.name === buddyDef.name)
-      if (!fallback) throw new Error(`Cannot find existing buddy "${buddyDef.name}": ${msg}`)
+      const fallback = fallbackAgents.find((agent) => buddyMatchesScope(agent, buddyDef, scope))
+      if (!fallback) {
+        throw new Error(`Cannot find existing scoped buddy "${buddyDef.name}": ${msg}`)
+      }
 
       agentId = fallback.id
       await ensureBuddyServerAccess(
@@ -711,13 +819,13 @@ async function provisionBuddy(
       const tokenResult = await client.generateAgentToken(agentId)
       token = tokenResult.token
       userId = (fallback as { userId?: string }).userId ?? ''
-      log.dim(`  Found existing buddy: ${buddyDef.name} (agent: ${agentId})`)
+      log.dim(`  Found existing scoped buddy: ${buddyDef.name} (agent: ${agentId})`)
     } else {
       throw err
     }
   }
 
-  return { agentId, token, userId }
+  return withBuddyScope({ agentId, token, userId }, scope)
 }
 
 async function processBinding(
@@ -1038,13 +1146,22 @@ export function buildProvisionedEnvVars(
 
   // Find bindings for this agent
   const bindings = plugin.bindings?.filter((b) => b.agentId === agentId) ?? []
+  const boundBuddyAgentIds = new Set<string>()
 
   for (const binding of bindings) {
     const buddyInfo = provision.buddies.get(binding.targetId)
     if (!buddyInfo) continue
 
+    if (buddyInfo.agentId) {
+      boundBuddyAgentIds.add(buddyInfo.agentId)
+    }
+
     const envKey = `SHADOWOB_TOKEN_${binding.targetId.toUpperCase().replace(/-/g, '_')}`
     env[envKey] = buddyInfo.token
+  }
+
+  if (boundBuddyAgentIds.size === 1) {
+    env.SHADOWOB_AGENT_ID = [...boundBuddyAgentIds][0]!
   }
 
   for (const [seedId, ids] of provision.commerce ?? new Map()) {
@@ -1103,7 +1220,13 @@ export function provisionResultToState(
         buddies: Object.fromEntries(
           Array.from(result.buddies.entries()).map(([id, info]) => [
             id,
-            { agentId: info.agentId, userId: info.userId },
+            {
+              agentId: info.agentId,
+              userId: info.userId,
+              ...(info.scopeKey ? { scopeKey: info.scopeKey } : {}),
+              ...(info.deploymentId ? { deploymentId: info.deploymentId } : {}),
+              ...(info.namespace ? { namespace: info.namespace } : {}),
+            },
           ]),
         ),
         ...(result.listings?.size > 0 ? { listings: Object.fromEntries(result.listings) } : {}),
@@ -1124,7 +1247,7 @@ export function stateToProvisionResult(state: ProvisionState): ProvisionResult {
   const s = (state.plugins?.shadowob ?? {}) as {
     servers?: Record<string, string>
     channels?: Record<string, string>
-    buddies?: Record<string, { agentId: string; userId: string; token?: string }>
+    buddies?: Record<string, PersistedBuddyInfo>
     listings?: Record<string, string>
     serverApps?: Record<string, { serverAppId: string; appKey: string; serverId: string }>
     commerce?: Record<
@@ -1144,7 +1267,14 @@ export function stateToProvisionResult(state: ProvisionState): ProvisionResult {
     buddies: new Map(
       Object.entries(s.buddies ?? {}).map(([id, info]) => [
         id,
-        { agentId: info.agentId, userId: info.userId, token: info.token ?? '' },
+        {
+          agentId: info.agentId,
+          userId: info.userId,
+          token: info.token ?? '',
+          ...(info.scopeKey ? { scopeKey: info.scopeKey } : {}),
+          ...(info.deploymentId ? { deploymentId: info.deploymentId } : {}),
+          ...(info.namespace ? { namespace: info.namespace } : {}),
+        },
       ]),
     ),
     listings: new Map(Object.entries(s.listings ?? {})),

--- a/apps/cloud/src/runtimes/images.ts
+++ b/apps/cloud/src/runtimes/images.ts
@@ -19,7 +19,7 @@ export function defaultRunnerImage(options: {
   fallback?: string
 }): string {
   return (
-    (options.env ? process.env[options.env]?.trim() : undefined) ??
+    (options.env ? envValue(options.env) : undefined) ??
     options.fallback ??
     `${DEFAULT_RUNNER_REGISTRY}/${options.runner}:${DEFAULT_RUNNER_IMAGE_TAG}`
   )

--- a/apps/cloud/src/services/deploy.service.ts
+++ b/apps/cloud/src/services/deploy.service.ts
@@ -367,6 +367,10 @@ export class DeployService {
     // can't resolve the pod-facing one, so we pass the host-side URL separately.
     if (options.shadowUrl) extraSecrets.SHADOWOB_PROVISION_URL = options.shadowUrl
     if (options.shadowToken) extraSecrets.SHADOWOB_USER_TOKEN = options.shadowToken
+    if (effectiveEnv.SHADOWOB_CLOUD_DEPLOYMENT_ID) {
+      extraSecrets.SHADOWOB_CLOUD_DEPLOYMENT_ID = effectiveEnv.SHADOWOB_CLOUD_DEPLOYMENT_ID
+    }
+    extraSecrets.SHADOWOB_CLOUD_NAMESPACE = namespace
 
     // 3. Resolve config (expand extends + templates)
     this.logger.step('Resolving config...')


### PR DESCRIPTION
## Summary
- treat blank per-runtime runner image environment variables as unset so runner image fallback cannot render empty Kubernetes image fields
- scope cloud-provisioned Buddies by deployment/namespace instead of display name, and persist that scope in provision state
- inject the real provisioned Buddy agent UUID into both runtime and exposure sidecar env so Hermes/app exposure calls do not use workload slugs as agent IDs
- harden agent-sandbox preflight for fully-qualified api-resources output and CRD lookup fallback so installed sandbox CRDs do not get misdetected as missing

## Why
Production deployment exposed three linked issues: docker-compose blank override envs produced empty runner images; Shadow Buddy provisioning could reuse same-name/legacy unscoped Buddies across deployment lifecycles; and sandbox preflight misread installed CRDs, falling back from faststart/agent-sandbox to regular Deployments.

## Verification
- pnpm biome format --write apps/cloud/src/runtimes/images.ts apps/cloud/__tests__/runtimes/runtimes.test.ts apps/cloud/src/clients/kubectl-runtime.ts apps/cloud/__tests__/clients/kubectl-runtime.test.ts apps/cloud/src/plugins/shadowob/provisioning.ts apps/cloud/src/plugins/shadowob/index.ts apps/cloud/__tests__/provisioning/provisioning.test.ts apps/cloud/src/services/deploy.service.ts apps/cloud/__tests__/services/deploy.service.test.ts apps/cloud/src/infra/agent-pod.ts apps/cloud/src/infra/agent-pod.test.ts apps/cloud/__tests__/utils/state.test.ts
- pnpm biome check apps/cloud/src/runtimes/images.ts apps/cloud/__tests__/runtimes/runtimes.test.ts apps/cloud/src/clients/kubectl-runtime.ts apps/cloud/__tests__/clients/kubectl-runtime.test.ts apps/cloud/src/plugins/shadowob/provisioning.ts apps/cloud/src/plugins/shadowob/index.ts apps/cloud/__tests__/provisioning/provisioning.test.ts apps/cloud/src/services/deploy.service.ts apps/cloud/__tests__/services/deploy.service.test.ts apps/cloud/src/infra/agent-pod.ts apps/cloud/src/infra/agent-pod.test.ts apps/cloud/__tests__/utils/state.test.ts
- ./node_modules/.bin/vitest run __tests__/services/deploy.service.test.ts __tests__/provisioning/provisioning.test.ts __tests__/clients/kubectl-runtime.test.ts src/infra/agent-pod.test.ts __tests__/runtimes/runtimes.test.ts __tests__/utils/state.test.ts
- pnpm --filter @shadowob/cloud typecheck

## Production note
Production was temporarily mitigated by setting all runner image overrides to the current runner tag and restarting the server. The latest retry deployed successfully, but this PR fixes the root causes so future deployments do not depend on that manual env workaround and do not reuse unscoped same-name Buddies.