### PR TITLE
Add Zen App Store pages and stabilize production CI

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,7 +2,7 @@ name: deploy-production
 
 on:
   workflow_run:
-    workflows: [publish-prod-images]
+    workflows: [Publish runner images]
     branches: [main]
     types: [completed]
   workflow_dispatch:
@@ -62,7 +62,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Wait for matching runner images
+      - name: Wait for matching production images
         shell: bash
         env:
           IMAGE_REGISTRY: ${{ vars.PROD_IMAGE_REGISTRY || 'ghcr.io' }}
@@ -73,6 +73,9 @@ jobs:
 
           namespace="$(printf '%s' "$IMAGE_NAMESPACE" | tr '[:upper:]' '[:lower:]')"
           images=(
+            shadow-server
+            shadow-web
+            shadow-admin
             openclaw-runner
             claude-runner
             codex-runner
@@ -90,15 +93,15 @@ jobs:
             done
 
             if [ "${#missing[@]}" -eq 0 ]; then
-              echo "All runner images are available for ${IMAGE_TAG}."
+              echo "All production images are available for ${IMAGE_TAG}."
               exit 0
             fi
 
-            echo "Waiting for runner images (${IMAGE_TAG}): ${missing[*]}"
+            echo "Waiting for production images (${IMAGE_TAG}): ${missing[*]}"
             sleep 30
           done
 
-          echo "Timed out waiting for runner images tagged ${IMAGE_TAG}." >&2
+          echo "Timed out waiting for production images tagged ${IMAGE_TAG}." >&2
           exit 1
 
       - name: Prepare SSH auth

--- a/.github/workflows/publish-openclaw-runner.yml
+++ b/.github/workflows/publish-openclaw-runner.yml
@@ -68,6 +68,7 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         include:
           - image: openclaw-runner
@@ -169,7 +170,29 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push
+        id: build_push
+        continue-on-error: true
         if: github.event_name != 'workflow_dispatch' || inputs.image == 'all' || inputs.image == matrix.image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.image.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event.workflow_run.head_sha || github.sha }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image }},ignore-error=true
+
+      - name: Back off after a registry push failure
+        if: steps.build_push.outcome == 'failure'
+        shell: bash
+        run: sleep 180
+
+      - name: Retry build and push
+        if: steps.build_push.outcome == 'failure'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/integrations/warbuddy/__tests__/game.test.ts
+++ b/integrations/warbuddy/__tests__/game.test.ts
@@ -228,6 +228,68 @@ describe('warbuddy battle engine', () => {
     expect(implicit.frames.at(-1)?.state.tanks).toEqual(explicit.frames.at(-1)?.state.tanks)
   })
 
+  it('keeps the trusted bundled strategy deterministic under a strict custom script deadline', () => {
+    const rules = {
+      ...DEFAULT_WARBUDDY_RULES,
+      script: {
+        ...DEFAULT_WARBUDDY_RULES.script,
+        timeoutMs: 1,
+      },
+    }
+    const replay = runRealtimeBattle({
+      challenger: tank({ id: 'default-a', name: 'Default A', code: '' }),
+      defender: tank({
+        id: 'default-b',
+        name: 'Default B',
+        code: DEFAULT_TANK_STRATEGY_CODE,
+      }),
+      seed: 22,
+      mapId: 'dirt-maze',
+      maxFrames: 160,
+      rules,
+    })
+
+    expect(
+      replay.events.some(
+        (event) =>
+          event.type === 'runtime' &&
+          (event.action === 'compile_error' || event.action === 'script_error'),
+      ),
+    ).toBe(false)
+  })
+
+  it('still enforces script deadlines for submitted strategy code', () => {
+    const rules = {
+      ...DEFAULT_WARBUDDY_RULES,
+      script: {
+        ...DEFAULT_WARBUDDY_RULES.script,
+        timeoutMs: 5,
+      },
+    }
+    const replay = runRealtimeBattle({
+      challenger: tank({
+        id: 'loop',
+        name: 'Loop',
+        code: 'function onIdle() { while (true) {} }',
+      }),
+      defender: tank({ id: 'safe', name: 'Safe', code: 'function onIdle() {}' }),
+      seed: 5,
+      mapId: 'classic',
+      maxFrames: 0,
+      rules,
+    })
+
+    expect(
+      replay.events.some(
+        (event) =>
+          event.type === 'runtime' &&
+          event.action === 'script_error' &&
+          event.tank === 'Loop' &&
+          String(event.reason).includes('timed out'),
+      ),
+    ).toBe(true)
+  })
+
   it('keeps no-code default engineers moving when unsafe terrain bombs are rejected', () => {
     const replay = runRealtimeBattle({
       challenger: tank({ id: 'classic-a', name: 'Classic A', skillType: 'boost', code: '' }),

--- a/integrations/warbuddy/src/realtime-battle.ts
+++ b/integrations/warbuddy/src/realtime-battle.ts
@@ -170,6 +170,7 @@ function createScriptMath(rng: () => number) {
 
 class DuelScriptBrain {
   private readonly timeoutMs: number
+  private readonly usesBundledDefaultStrategy: boolean
   private readonly context: vm.Context
   private readonly callScript = new vm.Script(
     `(() => {
@@ -213,6 +214,7 @@ class DuelScriptBrain {
     const submittedCode =
       Buffer.byteLength(profile.code, 'utf8') > rules.script.maxBytes ? '' : profile.code.trim()
     const raw = submittedCode || DEFAULT_TANK_STRATEGY_CODE
+    this.usesBundledDefaultStrategy = raw === DEFAULT_TANK_STRATEGY_CODE
     if (!raw) {
       this.compileError = null
       this.hasHandlers = false
@@ -237,13 +239,19 @@ class DuelScriptBrain {
             throw new Error("invalid_onEngineerIdle");
           }
         })();`,
-      ).runInContext(this.context, { timeout: this.timeoutMs })
+      ).runInContext(
+        this.context,
+        this.usesBundledDefaultStrategy ? undefined : { timeout: this.timeoutMs },
+      )
       this.hasHandlers = Boolean(
         new vm.Script(
           `typeof onIdle === "function" ||
             typeof onTankIdle === "function" ||
             typeof onEngineerIdle === "function"`,
-        ).runInContext(this.context, { timeout: this.timeoutMs }),
+        ).runInContext(
+          this.context,
+          this.usesBundledDefaultStrategy ? undefined : { timeout: this.timeoutMs },
+        ),
       )
       this.compileError = null
     } catch (error) {
@@ -277,7 +285,10 @@ class DuelScriptBrain {
     ;(this.context as Record<string, unknown>).__enemy = snapshot.enemy
     ;(this.context as Record<string, unknown>).__game = snapshot.game
     try {
-      this.callScript.runInContext(this.context, { timeout: this.timeoutMs })
+      this.callScript.runInContext(
+        this.context,
+        this.usesBundledDefaultStrategy ? undefined : { timeout: this.timeoutMs },
+      )
       return {
         ok: true as const,
         actions: sanitizeDuelActions(actions),

--- a/website/docs/en/apps/zen/privacy.mdx
+++ b/website/docs/en/apps/zen/privacy.mdx
@@ -1,0 +1,75 @@
+---
+pageType: custom
+title: Zen Privacy Policy
+---
+
+import {
+  LegalExternalLink,
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="en" title="Zen (禅心问佛) Privacy Policy">
+  <LegalUpdated>Effective: August 8, 2026</LegalUpdated>
+
+  <p className="font-medium">This policy applies to Zen (禅心问佛), bundle identifier <code>com.shadowob.zen</code>. The developer or seller identified on the app's App Store product page is responsible for the app. This page explains what information the current version handles and where that processing happens.</p>
+
+  <LegalSectionHeading>1. Information stored on your device</LegalSectionHeading>
+  <p className="font-medium">The app stores the following information on your device so its features can work and your progress can be restored:</p>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li>daily practice order, duration, and completion status;</li>
+    <li>scripture bookmarks, reading position, text size, script preference, and copying, recitation, and listening progress;</li>
+    <li>prayer bead settings, instrument settings, check-ins, wishes, rituals, and temple visit records;</li>
+    <li>wishes, names, memorial text, and other content you choose to enter; and</li>
+    <li>photos you choose or take, plus colors, digital fingerprints, and share images generated from those photos on your device.</li>
+  </ul>
+  <p className="font-medium">This information is normally kept in the app sandbox or App Group container. Using daily practice, scriptures, instruments, or rituals does not upload it to our servers.</p>
+
+  <LegalSectionHeading>2. Camera and photos</LegalSectionHeading>
+  <p className="font-medium">The app accesses the camera only after you grant permission and start a feature that takes a photo. These photos are stored in the app sandbox.</p>
+  <p className="font-medium">For the “Old Photo Relic” feature, you select one photo. The app extracts colors, calculates a hash, and creates a texture on your device. The original photo does not appear in the generated share image. If you delete the original, it remains recoverable inside the app for seven days and is then removed.</p>
+  <p className="font-medium">For a temple check-in, you can select up to nine photos. The app compresses and stores them in its sandbox. The first photo may be used to create a check-in card. A share image is passed to another app only when you use the iOS share sheet.</p>
+  <p className="font-medium">When you save a check-in card, wish card, or another share image, the app writes the image to your photo library only after you grant permission.</p>
+
+  <LegalSectionHeading>3. Location and temple services</LegalSectionHeading>
+  <p className="font-medium">The app requests device location only when you open Nearby Temples or start location verification for a temple visit. You may decline this permission and continue using the app's other main features.</p>
+  <p className="font-medium">Temple features may use these external services:</p>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li><strong>Apple MapKit</strong> for nearby place search, distance calculation, and system navigation. See <LegalExternalLink href="https://www.apple.com/legal/privacy/data/en/apple-maps/">Apple Maps &amp; Privacy</LegalExternalLink>.</li>
+    <li><strong>National Religious Affairs Administration public place search</strong> to load public religious activity venue records. A temple keyword and selected region are sent with the query.</li>
+    <li><strong>Amap Web Service</strong> to supplement public temple addresses, telephone numbers, opening hours, and images. A request may include the temple name, region, and ordinary network connection information. See the <LegalExternalLink href="https://developer.amap.com/pages/privacy/">Amap Open Platform Privacy Policy</LegalExternalLink>.</li>
+  </ul>
+  <p className="font-medium">We do not use location for advertising and do not build a location history on our servers.</p>
+
+  <LegalSectionHeading>4. Permission summary</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li><strong>Camera:</strong> only for a photo feature you start.</li>
+    <li><strong>Photos:</strong> only when you select an old photo, attach temple check-in photos, save a share image, or use the iOS share sheet.</li>
+    <li><strong>Location:</strong> only for nearby temples, distance calculation, and temple visit verification.</li>
+    <li><strong>Background audio:</strong> so a bell or wooden fish session you start can continue while the device is locked or another app is open.</li>
+  </ul>
+  <p className="font-medium">You can change these permissions at any time in iOS Settings. Only features that need a disabled permission will stop working.</p>
+
+  <LegalSectionHeading>5. What the app does not do</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li>It does not require an account.</li>
+    <li>It does not include an advertising network.</li>
+    <li>It does not use App Tracking Transparency for cross-app tracking.</li>
+    <li>It does not sell personal information.</li>
+    <li>It does not use local practice records, wishes, or photos to create advertising profiles.</li>
+  </ul>
+
+  <LegalSectionHeading>6. Retention and deletion</LegalSectionHeading>
+  <p className="font-medium">Local information remains until you delete it in the app, the app removes it under a feature-specific rule, or you uninstall the app. Uninstalling normally removes data in the app sandbox. iOS backup and restore behavior depends on your device settings.</p>
+  <p className="font-medium">An original photo deleted from “Old Photo Relic” remains in the app's recovery area for seven days and is then removed. The current version does not have a single control for clearing all local data; uninstall the app if you need to remove its sandbox data at once.</p>
+
+  <LegalSectionHeading>7. Children</LegalSectionHeading>
+  <p className="font-medium">The app is not designed specifically for children. A minor should use features involving location, camera, photos, fasting, or other personal judgment with guidance from a parent or guardian.</p>
+
+  <LegalSectionHeading>8. Policy changes</LegalSectionHeading>
+  <p className="font-medium">If app features, external services, or information handling change, we will update this policy and its effective date. We will provide an appropriate notice for a material change.</p>
+
+  <LegalSectionHeading>9. Contact</LegalSectionHeading>
+  <p className="font-medium">To ask a privacy question, open a <a href="https://github.com/buggyblues/shadow/issues/new?title=%5BZen%20Privacy%5D%20" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Zen privacy request</a>. This is a public support channel. Do not include private wishes, photos, precise location, Apple account credentials, or other sensitive information.</p>
+</PublicDocPage>

--- a/website/docs/en/apps/zen/support.mdx
+++ b/website/docs/en/apps/zen/support.mdx
@@ -1,0 +1,38 @@
+---
+pageType: custom
+title: Zen App Support
+---
+
+import {
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="en" title="Zen (禅心问佛) Support">
+  <LegalUpdated>For app bundle: com.shadowob.zen</LegalUpdated>
+
+  <p className="font-medium">Use this page for help with daily practice, scripture reading, copying, recitation, listening, prayer beads, instruments, rituals, temple records, widgets, and Zen Pro purchases.</p>
+
+  <LegalSectionHeading>Contact support</LegalSectionHeading>
+  <p className="font-medium">Open a <a href="https://github.com/buggyblues/shadow/issues/new?title=%5BZen%20Support%5D%20" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Zen support request</a> and include your iPhone or iPad model, iOS version, app version, the steps that led to the problem, and a screenshot if it contains no private information. This is a public support channel.</p>
+  <p className="font-medium">Do not post private wishes, personal photos, precise location, Apple account credentials, payment information, or other sensitive information. Support will never ask for your Apple account password.</p>
+
+  <LegalSectionHeading>Restore a purchase</LegalSectionHeading>
+  <p className="font-medium">Open the profile tab, choose “Zen Pro,” and tap “Restore Purchases” at the top right. Restoring does not charge you again. Apple manages payment, renewal, cancellation, and refund status.</p>
+
+  <LegalSectionHeading>Nearby temples are not showing</LegalSectionHeading>
+  <p className="font-medium">Check that the device is online and that Zen has location permission in iOS Settings. Precise Location is optional; turning it off can make distance results less accurate.</p>
+
+  <LegalSectionHeading>A bell or wooden fish stops in the background</LegalSectionHeading>
+  <p className="font-medium">Check that audio is not paused in Control Center and that a system setting is not restricting background activity. Return to the instrument page and start the session again.</p>
+
+  <LegalSectionHeading>Delete an old photo</LegalSectionHeading>
+  <p className="font-medium">Open the “Old Photo Relic” detail page and delete the original photo. It remains in the app's recovery area for seven days and is then removed. You can restore it during those seven days.</p>
+
+  <LegalSectionHeading>Uninstalling the app</LegalSectionHeading>
+  <p className="font-medium">Practice plans, scripture progress, ritual records, and photos in the app sandbox are mainly stored on the device. Uninstalling normally removes them. Save any share images you want to keep before uninstalling.</p>
+
+  <LegalSectionHeading>Privacy</LegalSectionHeading>
+  <p className="font-medium">Read the <a href="/apps/zen/privacy" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Zen Privacy Policy</a>.</p>
+</PublicDocPage>

--- a/website/docs/zh/apps/zen/privacy.mdx
+++ b/website/docs/zh/apps/zen/privacy.mdx
@@ -1,0 +1,75 @@
+---
+pageType: custom
+title: 禅心问佛隐私政策
+---
+
+import {
+  LegalExternalLink,
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="zh" title="禅心问佛隐私政策">
+  <LegalUpdated>生效日期：2026 年 8 月 8 日</LegalUpdated>
+
+  <p className="font-medium">本政策适用于“禅心问佛”（Bundle ID：<code>com.shadowob.zen</code>）。App Store 产品页显示的开发者或销售方是本应用的责任主体。本页说明当前版本会处理哪些信息，以及这些处理发生在哪里。</p>
+
+  <LegalSectionHeading>一、保存在设备上的信息</LegalSectionHeading>
+  <p className="font-medium">应用会在你的设备上保存以下内容，用于提供功能和恢复使用进度：</p>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li>今日功课的顺序、时长与完成状态；</li>
+    <li>经文收藏、阅读进度、字号、简繁偏好，以及抄经、诵经和听经进度；</li>
+    <li>念珠设置、法器设置、打卡、祈愿、仪轨与寺院到访记录；</li>
+    <li>你主动填写的心愿、称谓、追思内容和其他表单内容；</li>
+    <li>你主动选择或拍摄的照片，以及应用在本机从这些照片生成的颜色、数字指纹和分享图片。</li>
+  </ul>
+  <p className="font-medium">这些内容通常保存在应用沙盒或 App Group 容器中。使用日课、经文、法器或仪轨功能不会把这些内容上传至我们的服务器。</p>
+
+  <LegalSectionHeading>二、相机与照片</LegalSectionHeading>
+  <p className="font-medium">只有在你授权并主动开始拍摄功能后，应用才会调用相机。拍摄的照片保存在应用沙盒中。</p>
+  <p className="font-medium">使用“旧我舍利”时，你可以选择一张照片。应用会在本机取色、计算哈希并生成纹理，原照片不会出现在生成的分享图中。删除原照片后，照片会在应用内保留七天用于恢复，期满后删除。</p>
+  <p className="font-medium">为探寺打卡关联图片时，你可以选择最多九张照片。应用会压缩照片并保存在应用沙盒中。第一张图片可用于生成打卡卡片；只有你主动打开 iOS 系统分享时，分享图片才会交给你选择的目标应用。</p>
+  <p className="font-medium">保存打卡卡片、祈愿卡或其他分享图片时，应用只会在你授权后把图片写入系统照片图库。</p>
+
+  <LegalSectionHeading>三、位置与寺院服务</LegalSectionHeading>
+  <p className="font-medium">只有在你主动打开“附近寺院”或开始到寺定位验证时，应用才会请求使用设备位置。你可以拒绝授权，其他主要功能仍可使用。</p>
+  <p className="font-medium">寺院功能可能使用以下外部服务：</p>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li><strong>Apple MapKit</strong>：用于附近地点搜索、距离计算与系统导航。相关规则见 <LegalExternalLink href="https://www.apple.com.cn/legal/privacy/data/zh-cn/apple-maps/">Apple 地图与隐私</LegalExternalLink>。</li>
+    <li><strong>国家宗教事务局宗教活动场所查询接口</strong>：用于加载公开的宗教活动场所名录。你输入的寺院关键词和选择的地区会随查询请求发送。</li>
+    <li><strong>高德地点 Web 服务</strong>：用于补充公开的寺院地址、电话、开放时间与图片信息。请求可能包含寺院名称、地区和正常网络连接所需的信息。相关规则见 <LegalExternalLink href="https://developer.amap.com/pages/privacy/">高德地图开放平台隐私权政策</LegalExternalLink>。</li>
+  </ul>
+  <p className="font-medium">我们不会把位置用于广告，也不会在自己的服务器上建立位置轨迹。</p>
+
+  <LegalSectionHeading>四、权限说明</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li><strong>相机：</strong>仅用于你主动开始的拍摄功能。</li>
+    <li><strong>照片：</strong>仅用于你选择旧照、关联探寺打卡图片、保存分享图片或使用 iOS 系统分享。</li>
+    <li><strong>位置：</strong>仅用于附近寺院、距离计算和到寺验证。</li>
+    <li><strong>后台音频：</strong>用于你主动开启的钟声或木鱼练习在锁屏或切换应用后继续播放。</li>
+  </ul>
+  <p className="font-medium">你可以随时在 iOS“设置”中修改权限。关闭权限后，只有依赖该权限的功能会受限。</p>
+
+  <LegalSectionHeading>五、应用不会做的事</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li>不要求注册账户；</li>
+    <li>不接入广告网络；</li>
+    <li>不使用 App Tracking Transparency 进行跨应用追踪；</li>
+    <li>不出售个人信息；</li>
+    <li>不使用本机修持记录、心愿或照片建立广告画像。</li>
+  </ul>
+
+  <LegalSectionHeading>六、信息保存与删除</LegalSectionHeading>
+  <p className="font-medium">本机信息会保留到你在应用内删除、应用按具体功能规则自动清理，或你卸载应用为止。卸载应用通常会删除应用沙盒中的数据；iOS 系统备份与恢复行为取决于你的设备设置。</p>
+  <p className="font-medium">“旧我舍利”的原照片进入恢复区后保留七天，期满删除。当前版本没有单独清除全部本地数据的总开关；如果需要一次删除应用沙盒内的数据，可以卸载应用。</p>
+
+  <LegalSectionHeading>七、未成年人</LegalSectionHeading>
+  <p className="font-medium">本应用不是专门面向儿童设计的产品。未成年人应在监护人指导下使用涉及位置、相机、照片、斋戒或其他需要自行判断的功能。</p>
+
+  <LegalSectionHeading>八、政策更新</LegalSectionHeading>
+  <p className="font-medium">如果应用功能、外部服务或信息处理方式发生变化，我们会更新本政策和生效日期。发生重大变化时，我们会通过适当方式提示。</p>
+
+  <LegalSectionHeading>九、联系我们</LegalSectionHeading>
+  <p className="font-medium">如需咨询隐私问题，请提交<a href="https://github.com/buggyblues/shadow/issues/new?title=%5BZen%20Privacy%5D%20" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>禅心问佛隐私请求</a>。该渠道内容公开，请勿提交私人心愿、照片、精确位置、Apple 账户凭据或其他敏感信息。</p>
+</PublicDocPage>

--- a/website/docs/zh/apps/zen/support.mdx
+++ b/website/docs/zh/apps/zen/support.mdx
@@ -1,0 +1,38 @@
+---
+pageType: custom
+title: 禅心问佛支持
+---
+
+import {
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="zh" title="禅心问佛支持">
+  <LegalUpdated>适用 App Bundle：com.shadowob.zen</LegalUpdated>
+
+  <p className="font-medium">本页提供今日功课、经文阅读、抄经、诵经、听经、念珠、法器、仪轨、寺院记录、小组件和禅心 Pro 购买帮助。</p>
+
+  <LegalSectionHeading>联系支持</LegalSectionHeading>
+  <p className="font-medium">请提交<a href="https://github.com/buggyblues/shadow/issues/new?title=%5BZen%20Support%5D%20" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>禅心问佛支持请求</a>，并提供 iPhone 或 iPad 机型、iOS 版本、应用版本、问题出现前的操作步骤，以及不含私人信息的截图。该渠道内容公开。</p>
+  <p className="font-medium">请勿提交私人心愿、个人照片、精确位置、Apple 账户凭据、付款信息或其他敏感信息。支持人员不会索要你的 Apple 账户密码。</p>
+
+  <LegalSectionHeading>恢复购买</LegalSectionHeading>
+  <p className="font-medium">打开右下角“我的”，进入“禅心 Pro”，点击右上角“恢复购买”。恢复购买不会重复收费。付款、续订、取消和退款状态由 Apple 管理。</p>
+
+  <LegalSectionHeading>附近寺院无法显示</LegalSectionHeading>
+  <p className="font-medium">请确认设备已联网，并在 iOS“设置”中允许禅心问佛使用位置。精确位置不是必需权限；关闭后，距离结果可能不够准确。</p>
+
+  <LegalSectionHeading>钟声或木鱼切换应用后停止</LegalSectionHeading>
+  <p className="font-medium">请确认控制中心没有暂停音频，系统设置也没有限制后台活动。返回法器页面后可以重新开始。</p>
+
+  <LegalSectionHeading>删除旧照</LegalSectionHeading>
+  <p className="font-medium">进入“旧我舍利”详情页，删除原照片。照片会在应用内的恢复区保留七天，期间可以恢复，期满后删除。</p>
+
+  <LegalSectionHeading>卸载应用</LegalSectionHeading>
+  <p className="font-medium">修持计划、经文进度、仪轨记录和应用沙盒内的照片主要保存在本机。卸载应用通常会删除这些数据。卸载前，请先保存需要保留的分享图片。</p>
+
+  <LegalSectionHeading>隐私政策</LegalSectionHeading>
+  <p className="font-medium">查看<a href="/zh/apps/zen/privacy" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>《禅心问佛隐私政策》</a>。</p>
+</PublicDocPage>

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -81,6 +81,16 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
       description:
         'Download the Shadow desktop app to run local Buddies, connect model providers, and link them to your community Spaces.',
     },
+    '/apps/zen/privacy': {
+      title: 'Zen Privacy Policy - Shadow',
+      description:
+        'Read how the Zen app handles local practice records, photos, location permissions, and third-party temple search services.',
+    },
+    '/apps/zen/support': {
+      title: 'Zen App Support - Shadow',
+      description:
+        'Get help with Zen practice plans, scripture reading, instruments, temple records, widgets, and App Store purchases.',
+    },
     '/platform/cloud': {
       title: 'Cloud Docs - Templates, Plugins, CLI, and Deployments',
       description:
@@ -136,6 +146,14 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
     '/download': {
       title: '下载虾豆桌面端 - 虾豆',
       description: '下载虾豆桌面端，在本机运行 Buddy、连接模型供应商，并关联到你的 Space。',
+    },
+    '/apps/zen/privacy': {
+      title: '禅心问佛隐私政策',
+      description: '了解禅心问佛如何处理本机修持记录、照片、位置权限和寺院查询服务涉及的信息。',
+    },
+    '/apps/zen/support': {
+      title: '禅心问佛支持',
+      description: '查看功课、经文、法器、寺院记录、小组件和 App Store 购买的帮助信息。',
     },
     '/platform/cloud': {
       title: '云文档 - 模版、插件、CLI 与部署',


### PR DESCRIPTION
## Summary

- add localized Zen privacy-policy and support pages under `shadowob.com/apps/zen/*`
- keep the bundled WarBuddy default strategy deterministic while preserving timeouts for submitted scripts
- reduce runner image push concurrency, retry transient registry failures, and gate production deployment on all matching core and runner images

## App Store URLs after production deployment

- `https://shadowob.com/apps/zen/privacy`
- `https://shadowob.com/apps/zen/support`
- `https://shadowob.com/zh/apps/zen/privacy`
- `https://shadowob.com/zh/apps/zen/support`

## Validation

- `pnpm --filter @shadowob/website build`
- WarBuddy game tests: 31 passed
- targeted WarBuddy deadline regressions: 5 consecutive passes
- `bash scripts/ops/verify-prod-no-build.sh`
- browser QA for English privacy and Chinese support pages
- all four local preview routes returned HTTP 200
- pre-commit and pre-push repository checks passed

## Pipeline failures addressed

- post-merge test flake: the published default strategy occasionally exceeded a 25 ms VM wall-clock deadline on a shared runner
- production deploy failure: concurrent runner image pushes hit a GHCR secondary rate limit, leaving `hermes-runner` unavailable for the deploy revision
