### PR TITLE
feat(cli): complete Local Bridge live sync controls

### DIFF
--- a/docs/local-bridge.md
+++ b/docs/local-bridge.md
@@ -59,11 +59,12 @@ Omit `--detach` when you want a foreground process that stops with the terminal.
 1. Open **Shadow Clipper → Settings → Sync → Local Bridge**.
 2. Paste the address and token printed by the CLI.
 3. Choose **Test connection**.
-4. Choose **Sync now** once to create the local library.
-5. Leave automatic sync enabled if later library changes should appear locally.
+4. The first sync runs automatically after the test passes. Leave automatic sync enabled if later
+   library changes should appear locally.
 
 Local Bridge updates only files recorded in its managed-file manifest. Unrelated files already in
-the selected directory are not removed.
+the selected directory are not removed. Each sync compares file hashes, writes only changes, and
+keeps the latest 100 sync records.
 
 ## 4. Connect Codex
 
@@ -84,9 +85,13 @@ Codex receives these capabilities:
 - Read a library overview with file types, source platforms, date range, tags, favorites, and reading state.
 - Page through managed Markdown, text, and JSON resources and read selected line ranges.
 - Search the local Clipper library by relevance and continue through paginated results.
+- Request a fresh browser export with `clipper_sync_library` and inspect sync records with
+  `clipper_list_library_syncs`; the extension also refreshes the snapshot shortly after library
+  changes when automatic sync is enabled.
 - Inspect every connected browser plugin together with its capability tags, callable interfaces,
   task parameters, and choices.
 - Invoke a callable plugin interface or send one of its declared tasks to the extension.
+- List and run automations already saved in Shadow Clipper.
 - Publish declarative custom plugins and manage plugin settings, Pets, themes, wallpapers, and Skills.
 - Wait for a task result or cancel a queued task before the browser claims it.
 - Discover configured local MCP servers and call their tools, resources, or prompts.
@@ -101,10 +106,11 @@ Local Bridge exposes the same functional surface through CLI, authenticated HTTP
 
 | Capability | CLI | HTTP | MCP |
 | --- | --- | --- | --- |
-| Library overview, files, line reads, and search | `library` | `/v1/library/*` | `clipper_*library*` |
-| Plugin discovery, tasks, and callable interfaces | `plugins` | `/v1/plugins*`, `/v1/tasks` | `clipper_list_plugins`, `clipper_enqueue_task`, `clipper_invoke_plugin` |
+| Library overview, files, line reads, search, live sync, and sync history | `library` | `/v1/library/*`, `/v1/resources/library/sync` | `clipper_*library*`, `clipper_sync_library`, `clipper_list_library_syncs` |
+| Plugin discovery, task catalog, and callable interfaces | `plugins`, `tasks list` | `/v1/plugins*`, `/v1/plugin-tasks`, `/v1/tasks` | `clipper_list_plugins`, `clipper_list_tasks`, `clipper_enqueue_task`, `clipper_invoke_plugin` |
+| Saved automations | `automations` | `/v1/resources/automations/*` | `clipper_list_automations`, `clipper_run_automation`, `clipper_manage_resource` |
 | Custom plugins, settings, plugin Agents, Pets, themes, wallpapers, and Skills | `custom-plugins`, `plugin-settings`, `plugin-agents`, `pets`, `themes`, `wallpapers`, `skills` | `/v1/resources/*`, `/v1/artifacts*` | `clipper_list_resource_capabilities`, `clipper_manage_resource` |
-| Task list, result, wait, and cancellation | `tasks` | `/v1/tasks*` | `clipper_*task*` |
+| Task run result, wait, and cancellation | `tasks runs`, `tasks get/wait/cancel` | `/v1/tasks*` | `clipper_*task*` |
 | Configured local MCP servers | `mcp-servers` | `/v1/mcp-servers*` | `clipper_list_mcp_servers`, `clipper_call_mcp_server` |
 | JavaScript and Python runtimes | `runtimes` | `/v1/runtimes*` | `clipper_list_runtimes`, `clipper_execute_runtime` |
 
@@ -132,6 +138,23 @@ View its background log or stop it safely:
 ```bash
 shadowob local-bridge logs --root ~/ClipperLibrary
 shadowob local-bridge stop --root ~/ClipperLibrary
+```
+
+Show a forgotten token, or rotate it while the bridge is running to invalidate the previous token:
+
+```bash
+shadowob local-bridge token show --root ~/ClipperLibrary
+shadowob local-bridge token rotate --root ~/ClipperLibrary
+```
+
+After rotation, paste the new token into **Shadow Clipper → Settings → Shadow CLI**. The sync page
+remembers it across browser restarts.
+
+Inspect the last sync time and recent incremental counts:
+
+```bash
+shadowob local-bridge library overview --root ~/ClipperLibrary
+shadowob local-bridge library history --root ~/ClipperLibrary
 ```
 
 `status`, `inspect`, `doctor`, `stop`, and `mcp` use the address recorded for that library directory.
@@ -196,10 +219,28 @@ Inspect or manage tasks without an MCP client:
 
 ```bash
 shadowob local-bridge tasks list --root ~/ClipperLibrary
+shadowob local-bridge tasks runs --root ~/ClipperLibrary
 shadowob local-bridge tasks get <task-id> --root ~/ClipperLibrary
 shadowob local-bridge tasks wait <task-id> --root ~/ClipperLibrary --timeout 60
 shadowob local-bridge tasks cancel <task-id> --root ~/ClipperLibrary
 ```
+
+`tasks list` shows task definitions currently advertised by connected plugins and recent execution
+runs. `tasks runs` shows only execution history. Saved automations are separate browser data:
+
+```bash
+shadowob local-bridge automations list --root ~/ClipperLibrary --timeout 60
+shadowob local-bridge automations run <automation-id> --root ~/ClipperLibrary --timeout 60
+```
+
+Request the freshest library snapshot at any time:
+
+```bash
+shadowob local-bridge library sync --root ~/ClipperLibrary --timeout 60
+```
+
+This command asks the connected browser extension to export immediately. Normal CLI and MCP reads
+use the latest local snapshot, so they remain fast and continue to work when Chrome is closed.
 
 The CLI uses the authenticated Local Bridge HTTP interface directly. Both HTTP and MCP accept only
 tasks and options declared by a recently connected Shadow Clipper plugin.

--- a/docs/local-bridge.zh-CN.md
+++ b/docs/local-bridge.zh-CN.md
@@ -57,10 +57,10 @@ shadowob local-bridge start --detach --port 43145 --root ~/Documents/ShadowClipp
 1. 打开 **Shadow Clipper → 设置 → 同步 → Local Bridge**。
 2. 填入 CLI 显示的地址和令牌。
 3. 点击**测试连接**。
-4. 点击一次**立即同步**，生成本地资料库。
-5. 如果希望后续资料变更自动写入本地，请保持自动同步开启。
+4. 测试通过后会自动完成首次同步；如果希望后续资料变更自动写入本地，请保持自动同步开启。
 
 Local Bridge 只会更新其清单中记录的文件，不会删除所选目录里原本存在的无关文件。
+每次同步都会比较文件内容哈希，只写入变化的文件，并保留最近 100 次同步记录。
 
 ## 4. 连接 Codex
 
@@ -80,8 +80,10 @@ codex mcp add shadow-clipper -- \
 - 先读取资料库概览，包括文件类型、来源平台、时间范围、标签、收藏和阅读状态。
 - 分页列出 Markdown、文本和 JSON 资料，并按行读取指定文件。
 - 按相关性搜索本地 Clipper 资料库，并继续读取下一页结果。
+- 使用 `clipper_sync_library` 请求浏览器立即导出最新资料，并通过 `clipper_list_library_syncs` 查看同步记录；开启自动同步后，资料库变化也会在短时间内刷新本地副本。
 - 查看每个在线浏览器插件的能力标签、可调用接口、任务、参数说明和可选值。
 - 调用插件接口，或向扩展发送其中一个已声明的任务。
+- 查看并运行已经保存在 Shadow Clipper 中的自动化。
 - 动态发布声明式自定义插件，并管理插件设置、Pet、主题、壁纸和 Skills。
 - 等待任务结果，或在浏览器领取前取消排队任务。
 - 查看已配置的本地 MCP 服务，并调用其工具、资源或提示词。
@@ -96,10 +98,11 @@ Local Bridge 通过 CLI、带令牌保护的 HTTP 和 MCP 提供同一套功能�
 
 | 能力 | CLI | HTTP | MCP |
 | --- | --- | --- | --- |
-| 资料库概览、文件列表、按行读取、搜索 | `library` | `/v1/library/*` | `clipper_*library*` |
-| 插件发现、任务、可调用接口 | `plugins` | `/v1/plugins*`、`/v1/tasks` | `clipper_list_plugins`、`clipper_enqueue_task`、`clipper_invoke_plugin` |
+| 资料库概览、文件列表、按行读取、搜索、实时同步请求与同步记录 | `library` | `/v1/library/*`、`/v1/resources/library/sync` | `clipper_*library*`、`clipper_sync_library`、`clipper_list_library_syncs` |
+| 插件发现、任务目录、可调用接口 | `plugins`、`tasks list` | `/v1/plugins*`、`/v1/plugin-tasks`、`/v1/tasks` | `clipper_list_plugins`、`clipper_list_tasks`、`clipper_enqueue_task`、`clipper_invoke_plugin` |
+| 已保存的自动化 | `automations` | `/v1/resources/automations/*` | `clipper_list_automations`、`clipper_run_automation`、`clipper_manage_resource` |
 | 自定义插件、插件设置、插件 Agent、Pet、主题、壁纸、Skills | `custom-plugins`、`plugin-settings`、`plugin-agents`、`pets`、`themes`、`wallpapers`、`skills` | `/v1/resources/*`、`/v1/artifacts*` | `clipper_list_resource_capabilities`、`clipper_manage_resource` |
-| 任务列表、结果、等待、取消 | `tasks` | `/v1/tasks*` | `clipper_*task*` |
+| 任务执行记录、结果、等待、取消 | `tasks runs`、`tasks get/wait/cancel` | `/v1/tasks*` | `clipper_*task*` |
 | 已配置的本地 MCP 服务 | `mcp-servers` | `/v1/mcp-servers*` | `clipper_list_mcp_servers`、`clipper_call_mcp_server` |
 | JavaScript、Python 本地运行环境 | `runtimes` | `/v1/runtimes*` | `clipper_list_runtimes`、`clipper_execute_runtime` |
 
@@ -126,6 +129,22 @@ shadowob local-bridge status --root ~/ClipperLibrary --json
 ```bash
 shadowob local-bridge logs --root ~/ClipperLibrary
 shadowob local-bridge stop --root ~/ClipperLibrary
+```
+
+忘记令牌时可以重新显示；需要让旧令牌立即失效时，可以在服务运行期间轮换令牌：
+
+```bash
+shadowob local-bridge token show --root ~/ClipperLibrary
+shadowob local-bridge token rotate --root ~/ClipperLibrary
+```
+
+轮换后，把新令牌粘贴到 **Shadow Clipper → 设置 → Shadow CLI**。同步页会保存它，浏览器重启后仍然可用。
+
+查看上次同步时间、增量写入数量和最近记录：
+
+```bash
+shadowob local-bridge library overview --root ~/ClipperLibrary
+shadowob local-bridge library history --root ~/ClipperLibrary
 ```
 
 `status`、`inspect`、`doctor`、`stop` 和 `mcp` 会自动使用该资料目录记录的服务地址。只有连接旧版
@@ -188,10 +207,28 @@ shadowob local-bridge plugins run zhihu hot-questions \
 
 ```bash
 shadowob local-bridge tasks list --root ~/ClipperLibrary
+shadowob local-bridge tasks runs --root ~/ClipperLibrary
 shadowob local-bridge tasks get <task-id> --root ~/ClipperLibrary
 shadowob local-bridge tasks wait <task-id> --root ~/ClipperLibrary --timeout 60
 shadowob local-bridge tasks cancel <task-id> --root ~/ClipperLibrary
 ```
+
+`tasks list` 会同时显示在线插件声明的可用任务和最近执行记录；`tasks runs` 只显示执行记录。
+浏览器中保存的自动化属于另一类数据，可直接查询和运行：
+
+```bash
+shadowob local-bridge automations list --root ~/ClipperLibrary --timeout 60
+shadowob local-bridge automations run <automation-id> --root ~/ClipperLibrary --timeout 60
+```
+
+需要马上读取最新资料时，可以主动请求浏览器导出：
+
+```bash
+shadowob local-bridge library sync --root ~/ClipperLibrary --timeout 60
+```
+
+这个命令会让当前连接的扩展立即导出。平时 CLI/MCP 读取的是最近一次本地快照，因此速度快，Chrome
+关闭后也仍然可以读取。
 
 这些命令直接使用带令牌保护的 Local Bridge HTTP 接口。HTTP 和 MCP 都只接受最近连接的 Shadow
 Clipper 插件已经声明的任务及参数。
@@ -204,7 +241,7 @@ Clipper 插件已经声明的任务及参数。
 shadowob local-bridge resources capabilities --root ~/ClipperLibrary
 ```
 
-六类资源都有独立 CLI 命令，它们与 HTTP、MCP 共用同一个协议：
+这些资源都有独立 CLI 命令，它们与 HTTP、MCP 共用同一个协议：
 
 最小可用的 `plugin.json` 如下：
 

--- a/packages/cli/__tests__/local-bridge.test.ts
+++ b/packages/cli/__tests__/local-bridge.test.ts
@@ -214,6 +214,10 @@ describe('Shadow Local Bridge', () => {
         },
       ],
       protocolVersion: 2,
+      resources: {
+        automations: ['list', 'get', 'run', 'pause', 'resume'],
+        library: ['sync'],
+      },
     }
 
     const connected = await fetch(`${baseUrl}/v1/clients/vitest/heartbeat`, {
@@ -257,6 +261,21 @@ describe('Shadow Local Bridge', () => {
       connected: true,
       ok: true,
     })
+    const directTaskCatalog = await fetch(`${baseUrl}/v1/plugin-tasks`, {
+      headers: authorizedHeaders(),
+    }).then((response) => response.json())
+    expect(directTaskCatalog).toMatchObject({
+      connected: true,
+      ok: true,
+      tasks: [
+        expect.objectContaining({
+          clientIds: ['vitest'],
+          id: 'hot-questions',
+          pluginId: 'zhihu',
+          pluginName: 'Zhihu',
+        }),
+      ],
+    })
 
     const undeclaredTask = await fetch(`${baseUrl}/v1/tasks`, {
       body: JSON.stringify({ options: {}, pluginId: 'zhihu', taskId: 'not-declared' }),
@@ -299,6 +318,21 @@ describe('Shadow Local Bridge', () => {
     expect(await readFile(join(root, 'clipper/social/demo.md'), 'utf8')).toContain(
       'connected library entry',
     )
+
+    const syncHistory = await fetch(`${baseUrl}/v1/library/history`, {
+      headers: authorizedHeaders(),
+    }).then((response) => response.json())
+    expect(syncHistory).toMatchObject({
+      history: [
+        expect.objectContaining({
+          files: 2,
+          status: 'succeeded',
+          unchanged: 0,
+          written: 2,
+        }),
+      ],
+      ok: true,
+    })
 
     const directOverview = await fetch(`${baseUrl}/v1/library/overview`, {
       headers: authorizedHeaders(),
@@ -377,6 +411,14 @@ describe('Shadow Local Bridge', () => {
       sources: { platforms: [{ count: 1, value: 'zhihu' }] },
     })
 
+    const syncHistoryTool = await mcpRequest(baseUrl, 'tools/call', {
+      arguments: { limit: 5 },
+      name: 'clipper_list_library_syncs',
+    })
+    expect(syncHistoryTool.result?.structuredContent).toMatchObject({
+      history: [expect.objectContaining({ status: 'succeeded', written: 2 })],
+    })
+
     const search = await mcpRequest(baseUrl, 'tools/call', {
       arguments: { query: 'composable pipelines' },
       name: 'clipper_search_library',
@@ -396,6 +438,16 @@ describe('Shadow Local Bridge', () => {
     })
     expect(JSON.stringify(plugins.result)).toContain('Question limit')
     expect(JSON.stringify(plugins.result)).toContain('questionLimit')
+
+    const taskCatalog = await mcpRequest(baseUrl, 'tools/call', {
+      arguments: {},
+      name: 'clipper_list_tasks',
+    })
+    expect(taskCatalog.result?.structuredContent).toMatchObject({
+      availableTasks: [expect.objectContaining({ id: 'hot-questions', pluginId: 'zhihu' })],
+      connected: true,
+      runs: [],
+    })
 
     const queued = await mcpRequest(baseUrl, 'tools/call', {
       arguments: {
@@ -484,6 +536,40 @@ describe('Shadow Local Bridge', () => {
       ok: true,
       task: { options: { questionLimit: 1 }, taskId: 'hot-questions' },
     })
+
+    const syncRequested = await mcpRequest(baseUrl, 'tools/call', {
+      arguments: { wait: false },
+      name: 'clipper_sync_library',
+    })
+    expect(syncRequested.result?.structuredContent).toMatchObject({
+      task: { kind: 'resource-operation', operation: { action: 'sync', resource: 'library' } },
+    })
+    const claimedSync = (await fetch(`${baseUrl}/v1/clients/vitest/heartbeat`, {
+      body: JSON.stringify({ capabilities, claim: true }),
+      headers: authorizedHeaders({ 'Content-Type': 'application/json' }),
+      method: 'POST',
+    }).then((response) => response.json())) as {
+      task: { id: string; lease: Record<string, unknown> }
+    }
+    await fetch(`${baseUrl}/v1/tasks/${claimedSync.task.id}/result`, {
+      body: JSON.stringify({
+        lease: claimedSync.task.lease,
+        result: { ok: true, data: { written: 2 } },
+      }),
+      headers: authorizedHeaders({
+        'Content-Type': 'application/json',
+        'X-Clipper-Client': 'vitest',
+      }),
+      method: 'POST',
+    })
+
+    const automationsRequested = await mcpRequest(baseUrl, 'tools/call', {
+      arguments: { wait: false },
+      name: 'clipper_list_automations',
+    })
+    expect(automationsRequested.result?.structuredContent).toMatchObject({
+      task: { operation: { action: 'list', resource: 'automations' }, status: 'queued' },
+    })
   })
 
   it('requires the token, keeps runtime execution off by default, and limits browser origins', async () => {
@@ -515,6 +601,28 @@ describe('Shadow Local Bridge', () => {
       headers: { Origin: 'https://example.com' },
     })
     expect(denied.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  it('rotates the running token, persists it, and rejects the previous token', async () => {
+    const { baseUrl, root } = await startBridge()
+    const rotated = await fetch(`${baseUrl}/v1/admin/token/rotate`, {
+      headers: authorizedHeaders(),
+      method: 'POST',
+    })
+    expect(rotated.status).toBe(200)
+    const result = (await rotated.json()) as { ok: boolean; token: string }
+    expect(result.ok).toBe(true)
+    expect(result.token).not.toBe('test-token')
+    expect(await readFile(join(root, '.clipper/bridge-token'), 'utf8')).toBe(`${result.token}\n`)
+
+    const previous = await fetch(`${baseUrl}/v1/library/status`, {
+      headers: authorizedHeaders(),
+    })
+    expect(previous.status).toBe(401)
+    const current = await fetch(`${baseUrl}/v1/library/status`, {
+      headers: { Authorization: `Bearer ${result.token}` },
+    })
+    expect(current.status).toBe(200)
   })
 
   it('stops only after an authenticated admin request', async () => {
@@ -663,6 +771,15 @@ describe('Shadow Local Bridge', () => {
     expect(guide.extension.steps).toHaveLength(3)
     expect(guide.checks.startCommand).toBe(
       'shadowob local-bridge start --detach --port 32145 --root /Users/example/ClipperLibrary',
+    )
+    expect(guide.checks.syncCommand).toBe(
+      'shadowob local-bridge library sync --url http://127.0.0.1:32145 --root /Users/example/ClipperLibrary --timeout 60',
+    )
+    expect(guide.checks.tokenShowCommand).toBe(
+      'shadowob local-bridge token show --root /Users/example/ClipperLibrary',
+    )
+    expect(guide.checks.libraryHistoryCommand).toBe(
+      'shadowob local-bridge library history --url http://127.0.0.1:32145 --root /Users/example/ClipperLibrary',
     )
     expect(guide.codex.addCommand).toBe(
       'codex mcp add shadow-clipper -- shadowob local-bridge mcp --url http://127.0.0.1:32145 --root /Users/example/ClipperLibrary',

--- a/packages/cli/__tests__/program.test.ts
+++ b/packages/cli/__tests__/program.test.ts
@@ -22,10 +22,12 @@ describe('CLI program metadata and options', () => {
       'start',
       'status',
       'stop',
+      'token',
       'logs',
       'library',
       'plugins',
       'resources',
+      'automations',
       'custom-plugins',
       'plugin-settings',
       'plugin-agents',
@@ -46,6 +48,7 @@ describe('CLI program metadata and options', () => {
     const tasks = localBridge?.commands.find((command) => command.name() === 'tasks')
     expect(tasks?.commands.map((command) => command.name())).toEqual([
       'list',
+      'runs',
       'get',
       'wait',
       'cancel',
@@ -53,9 +56,21 @@ describe('CLI program metadata and options', () => {
     const library = localBridge?.commands.find((command) => command.name() === 'library')
     expect(library?.commands.map((command) => command.name())).toEqual([
       'overview',
+      'history',
       'files',
       'read',
       'search',
+      'sync',
+    ])
+    const token = localBridge?.commands.find((command) => command.name() === 'token')
+    expect(token?.commands.map((command) => command.name())).toEqual(['show', 'rotate'])
+    const automations = localBridge?.commands.find((command) => command.name() === 'automations')
+    expect(automations?.commands.map((command) => command.name())).toEqual([
+      'list',
+      'get',
+      'run',
+      'pause',
+      'resume',
     ])
     const runtimes = localBridge?.commands.find((command) => command.name() === 'runtimes')
     expect(runtimes?.commands.map((command) => command.name())).toEqual(['list', 'run'])

--- a/packages/cli/src/commands/local-bridge.ts
+++ b/packages/cli/src/commands/local-bridge.ts
@@ -18,11 +18,15 @@ interface LocalBridgeConnectionGuide {
   checks: {
     doctorCommand: string
     inspectCommand: string
+    libraryHistoryCommand: string
     logsCommand: string
     resourcesCommand: string
+    syncCommand: string
     startCommand: string
     statusCommand: string
     stopCommand: string
+    tokenRotateCommand: string
+    tokenShowCommand: string
   }
   codex: {
     addCommand: string
@@ -59,6 +63,11 @@ interface StatusOptions {
   root?: string
   token?: string
   url?: string
+}
+
+interface TokenShowOptions {
+  json?: boolean
+  root?: string
 }
 
 interface McpProxyOptions {
@@ -179,6 +188,23 @@ export function createLocalBridgeCommand(): Command {
     .option('--json', 'Output as JSON')
     .action(stopLocalBridge)
 
+  const tokenCommands = command
+    .command('token')
+    .description('Show or replace the saved Local Bridge connection token')
+
+  tokenCommands
+    .command('show')
+    .description('Show the saved connection token')
+    .option('--root <directory>', 'Local library directory', '~/ClipperLibrary')
+    .option('--json', 'Output as JSON')
+    .action(showLocalBridgeToken)
+
+  addLocalBridgeConnectionOptions(
+    tokenCommands
+      .command('rotate')
+      .description('Replace the token and invalidate the previous one'),
+  ).action(rotateLocalBridgeToken)
+
   command
     .command('logs')
     .description('Show recent background Local Bridge logs')
@@ -192,6 +218,13 @@ export function createLocalBridgeCommand(): Command {
   addLocalBridgeConnectionOptions(
     library.command('overview').description('Summarize the synced library'),
   ).action(showLocalBridgeLibraryOverview)
+
+  addLocalBridgeConnectionOptions(
+    library
+      .command('history')
+      .description('Show recent incremental library syncs')
+      .option('--limit <number>', 'Maximum sync records', '20'),
+  ).action(showLocalBridgeLibraryHistory)
 
   addLocalBridgeConnectionOptions(
     library
@@ -218,6 +251,15 @@ export function createLocalBridgeCommand(): Command {
       .option('--cursor <cursor>', 'Continue from a previous page')
       .option('--path-prefix <path>', 'Restrict results to a path prefix'),
   ).action(searchLocalBridgeLibrary)
+
+  addLocalBridgeConnectionOptions(
+    library.command('sync').description('Request an immediate library sync from Shadow Clipper'),
+  )
+    .option('--no-wait', 'Return after queueing instead of waiting for the browser result')
+    .option('--timeout <seconds>', 'Wait timeout in seconds, up to 60', '30')
+    .action((options: ResourceCommandOptions) =>
+      runResourceAlias('library', 'sync', undefined, undefined, options),
+    )
 
   const plugins = command
     .command('plugins')
@@ -279,18 +321,25 @@ export function createLocalBridgeCommand(): Command {
   addLocalBridgeConnectionOptions(
     tasks
       .command('list')
-      .description('List recent plugin tasks')
-      .option('--limit <number>', 'Maximum tasks', '50'),
+      .description('List available plugin tasks and recent task runs')
+      .option('--limit <number>', 'Maximum recent task runs', '50'),
   ).action(listLocalBridgeTasks)
 
   addLocalBridgeConnectionOptions(
-    tasks.command('get <task-id>').description('Read one plugin task'),
+    tasks
+      .command('runs')
+      .description('List recent queued, running, and completed task runs')
+      .option('--limit <number>', 'Maximum task runs', '50'),
+  ).action(listLocalBridgeTaskRuns)
+
+  addLocalBridgeConnectionOptions(
+    tasks.command('get <task-id>').description('Read one task run'),
   ).action(getLocalBridgeTask)
 
   addLocalBridgeConnectionOptions(
     tasks
       .command('wait <task-id>')
-      .description('Wait briefly for one plugin task to finish')
+      .description('Wait briefly for one task run to finish')
       .option('--timeout <seconds>', 'Wait timeout in seconds, up to 60', '30'),
   ).action(waitForLocalBridgeTaskCommand)
 
@@ -407,6 +456,18 @@ function registerResourceCommands(command: Command): void {
     resource: string
     actions: Array<{ action: string; argument?: 'id' | 'file'; description: string }>
   }> = [
+    {
+      command: 'automations',
+      description: 'Inspect and run saved Shadow Clipper automations',
+      resource: 'automations',
+      actions: [
+        { action: 'list', description: 'List saved automations' },
+        { action: 'get', argument: 'id', description: 'Read one saved automation' },
+        { action: 'run', argument: 'id', description: 'Run one saved automation' },
+        { action: 'pause', argument: 'id', description: 'Pause a scheduled automation' },
+        { action: 'resume', argument: 'id', description: 'Resume a scheduled automation' },
+      ],
+    },
     {
       command: 'custom-plugins',
       description: 'Publish and manage safe declarative browser plugins',
@@ -710,6 +771,10 @@ async function showLocalBridgeStatus(options: StatusOptions): Promise<void> {
       fetchJson(`${url}/v1/tasks`, headers),
     ])
     const taskList = Array.isArray(tasks.tasks) ? tasks.tasks : []
+    const clients = (Array.isArray(library.clients) ? library.clients : []).map((clientValue) => {
+      const client = record(clientValue)
+      return { clientId: client.clientId, seenAt: client.seenAt }
+    })
     const state = await readLocalBridgeState(root)
     const activeState = state?.instanceId === health.instanceId ? state : undefined
     const result = {
@@ -721,7 +786,7 @@ async function showLocalBridgeStatus(options: StatusOptions): Promise<void> {
         startedAt: health.startedAt,
         uptimeSeconds: health.uptimeSeconds,
       },
-      library,
+      library: { ...library, clients },
       ok: health.ok === true && library.ok === true && tasks.ok === true,
       service: health.service,
       tasks: {
@@ -734,6 +799,43 @@ async function showLocalBridgeStatus(options: StatusOptions): Promise<void> {
     }
     output(result, { json: options.json })
     if (!result.ok) process.exitCode = 1
+  } catch (error) {
+    outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+    process.exitCode = 1
+  }
+}
+
+async function showLocalBridgeToken(options: TokenShowOptions): Promise<void> {
+  try {
+    const root = resolveLocalBridgeRoot(options.root)
+    const token = await readLocalBridgeToken(root)
+    output({ ok: true, root, token }, { json: options.json })
+  } catch (error) {
+    outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+    process.exitCode = 1
+  }
+}
+
+async function rotateLocalBridgeToken(options: StatusOptions): Promise<void> {
+  try {
+    const root = resolveLocalBridgeRoot(options.root)
+    const currentToken = await readLocalBridgeToken(root, options.token)
+    const url = await resolveLocalBridgeUrl(root, options.url)
+    const result = await fetchJson(
+      `${url}/v1/admin/token/rotate`,
+      authorizationHeaders(currentToken, true),
+      'POST',
+    )
+    output(
+      {
+        message: 'Paste this new token into Shadow Clipper. The previous token no longer works.',
+        ok: result.ok === true,
+        root,
+        token: result.token,
+        url,
+      },
+      { json: options.json },
+    )
   } catch (error) {
     outputError(error instanceof Error ? error.message : String(error), { json: options.json })
     process.exitCode = 1
@@ -802,6 +904,34 @@ async function showLocalBridgeLibraryOverview(options: StatusOptions): Promise<v
     const { token, url } = await resolveLocalBridgeConnection(options)
     const overview = await fetchJson(`${url}/v1/library/overview`, authorizationHeaders(token))
     output(overview, { json: options.json })
+  } catch (error) {
+    outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+    process.exitCode = 1
+  }
+}
+
+async function showLocalBridgeLibraryHistory(options: TaskListOptions): Promise<void> {
+  try {
+    const { token, url } = await resolveLocalBridgeConnection(options)
+    const result = await fetchJson(
+      localBridgeEndpoint(url, '/v1/library/history', {
+        limit: String(parseIntegerOption(options.limit, 1, 100, 'Limit')),
+      }),
+      authorizationHeaders(token),
+    )
+    const history = Array.isArray(result.history) ? result.history : []
+    if (options.json) output(result, { json: true })
+    else if (!history.length) console.log('No library syncs yet')
+    else {
+      for (const value of history) {
+        const entry = record(value)
+        const counts =
+          entry.status === 'succeeded'
+            ? `written ${Number(entry.written ?? 0)}, unchanged ${Number(entry.unchanged ?? 0)}, removed ${Number(entry.removed ?? 0)}`
+            : String(entry.error ?? 'sync failed')
+        console.log(`${String(entry.completedAt ?? '')}  ${String(entry.status ?? '')}  ${counts}`)
+      }
+    }
   } catch (error) {
     outputError(error instanceof Error ? error.message : String(error), { json: options.json })
     process.exitCode = 1
@@ -1090,11 +1220,46 @@ async function invokeLocalBridgePluginInterface(
 async function listLocalBridgeTasks(options: TaskListOptions): Promise<void> {
   try {
     const { token, url } = await resolveLocalBridgeConnection(options)
+    const [catalogResponse, runsResponse] = await Promise.all([
+      fetchJson(`${url}/v1/plugin-tasks`, authorizationHeaders(token)),
+      fetchJson(`${url}/v1/tasks`, authorizationHeaders(token)),
+    ])
+    const limit = parseIntegerOption(options.limit, 1, 200, 'Limit')
+    const availableTasks = Array.isArray(catalogResponse.tasks) ? catalogResponse.tasks : []
+    const runs = (Array.isArray(runsResponse.tasks) ? runsResponse.tasks : []).slice(0, limit)
+    if (options.json) {
+      output(
+        {
+          availableTasks,
+          connected: catalogResponse.connected === true,
+          ok: true,
+          runs,
+          url,
+        },
+        { json: true },
+      )
+    } else {
+      printAvailablePluginTasks(availableTasks, catalogResponse.connected === true)
+      if (runs.length) {
+        console.log('')
+        console.log('Recent task runs')
+        printTasks(runs)
+      }
+    }
+  } catch (error) {
+    outputError(error instanceof Error ? error.message : String(error), { json: options.json })
+    process.exitCode = 1
+  }
+}
+
+async function listLocalBridgeTaskRuns(options: TaskListOptions): Promise<void> {
+  try {
+    const { token, url } = await resolveLocalBridgeConnection(options)
     const response = await fetchJson(`${url}/v1/tasks`, authorizationHeaders(token))
     const limit = parseIntegerOption(options.limit, 1, 200, 'Limit')
-    const tasks = (Array.isArray(response.tasks) ? response.tasks : []).slice(0, limit)
-    if (options.json) output({ ok: true, tasks, url }, { json: true })
-    else printTasks(tasks)
+    const runs = (Array.isArray(response.tasks) ? response.tasks : []).slice(0, limit)
+    if (options.json) output({ ok: true, runs, url }, { json: true })
+    else printTasks(runs)
   } catch (error) {
     outputError(error instanceof Error ? error.message : String(error), { json: options.json })
     process.exitCode = 1
@@ -1318,14 +1483,6 @@ async function diagnoseLocalBridge(options: StatusOptions): Promise<void> {
         Authorization: `Bearer ${token}`,
       })
       const fileCount = Number(record(library.files).total ?? library.files ?? 0)
-      checks.push({
-        check: 'library',
-        message:
-          fileCount > 0
-            ? `${fileCount} managed files are available`
-            : 'The library is empty. Choose Sync now in Shadow Clipper.',
-        ok: fileCount > 0,
-      })
       const clients = Array.isArray(library.clients) ? library.clients : []
       checks.push({
         check: 'browser',
@@ -1334,6 +1491,16 @@ async function diagnoseLocalBridge(options: StatusOptions): Promise<void> {
             ? `${clients.length} Shadow Clipper client${clients.length === 1 ? ' is' : 's are'} connected`
             : 'No recent Shadow Clipper heartbeat. Open Chrome and test the connection.',
         ok: clients.length > 0,
+      })
+      checks.push({
+        check: 'library',
+        message:
+          fileCount > 0
+            ? `${fileCount} managed files are available`
+            : clients.length > 0
+              ? `The browser is connected, but no library snapshot has arrived. Run: shadowob local-bridge library sync --url ${url} --root ${shellQuote(root)} --timeout 60`
+              : 'The library snapshot is empty. Connect Shadow Clipper, then run local-bridge library sync.',
+        ok: fileCount > 0,
       })
     } catch (error) {
       checks.push({
@@ -1371,11 +1538,15 @@ export function buildConnectionGuide(
     checks: {
       doctorCommand: `shadowob local-bridge doctor --url ${address} --root ${shellQuote(library)}`,
       inspectCommand: `shadowob local-bridge inspect --url ${address} --root ${shellQuote(library)}`,
+      libraryHistoryCommand: `shadowob local-bridge library history --url ${address} --root ${shellQuote(library)}`,
       logsCommand: `shadowob local-bridge logs --root ${shellQuote(library)}`,
       resourcesCommand: `shadowob local-bridge resources capabilities --url ${address} --root ${shellQuote(library)}`,
+      syncCommand: `shadowob local-bridge library sync --url ${address} --root ${shellQuote(library)} --timeout 60`,
       startCommand: `shadowob local-bridge start --detach --port ${new URL(address).port || '80'} --root ${shellQuote(library)}`,
       statusCommand: `shadowob local-bridge status --url ${address} --root ${shellQuote(library)}`,
       stopCommand: `shadowob local-bridge stop --url ${address} --root ${shellQuote(library)}`,
+      tokenRotateCommand: `shadowob local-bridge token rotate --url ${address} --root ${shellQuote(library)}`,
+      tokenShowCommand: `shadowob local-bridge token show --root ${shellQuote(library)}`,
     },
     codex: {
       addCommand: `codex mcp add shadow-clipper -- shadowob local-bridge mcp --url ${address} --root ${shellQuote(library)}`,
@@ -1383,9 +1554,9 @@ export function buildConnectionGuide(
     extension: {
       address,
       steps: [
-        'Open Shadow Clipper → Settings → Sync → Local Bridge.',
+        'Open Shadow Clipper → Settings → Shadow CLI.',
         'Paste the address and token shown here, then choose Test connection.',
-        'Choose Sync now once; later library changes can sync automatically.',
+        'The first library sync starts automatically. Later changes keep the local snapshot updated.',
       ],
       token,
     },
@@ -1418,8 +1589,14 @@ function printConnectionGuide(
   console.log('')
   console.log('Verify the connection:')
   console.log(`  ${guide.checks.doctorCommand}`)
+  console.log(`  ${guide.checks.syncCommand}`)
   console.log(`  ${guide.checks.inspectCommand}`)
   console.log(`  ${guide.checks.resourcesCommand}`)
+  console.log('')
+  console.log('Token and sync history:')
+  console.log(`  ${guide.checks.tokenShowCommand}`)
+  console.log(`  ${guide.checks.tokenRotateCommand}`)
+  console.log(`  ${guide.checks.libraryHistoryCommand}`)
   console.log('')
   if (options.mode === 'background') {
     if (options.logPath) console.log(`Logs: ${options.logPath}`)
@@ -1705,7 +1882,7 @@ function localizedText(value: unknown): string {
 
 function printTasks(tasks: unknown[]): void {
   if (!tasks.length) {
-    console.log('No plugin tasks')
+    console.log('No task runs yet')
     return
   }
   for (const taskValue of tasks) {
@@ -1715,6 +1892,25 @@ function printTasks(tasks: unknown[]): void {
         ? `${String(record(task.operation).resource ?? 'unknown')}/${String(record(task.operation).action ?? 'unknown')}`
         : `${String(task.pluginId ?? 'unknown')}/${String(task.taskId ?? 'unknown')}`
     console.log(`${String(task.id ?? 'unknown')}  ${String(task.status ?? 'unknown')}  ${target}`)
+  }
+}
+
+function printAvailablePluginTasks(tasks: unknown[], connected: boolean): void {
+  if (!connected) {
+    console.log('No connected Shadow Clipper client. Open Chrome and test the connection first.')
+    return
+  }
+  if (!tasks.length) {
+    console.log('No plugin task definitions are available from the connected client.')
+    return
+  }
+  console.log('Available plugin tasks')
+  for (const taskValue of tasks) {
+    const task = record(taskValue)
+    const label = localizedText(task.label)
+    console.log(
+      `${String(task.pluginId ?? 'unknown')}/${String(task.id ?? 'unknown')}${label ? `  ${label}` : ''}`,
+    )
   }
 }
 

--- a/packages/cli/src/utils/local-bridge.ts
+++ b/packages/cli/src/utils/local-bridge.ts
@@ -72,6 +72,19 @@ interface LibraryOverviewCache {
   overview?: JsonRecord
 }
 
+interface LibrarySyncHistoryEntry {
+  completedAt: string
+  error?: string
+  files?: number
+  id: string
+  issues?: number
+  removed?: number
+  startedAt: string
+  status: 'succeeded' | 'failed'
+  unchanged?: number
+  written?: number
+}
+
 interface PluginTaskCapability {
   id: string
   label?: LocalizedCapability
@@ -134,6 +147,12 @@ interface ConnectedClient {
   plugins: PluginCapability[]
   resources: Record<string, string[]>
   seenAt: string
+}
+
+interface AvailablePluginTask extends PluginTaskCapability {
+  clientIds: string[]
+  pluginId: string
+  pluginName?: string
 }
 
 interface ResourceOperation {
@@ -258,7 +277,7 @@ export async function createLocalBridge(
   const root = resolveLocalBridgeRoot(options.root)
   const metadataDir = join(root, '.clipper')
   await mkdir(metadataDir, { recursive: true })
-  const token = await resolveLocalBridgeToken(root, options.token)
+  let activeToken = await resolveLocalBridgeToken(root, options.token)
   const mcpServers = resolveLocalMcpServers(options.mcpServers)
   const localRuntimeEnabled = options.localRuntimeEnabled === true
   const instanceId = randomUUID()
@@ -287,10 +306,16 @@ export async function createLocalBridge(
       requestShutdown: () => {
         setImmediate(() => void shutdown())
       },
+      readToken: () => activeToken,
       response,
       root,
+      rotateToken: async () => {
+        const nextToken = randomBytes(32).toString('base64url')
+        await writePrivateToken(localBridgeTokenPath(root), nextToken)
+        activeToken = nextToken
+        return nextToken
+      },
       startedAt,
-      token,
     }).catch((error: unknown) => {
       const status = errorStatus(error)
       sendJson(response, status, {
@@ -299,7 +324,15 @@ export async function createLocalBridge(
       })
     })
   })
-  return { instanceId, localRuntimeEnabled, root, server, shutdown, startedAt, token }
+  return {
+    instanceId,
+    localRuntimeEnabled,
+    root,
+    server,
+    shutdown,
+    startedAt,
+    token: activeToken,
+  }
 }
 
 async function handleRequest(context: {
@@ -308,12 +341,13 @@ async function handleRequest(context: {
   localRuntimeEnabled: boolean
   mcpServers: Map<string, LocalMcpServerDefinition>
   metadataDir: string
+  readToken: () => string
   request: IncomingMessage
   requestShutdown: () => void
   response: ServerResponse
   root: string
+  rotateToken: () => Promise<string>
   startedAt: string
-  token: string
 }): Promise<void> {
   const {
     allowedOrigins,
@@ -321,12 +355,13 @@ async function handleRequest(context: {
     localRuntimeEnabled,
     mcpServers,
     metadataDir,
+    readToken,
     request,
     requestShutdown,
     response,
     root,
+    rotateToken,
     startedAt,
-    token,
   } = context
   applyCors(request, response, allowedOrigins)
   if (request.method === 'OPTIONS') {
@@ -348,7 +383,7 @@ async function handleRequest(context: {
     })
     return
   }
-  if (request.headers.authorization !== `Bearer ${token}`) {
+  if (request.headers.authorization !== `Bearer ${readToken()}`) {
     sendJson(response, 401, { error: 'Unauthorized', ok: false })
     return
   }
@@ -359,9 +394,41 @@ async function handleRequest(context: {
     return
   }
 
+  if (request.method === 'POST' && url.pathname === '/v1/admin/token/rotate') {
+    const token = await rotateToken()
+    sendJson(response, 200, { ok: true, token })
+    return
+  }
+
   if (request.method === 'POST' && url.pathname === '/v1/library/sync') {
+    const startedAt = new Date().toISOString()
     const buffer = await readBody(request, MAX_ZIP_BYTES)
-    const result = await withLock('library', () => syncZip(buffer, root, metadataDir))
+    const result = await withLock('library', async () => {
+      try {
+        const synced = await syncZip(buffer, root, metadataDir)
+        await appendLibrarySyncHistory(metadataDir, {
+          completedAt: String(synced.completedAt),
+          files: Number(synced.files),
+          id: `sync_${randomUUID()}`,
+          issues: Number(synced.issues),
+          removed: Number(synced.removed),
+          startedAt,
+          status: 'succeeded',
+          unchanged: Number(synced.unchanged),
+          written: Number(synced.written),
+        })
+        return synced
+      } catch (error) {
+        await appendLibrarySyncHistory(metadataDir, {
+          completedAt: new Date().toISOString(),
+          error: error instanceof Error ? error.message : 'Library sync failed',
+          id: `sync_${randomUUID()}`,
+          startedAt,
+          status: 'failed',
+        }).catch(() => undefined)
+        throw error
+      }
+    })
     sendJson(response, 200, { ...result, ok: true, root })
     return
   }
@@ -460,9 +527,26 @@ async function handleRequest(context: {
     return
   }
 
+  if (request.method === 'GET' && url.pathname === '/v1/library/history') {
+    const limit = integerInRange(url.searchParams.get('limit') ?? undefined, 1, 100, 20, 'limit')
+    const history = await readLibrarySyncHistory(metadataDir)
+    sendJson(response, 200, { history: history.slice(0, limit), ok: true })
+    return
+  }
+
   if (request.method === 'GET' && url.pathname === '/v1/plugins') {
     const clients = await connectedClientCapabilities(metadataDir)
     sendJson(response, 200, { clients, connected: clients.length > 0, ok: true })
+    return
+  }
+
+  if (request.method === 'GET' && url.pathname === '/v1/plugin-tasks') {
+    const clients = await connectedClientCapabilities(metadataDir)
+    sendJson(response, 200, {
+      connected: clients.length > 0,
+      ok: true,
+      tasks: availablePluginTasks(clients),
+    })
     return
   }
 
@@ -974,13 +1058,68 @@ function mcpTools(localRuntimeEnabled: boolean): JsonRecord[] {
     },
     {
       annotations: { readOnlyHint: true },
-      description: 'List queued, running, and completed Shadow Clipper tasks.',
+      description:
+        'List currently available plugin task definitions together with queued, running, and completed task runs.',
       inputSchema: {
         additionalProperties: false,
         properties: { limit: { maximum: 200, minimum: 1, type: 'integer' } },
         type: 'object',
       },
       name: 'clipper_list_tasks',
+    },
+    {
+      description:
+        'Ask the connected Shadow Clipper browser to export the latest library snapshot to Local Bridge. Waits for completion by default.',
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          idempotencyKey: { maxLength: 240, type: 'string' },
+          timeoutMs: { maximum: MAX_TASK_WAIT_MS, minimum: 0, type: 'integer' },
+          wait: { type: 'boolean' },
+        },
+        type: 'object',
+      },
+      name: 'clipper_sync_library',
+    },
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        'List recent Local Bridge library sync attempts, including completion time and incremental written, unchanged, and removed counts.',
+      inputSchema: {
+        additionalProperties: false,
+        properties: { limit: { maximum: 100, minimum: 1, type: 'integer' } },
+        type: 'object',
+      },
+      name: 'clipper_list_library_syncs',
+    },
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        'List automations saved in the connected Shadow Clipper browser, including plugin, task, schedule, state, options, and latest run information.',
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          timeoutMs: { maximum: MAX_TASK_WAIT_MS, minimum: 0, type: 'integer' },
+          wait: { type: 'boolean' },
+        },
+        type: 'object',
+      },
+      name: 'clipper_list_automations',
+    },
+    {
+      description: 'Run one saved Shadow Clipper automation by its automation ID.',
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          automationId: { type: 'string' },
+          idempotencyKey: { maxLength: 240, type: 'string' },
+          timeoutMs: { maximum: MAX_TASK_WAIT_MS, minimum: 0, type: 'integer' },
+          wait: { type: 'boolean' },
+        },
+        required: ['automationId'],
+        type: 'object',
+      },
+      name: 'clipper_run_automation',
     },
     {
       annotations: { readOnlyHint: true },
@@ -1201,11 +1340,52 @@ async function callMcpTool(
   if (name === 'clipper_list_tasks') {
     const state = await readTaskState(metadataDir)
     const limit = integerInRange(args.limit, 1, 200, 50, 'limit')
+    const clients = await connectedClientCapabilities(metadataDir)
     return mcpTextResult({
-      tasks: state.order
+      availableTasks: availablePluginTasks(clients),
+      connected: clients.length > 0,
+      runs: state.order
         .slice(0, limit)
         .map((id) => state.tasks[id])
         .filter(Boolean),
+    })
+  }
+  if (name === 'clipper_sync_library') {
+    return mcpTextResult({
+      task: await enqueueAndMaybeWaitResourceOperation(metadataDir, {
+        action: 'sync',
+        idempotencyKey: args.idempotencyKey,
+        resource: 'library',
+        timeoutMs: args.timeoutMs,
+        wait: args.wait,
+      }),
+    })
+  }
+  if (name === 'clipper_list_library_syncs') {
+    const limit = integerInRange(args.limit, 1, 100, 20, 'limit')
+    const history = await readLibrarySyncHistory(metadataDir)
+    return mcpTextResult({ history: history.slice(0, limit) })
+  }
+  if (name === 'clipper_list_automations') {
+    return mcpTextResult({
+      task: await enqueueAndMaybeWaitResourceOperation(metadataDir, {
+        action: 'list',
+        resource: 'automations',
+        timeoutMs: args.timeoutMs,
+        wait: args.wait,
+      }),
+    })
+  }
+  if (name === 'clipper_run_automation') {
+    return mcpTextResult({
+      task: await enqueueAndMaybeWaitResourceOperation(metadataDir, {
+        action: 'run',
+        id: args.automationId,
+        idempotencyKey: args.idempotencyKey,
+        resource: 'automations',
+        timeoutMs: args.timeoutMs,
+        wait: args.wait,
+      }),
     })
   }
   if (name === 'clipper_get_task') {
@@ -1350,6 +1530,32 @@ async function connectedClientCapabilities(metadataDir: string): Promise<Connect
       resources: client.capabilities.resources ?? {},
       seenAt: client.seenAt,
     }))
+}
+
+function availablePluginTasks(clients: ConnectedClient[]): AvailablePluginTask[] {
+  const tasks = new Map<string, AvailablePluginTask>()
+  for (const client of clients) {
+    for (const plugin of client.plugins) {
+      for (const task of plugin.tasks) {
+        const key = `${plugin.id}:${task.id}`
+        const existing = tasks.get(key)
+        if (existing) {
+          if (!existing.clientIds.includes(client.clientId))
+            existing.clientIds.push(client.clientId)
+          continue
+        }
+        tasks.set(key, {
+          ...task,
+          clientIds: [client.clientId],
+          pluginId: plugin.id,
+          ...(plugin.name ? { pluginName: plugin.name } : {}),
+        })
+      }
+    }
+  }
+  return [...tasks.values()].sort(
+    (left, right) => left.pluginId.localeCompare(right.pluginId) || left.id.localeCompare(right.id),
+  )
 }
 
 async function touchClientSeenAt(metadataDir: string, clientId: string): Promise<void> {
@@ -1593,6 +1799,19 @@ async function enqueueDeclaredResourceOperation(
   if (operation.artifactId) await assertArtifactExists(metadataDir, operation.artifactId)
   return withLock('tasks', () =>
     enqueueResourceOperation(metadataDir, { ...record(input), ...operation }),
+  )
+}
+
+async function enqueueAndMaybeWaitResourceOperation(
+  metadataDir: string,
+  input: JsonRecord,
+): Promise<BridgeTask> {
+  const task = await enqueueDeclaredResourceOperation(metadataDir, input)
+  if (input.wait === false) return task
+  return waitForTask(
+    metadataDir,
+    task.id,
+    integerInRange(input.timeoutMs, 0, MAX_TASK_WAIT_MS, DEFAULT_TASK_WAIT_MS, 'timeoutMs'),
   )
 }
 
@@ -2027,6 +2246,30 @@ async function readTaskState(metadataDir: string): Promise<TaskState> {
 
 async function writeTaskState(metadataDir: string, state: TaskState): Promise<void> {
   await atomicJson(join(metadataDir, 'agent-tasks.json'), state)
+}
+
+async function readLibrarySyncHistory(metadataDir: string): Promise<LibrarySyncHistoryEntry[]> {
+  const history = await readJsonFile<unknown[]>(join(metadataDir, 'library-sync-history.json'), [])
+  return history.filter((value): value is LibrarySyncHistoryEntry => {
+    const entry = record(value)
+    return (
+      typeof entry.id === 'string' &&
+      typeof entry.startedAt === 'string' &&
+      typeof entry.completedAt === 'string' &&
+      (entry.status === 'succeeded' || entry.status === 'failed')
+    )
+  })
+}
+
+async function appendLibrarySyncHistory(
+  metadataDir: string,
+  entry: LibrarySyncHistoryEntry,
+): Promise<void> {
+  const history = await readLibrarySyncHistory(metadataDir)
+  await atomicJson(
+    join(metadataDir, 'library-sync-history.json'),
+    [entry, ...history].slice(0, 100),
+  )
 }
 
 async function managedLibraryFiles(metadataDir: string): Promise<string[]> {


### PR DESCRIPTION
## Summary
- expose the complete connected plugin task catalog and saved automations through CLI, HTTP, and MCP
- add immediate library sync, incremental sync history, and compact status output
- add Local Bridge token recovery and live rotation commands
- update the English and Chinese connection guides

## Validation
- pnpm --filter @shadowob/cli typecheck
- pnpm --filter @shadowob/cli test -- --run
- pnpm --filter @shadowob/cli build
- real Chrome Local Bridge smoke with automatic/manual sync, 160 discovered tasks, automation/resource operations, and MCP sync history
- global CLI installed under Node 22 and verified against the live 647-file library