### PR TITLE
Add Clipper Chrome Web Store pages

### DIFF
--- a/website/docs/en/apps/clipper/index.mdx
+++ b/website/docs/en/apps/clipper/index.mdx
@@ -1,0 +1,37 @@
+---
+pageType: custom
+title: Shadow Clipper
+---
+
+import {
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="en" title="Shadow Clipper">
+  <LegalUpdated>Web clipping and a local Markdown library</LegalUpdated>
+
+  <p className="font-medium">Save worthwhile web pages, feeds, and PDFs into a library you control. Clipper keeps content in your current Chrome profile by default, with tools for focused reading, search, organization, export, and synchronization you choose.</p>
+
+  <LegalSectionHeading>Keep the useful parts of the web</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li>Save the current page in one click, including its source details, readable text, images, PDFs, and page snapshots when available.</li>
+    <li>Collect public pages and RSS feeds on demand or on a schedule you create.</li>
+    <li>Read Markdown in a focused view, then add folders, favorites, tags, highlights, notes, and reading state.</li>
+    <li>Search across the local library and review earlier versions of saved content.</li>
+  </ul>
+
+  <LegalSectionHeading>Local by default, connected by choice</LegalSectionHeading>
+  <p className="font-medium">No account is required for the core library. You can export a portable ZIP or choose to connect Google Drive, GitHub, or HTTPS WebDAV. Optional AI tools work only after you select a service and start an action. You may also sign in to Shadow to use an official model or send selected clips to a community Buddy.</p>
+
+  <LegalSectionHeading>Your data, your controls</LegalSectionHeading>
+  <p className="font-medium">Clipper has no ads or usage analytics and does not automatically upload your library to the developer. Extra browser access is requested when a feature first needs it, and can be declined or revoked. API keys, passwords, and sign-in credentials are kept only for the current browser session.</p>
+
+  <LegalSectionHeading>Learn more</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li>Read the <a href="/apps/clipper/privacy" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Clipper Privacy Policy</a>.</li>
+    <li>Visit <a href="/apps/clipper/support" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Clipper Support</a>.</li>
+    <li>View the <a href="https://github.com/buggyblues/clipper" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Clipper project on GitHub</a>.</li>
+  </ul>
+</PublicDocPage>

--- a/website/docs/en/apps/clipper/privacy.mdx
+++ b/website/docs/en/apps/clipper/privacy.mdx
@@ -1,0 +1,61 @@
+---
+pageType: custom
+title: Clipper Privacy Policy
+---
+
+import {
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="en" title="Clipper Privacy Policy">
+  <LegalUpdated>Effective: August 9, 2026 · Contact: volthesitan@gmail.com</LegalUpdated>
+
+  <p className="font-medium">This policy explains how the Clipper Chrome extension handles user data. Clipper has one purpose: saving web content selected by the user, or named in sources configured by the user, into a local Markdown library for reading, organization, export, and synchronization or sharing initiated by the user.</p>
+  <p className="font-medium">Core features do not require an account. A user may choose to sign in to Shadow to use an official model or send explicitly selected clips to a Buddy in a community. Clipper has no advertising or usage analytics.</p>
+
+  <LegalSectionHeading>1. Information Clipper handles</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li><strong>Website content and browsing activity:</strong> URLs, titles, page text, authors, dates, visible comments, transcripts, images, PDFs, snapshots, and feed entries from pages the user saves or adds to a capture task.</li>
+    <li><strong>Organization data:</strong> folders, favorites, tags, ratings, read state, highlights, notes, saved searches, capture tasks, run records, sync state, quick notes, and saved tab sessions.</li>
+    <li><strong>Separately authorized browser data:</strong> bookmarks, Reading List entries, open tabs, and recent history, used only for the feature the user opens. Clipper does not modify original bookmarks or browsing history.</li>
+    <li><strong>Calendar, place, and widget data:</strong> upcoming event titles and times shown from Google Calendar; public place labels and image location details already present in selected content; a city chosen for weather; and public ticker symbols chosen for market data. Clipper does not request live device location.</li>
+    <li><strong>Optional Shadow account data:</strong> account ID, username, display name, avatar, possible email address, and available community, channel, and Buddy information.</li>
+    <li><strong>Settings and diagnostics:</strong> interface choices, enabled sources, granted permissions, migration state, and content-free local diagnostic summaries. A diagnostic file is created only when the user exports it.</li>
+    <li><strong>Credentials:</strong> remote AI keys, GitHub tokens, WebDAV credentials, local-service tokens, note-connection tokens, and Shadow sign-in credentials. These remain only for the current browser session. Old plaintext copies found from an earlier version are moved into the current session and deleted. Google Drive authorization is managed by Chrome.</li>
+  </ul>
+
+  <LegalSectionHeading>2. How information is used</LegalSectionHeading>
+  <p className="font-medium">Clipper uses this information only to provide visible features: extracting and saving content, building a local index, displaying the library, running capture tasks created by the user, organizing tabs, showing selected widgets, exporting files, connecting to services chosen by the user, and completing AI, sync, or community actions started by the user.</p>
+  <p className="font-medium">Clipper does not sell user data, serve ads, create advertising profiles, or use data for creditworthiness, lending, or unrelated analytics.</p>
+
+  <LegalSectionHeading>3. Storage and retention</LegalSectionHeading>
+  <p className="font-medium">Content, attachments, indexes, settings, and non-sensitive run records stay in the current Chrome profile until the user deletes them or uninstalls the extension. Keys, passwords, and Shadow sign-in credentials remain only for the current browser session and can also be cleared in settings.</p>
+  <p className="font-medium">Clipper does not add separate encryption to local library content. Users should protect it with their Chrome profile, operating-system account, and device access controls. Copies exported, synchronized, or shared by the user are retained under the chosen destination's settings and policies.</p>
+
+  <LegalSectionHeading>4. Transfers and external services</LegalSectionHeading>
+  <p className="font-medium">Most features run in the browser. Information leaves the browser only when needed for a feature the user configures, authorizes, or starts:</p>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li><strong>Source websites</strong> receive requests for pages, public interfaces, images, transcripts, PDFs, or other attachments. Requests may use an existing Chrome sign-in for that site.</li>
+    <li><strong>Remote AI providers</strong> receive selected content, instructions, model settings, and the required key after the user chooses a provider and runs an action.</li>
+    <li><strong>Sync destinations</strong> receive selected archive files and required credentials after the user starts synchronization to Google Drive, GitHub, or HTTPS WebDAV. Google Drive access is limited to files Clipper created or the user explicitly provided to it.</li>
+    <li><strong>Shadow</strong> receives authorization and profile requests after sign-in. When the user sends clips to a community Buddy, the selected titles, sources, text, metadata, instructions, and task status are sent to that community.</li>
+    <li><strong>Google Calendar, Open-Meteo, geocoding, and market-data services</strong> receive only the limited calendar-page request, chosen city or coordinates, place name, or public ticker needed for the widget or lookup the user opens.</li>
+    <li><strong>Local destinations</strong> may receive selected content through browser file access, the clipboard, or a connection to a service on the same device after a user action.</li>
+  </ul>
+  <p className="font-medium">External services process received data under their own terms and privacy policies. Users should connect only services they trust.</p>
+
+  <LegalSectionHeading>5. Permissions and user control</LegalSectionHeading>
+  <p className="font-medium">Clipper uses current-page, script, snapshot, scheduling, identity, and storage access to complete requested features. Access to bookmarks, Reading List, tabs, history, calendar pages, and custom service addresses is requested when a related feature first needs it. Users can decline or revoke optional access; only the related feature will stop working.</p>
+
+  <LegalSectionHeading>6. Sharing and Limited Use</LegalSectionHeading>
+  <p className="font-medium">Except for source websites, AI providers, sync destinations, Shadow communities, local destinations, and widget services selected by the user, the developer does not receive or sell Clipper data. Support personnel review specific data only when the user submits it, when needed for security, or when required by law.</p>
+  <p className="font-medium">Clipper's use and transfer of user data are limited to providing or improving the clipping, local organization, export, synchronization, AI, and user-initiated sharing features disclosed here and in its store listing. Clipper complies with the Chrome Web Store User Data Policy, including Limited Use requirements.</p>
+
+  <LegalSectionHeading>7. Deleting information</LegalSectionHeading>
+  <p className="font-medium">Users can delete archive items, clear credentials, sign out of Shadow, revoke permissions, and delete exported diagnostic files. Uninstalling normally removes the extension's local data from the current Chrome profile. Copies sent to another service must be deleted at that destination.</p>
+
+  <LegalSectionHeading>8. Policy changes and contact</LegalSectionHeading>
+  <p className="font-medium">If Clipper materially changes its information practices, this policy and its effective date will be updated, and consent will be requested where required. For privacy questions or deletion requests, email <a href="mailto:volthesitan@gmail.com" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>volthesitan@gmail.com</a>.</p>
+</PublicDocPage>

--- a/website/docs/en/apps/clipper/support.mdx
+++ b/website/docs/en/apps/clipper/support.mdx
@@ -1,0 +1,33 @@
+---
+pageType: custom
+title: Clipper Support
+---
+
+import {
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="en" title="Clipper Support">
+  <LegalUpdated>Support for the Shadow Clipper Chrome extension</LegalUpdated>
+
+  <LegalSectionHeading>Contact support</LegalSectionHeading>
+  <p className="font-medium">Open a <a href="https://github.com/buggyblues/clipper/issues/new?title=%5BSupport%5D%20" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>public Clipper support request</a>, or email <a href="mailto:volthesitan@gmail.com" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>volthesitan@gmail.com</a>. Include the Chrome and Clipper versions, the page address, the steps that led to the problem, and a screenshot only if it contains no private information.</p>
+  <p className="font-medium">Do not post clipped private content, API keys, passwords, sign-in tokens, cookies, or private community information in a public issue. Support will never ask for your account password or a complete local library.</p>
+
+  <LegalSectionHeading>A page does not clip correctly</LegalSectionHeading>
+  <p className="font-medium">Reload the page, open Clipper from the toolbar, and allow access to that website if Chrome asks. Try saving readable text first. Some sign-in pages, protected media, embedded documents, and pages that change while loading may not be fully available to an extension.</p>
+
+  <LegalSectionHeading>A scheduled source is not updating</LegalSectionHeading>
+  <p className="font-medium">Confirm that the task is enabled, Chrome is running, and the source is still publicly reachable. Open the source once to resolve any consent screen or changed address, then run the task again.</p>
+
+  <LegalSectionHeading>Sync or AI connection problems</LegalSectionHeading>
+  <p className="font-medium">Reconnect the service and enter its credential again; credentials are intentionally kept only for the current browser session. Confirm that the service address uses HTTPS and that the selected account has access to the destination.</p>
+
+  <LegalSectionHeading>Back up or remove local data</LegalSectionHeading>
+  <p className="font-medium">Export a ZIP before clearing data or uninstalling if you want a portable copy. Delete individual items in the library, clear credentials in settings, and sign out of Shadow when needed. Uninstalling normally removes the extension's local data from the current Chrome profile.</p>
+
+  <LegalSectionHeading>Privacy</LegalSectionHeading>
+  <p className="font-medium">Read the <a href="/apps/clipper/privacy" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Clipper Privacy Policy</a>.</p>
+</PublicDocPage>

--- a/website/docs/zh/apps/clipper/index.mdx
+++ b/website/docs/zh/apps/clipper/index.mdx
@@ -1,0 +1,37 @@
+---
+pageType: custom
+title: 虾豆剪藏
+---
+
+import {
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="zh" title="虾豆剪藏">
+  <LegalUpdated>网页剪藏与本地 Markdown 资料库</LegalUpdated>
+
+  <p className="font-medium">把值得保留的网页、RSS 和 PDF 存进自己掌控的资料库。内容默认保存在当前 Chrome 资料中，方便专注阅读、搜索、整理、导出和按需同步。</p>
+
+  <LegalSectionHeading>留下网页中真正有用的部分</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li>一键保存当前页面，并按来源保留正文、来源信息、图片、PDF 和网页快照。</li>
+    <li>为公开网页和 RSS 创建按需或定时采集任务。</li>
+    <li>在专注阅读视图中阅读 Markdown，并添加文件夹、收藏、标签、高亮、批注和阅读状态。</li>
+    <li>搜索本地资料库，并查看已保存内容的历史版本。</li>
+  </ul>
+
+  <LegalSectionHeading>默认留在本地，连接由你选择</LegalSectionHeading>
+  <p className="font-medium">使用核心资料库不需要账号。你可以导出便于迁移的 ZIP，也可以选择连接 Google Drive、GitHub 或 HTTPS WebDAV。可选 AI 工具只会在你选择服务并主动运行后工作。你也可以登录虾豆，使用官方模型，或把明确选择的剪藏交给社区 Buddy 处理。</p>
+
+  <LegalSectionHeading>你的资料，你来控制</LegalSectionHeading>
+  <p className="font-medium">虾豆剪藏不包含广告或使用分析，也不会自动把资料库上传给开发者。额外的浏览器访问权限会在功能首次需要时申请，你可以拒绝或随时撤销。API Key、密码和登录凭据只保留在当前浏览器会话中。</p>
+
+  <LegalSectionHeading>了解更多</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li>查看<a href="/zh/apps/clipper/privacy" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>《虾豆剪藏隐私政策》</a>。</li>
+    <li>前往<a href="/zh/apps/clipper/support" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>虾豆剪藏支持</a>。</li>
+    <li>在 GitHub 查看<a href="https://github.com/buggyblues/clipper" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>虾豆剪藏项目</a>。</li>
+  </ul>
+</PublicDocPage>

--- a/website/docs/zh/apps/clipper/privacy.mdx
+++ b/website/docs/zh/apps/clipper/privacy.mdx
@@ -1,0 +1,61 @@
+---
+pageType: custom
+title: 虾豆剪藏隐私政策
+---
+
+import {
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="zh" title="虾豆剪藏隐私政策">
+  <LegalUpdated>生效日期：2026 年 8 月 9 日 · 联系邮箱：volthesitan@gmail.com</LegalUpdated>
+
+  <p className="font-medium">本政策说明虾豆剪藏 Chrome 扩展如何处理用户数据。虾豆剪藏的单一用途是把用户选择或配置来源中的网页内容保存为本地 Markdown 资料库，并用于阅读、整理、导出和用户主动发起的同步或分享。</p>
+  <p className="font-medium">核心功能不要求账号。用户可以选择登录虾豆，以使用官方模型或把明确选择的剪藏交给社区中的 Buddy 处理。虾豆剪藏不包含广告或使用分析。</p>
+
+  <LegalSectionHeading>一、虾豆剪藏处理的信息</LegalSectionHeading>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li><strong>网站内容与浏览活动：</strong>用户保存或加入采集任务的 URL、标题、正文、作者、日期、可见评论、字幕、图片、PDF、网页快照和 RSS/Atom 条目。</li>
+    <li><strong>整理数据：</strong>文件夹、收藏、标签、评分、已读状态、高亮、批注、个人备注、保存的搜索、采集任务、运行记录、同步状态、快捷笔记和保存的标签页会话。</li>
+    <li><strong>单独授权的浏览器数据：</strong>书签、阅读列表、当前标签页和近期浏览记录，只用于用户打开的对应功能。虾豆剪藏不会修改原始书签或浏览记录。</li>
+    <li><strong>日历、地点和小组件数据：</strong>Google 日历页面中显示的近期活动标题与时间；所选内容已有的公开地点标签和图片地点信息；用户为天气选择的城市；以及行情小组件使用的公开证券代码。虾豆剪藏不请求设备实时位置。</li>
+    <li><strong>可选虾豆账号资料：</strong>账号 ID、用户名、显示名称、头像、可能存在的邮箱，以及可访问的社区、频道和 Buddy 信息。</li>
+    <li><strong>设置与诊断：</strong>界面偏好、已启用来源、已授予权限、迁移状态，以及不含资料库正文的本地诊断摘要。诊断文件只有在用户导出时才会生成。</li>
+    <li><strong>凭据：</strong>远程 AI Key、GitHub Token、WebDAV 凭据、本机服务 Token、笔记连接 Token 和虾豆登录凭据。这些信息只保留在当前浏览器会话中。发现旧版本留下的本地明文副本时，会迁移到当前会话并删除旧副本。Google Drive 授权由 Chrome 管理。</li>
+  </ul>
+
+  <LegalSectionHeading>二、信息用途</LegalSectionHeading>
+  <p className="font-medium">虾豆剪藏仅将这些信息用于用户可见的功能：提取和保存内容、建立本地索引、显示资料库、执行用户创建的采集任务、整理标签页、显示用户选择的小组件、导出文件、连接用户选择的服务，以及完成用户主动开始的 AI、同步或社区处理操作。</p>
+  <p className="font-medium">虾豆剪藏不出售用户数据，不投放广告，不建立广告画像，也不把数据用于信用评估、借贷或无关分析。</p>
+
+  <LegalSectionHeading>三、保存与保留期限</LegalSectionHeading>
+  <p className="font-medium">正文、附件、索引、设置和非敏感运行记录默认保存在当前 Chrome 资料中，直到用户删除或卸载扩展。Key、密码和虾豆登录凭据只保留在当前浏览器会话中，也可以在设置中立即清除。</p>
+  <p className="font-medium">虾豆剪藏不对本地资料库内容额外实施独立加密。用户应使用 Chrome 资料、操作系统账号和设备访问控制保护本机数据。用户主动导出、同步或分享后的副本，由所选目标按其设置和政策保留。</p>
+
+  <LegalSectionHeading>四、传输与外部服务</LegalSectionHeading>
+  <p className="font-medium">大多数功能在浏览器中运行。只有在用户配置、授权或主动开始对应功能后，信息才会按需要离开浏览器：</p>
+  <ul className="list-disc pl-6 space-y-2 font-medium">
+    <li><strong>来源网站</strong>会收到页面、公开接口、图片、字幕、PDF 或其他附件请求；请求可能使用该网站在当前 Chrome 中已有的登录状态。</li>
+    <li><strong>远程 AI 服务</strong>会在用户选择供应商并运行操作后，收到所选内容、操作说明、模型设置和所需 Key。</li>
+    <li><strong>同步目标</strong>会在用户开始同步后，收到所选归档文件和所需凭据，包括 Google Drive、GitHub 或 HTTPS WebDAV。Google Drive 访问仅限虾豆剪藏创建或用户明确交给它的文件。</li>
+    <li><strong>虾豆</strong>会在用户登录后收到授权和资料请求。用户把剪藏交给社区 Buddy 后，所选标题、来源、正文、元数据、操作说明和任务状态会发送到该社区。</li>
+    <li><strong>Google 日历、Open-Meteo、地理编码和行情服务</strong>只会收到用户打开的小组件或查询所需的有限日历页面请求、城市或坐标、地点名称或公开证券代码。</li>
+    <li><strong>本机目标</strong>可以在用户主动操作后，通过浏览器文件权限、剪贴板或同一设备上的服务连接接收所选内容。</li>
+  </ul>
+  <p className="font-medium">外部服务依照各自的条款和隐私政策处理收到的数据。用户应只连接自己信任的服务。</p>
+
+  <LegalSectionHeading>五、权限与用户控制</LegalSectionHeading>
+  <p className="font-medium">虾豆剪藏使用当前页面、脚本、网页快照、定时任务、身份和存储权限完成用户请求的功能。书签、阅读列表、标签页、浏览记录、日历页面和自定义服务地址会在对应功能首次需要时申请。用户可以拒绝或撤销可选权限，只有依赖该权限的功能会停止。</p>
+
+  <LegalSectionHeading>六、共享与 Limited Use</LegalSectionHeading>
+  <p className="font-medium">除用户选择的来源网站、AI 服务、同步目标、虾豆社区、本机目标和小组件服务外，开发者不会接收或出售虾豆剪藏数据。支持人员只有在用户主动提交、为安全调查所需或法律要求时才会查看特定数据。</p>
+  <p className="font-medium">虾豆剪藏对用户数据的使用和传输仅限于提供或改进本政策和商店页面披露的剪藏、本地整理、导出、同步、AI 和用户主动分享功能，并遵守 Chrome Web Store User Data Policy，包括 Limited Use 要求。</p>
+
+  <LegalSectionHeading>七、删除信息</LegalSectionHeading>
+  <p className="font-medium">用户可以删除归档、清除凭据、退出虾豆、撤销权限并删除导出的诊断文件。卸载扩展通常会删除当前 Chrome 资料中的本地数据。发送到其他服务的副本需要在对应目标中删除。</p>
+
+  <LegalSectionHeading>八、政策更新与联系</LegalSectionHeading>
+  <p className="font-medium">如果信息处理方式发生实质变化，我们会更新本政策和生效日期，并在需要时取得用户同意。隐私或数据删除问题请发送邮件至 <a href="mailto:volthesitan@gmail.com" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>volthesitan@gmail.com</a>。</p>
+</PublicDocPage>

--- a/website/docs/zh/apps/clipper/support.mdx
+++ b/website/docs/zh/apps/clipper/support.mdx
@@ -1,0 +1,33 @@
+---
+pageType: custom
+title: 虾豆剪藏支持
+---
+
+import {
+  LegalSectionHeading,
+  LegalUpdated,
+  PublicDocPage,
+} from '../../../../components/docs'
+
+<PublicDocPage lang="zh" title="虾豆剪藏支持">
+  <LegalUpdated>虾豆剪藏 Chrome 扩展帮助</LegalUpdated>
+
+  <LegalSectionHeading>联系支持</LegalSectionHeading>
+  <p className="font-medium">请提交公开的<a href="https://github.com/buggyblues/clipper/issues/new?title=%5BSupport%5D%20" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>虾豆剪藏支持请求</a>，或发送邮件至 <a href="mailto:volthesitan@gmail.com" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>volthesitan@gmail.com</a>。请提供 Chrome 与虾豆剪藏版本、页面地址、问题出现前的操作步骤，以及不含私人信息的截图。</p>
+  <p className="font-medium">请勿在公开 Issue 中提交私人剪藏、API Key、密码、登录 Token、Cookie 或非公开社区信息。支持人员不会索要你的账号密码或完整本地资料库。</p>
+
+  <LegalSectionHeading>页面无法正常剪藏</LegalSectionHeading>
+  <p className="font-medium">请刷新页面，从工具栏打开虾豆剪藏，并在 Chrome 询问时允许访问该网站。可以先尝试只保存可阅读正文。登录页、受保护媒体、嵌入文档或加载时持续变化的页面，可能无法被扩展完整获取。</p>
+
+  <LegalSectionHeading>定时来源没有更新</LegalSectionHeading>
+  <p className="font-medium">请确认任务已经启用、Chrome 正在运行，并且来源仍可公开访问。可以先手动打开一次来源，处理可能出现的同意页面或地址变化，再重新运行任务。</p>
+
+  <LegalSectionHeading>同步或 AI 连接失败</LegalSectionHeading>
+  <p className="font-medium">请重新连接服务并再次输入凭据；凭据只会保留在当前浏览器会话中。确认服务地址使用 HTTPS，所选账号也有权访问目标位置。</p>
+
+  <LegalSectionHeading>备份或删除本地数据</LegalSectionHeading>
+  <p className="font-medium">如果需要保留可迁移副本，请在清理数据或卸载前导出 ZIP。你可以在资料库中删除单条内容、在设置中清除凭据，并按需退出虾豆。卸载扩展通常会删除当前 Chrome 资料中的本地数据。</p>
+
+  <LegalSectionHeading>隐私政策</LegalSectionHeading>
+  <p className="font-medium">查看<a href="/zh/apps/clipper/privacy" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>《虾豆剪藏隐私政策》</a>。</p>
+</PublicDocPage>

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -91,6 +91,21 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
       description:
         'Get help with Zen practice plans, scripture reading, instruments, temple records, widgets, and App Store purchases.',
     },
+    '/apps/clipper': {
+      title: 'Shadow Clipper - Local Markdown Web Clipper',
+      description:
+        'Save web pages, feeds, and PDFs to a local Markdown library for focused reading, search, organization, export, and optional sync.',
+    },
+    '/apps/clipper/privacy': {
+      title: 'Clipper Privacy Policy - Shadow',
+      description:
+        'Read how Clipper handles local library content, browser permissions, session credentials, optional sync, AI tools, and Shadow community sharing.',
+    },
+    '/apps/clipper/support': {
+      title: 'Clipper Support - Shadow',
+      description:
+        'Get help with web clipping, capture tasks, local library data, export, synchronization, AI connections, and account access.',
+    },
     '/platform/cloud': {
       title: 'Cloud Docs - Templates, Plugins, CLI, and Deployments',
       description:
@@ -154,6 +169,20 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
     '/apps/zen/support': {
       title: '禅心问佛支持',
       description: '查看功课、经文、法器、寺院记录、小组件和 App Store 购买的帮助信息。',
+    },
+    '/apps/clipper': {
+      title: '虾豆剪藏 - 本地 Markdown 网页剪藏',
+      description:
+        '把网页、RSS 和 PDF 保存到本地 Markdown 资料库，用于阅读、搜索、整理、导出和按需同步。',
+    },
+    '/apps/clipper/privacy': {
+      title: '虾豆剪藏隐私政策',
+      description:
+        '了解虾豆剪藏如何处理本地资料、浏览器权限、会话凭据、可选同步、AI 工具和社区分享。',
+    },
+    '/apps/clipper/support': {
+      title: '虾豆剪藏支持',
+      description: '查看网页剪藏、采集任务、本地资料、导出、同步、AI 连接和账号访问的帮助信息。',
     },
     '/platform/cloud': {
       title: '云文档 - 模版、插件、CLI 与部署',


### PR DESCRIPTION
## Summary

- add public Clipper product pages in English and Chinese
- add privacy policy and support pages for Chrome Web Store submission
- add route-specific SEO metadata for all six pages

## Verification

- `pnpm --filter @shadowob/website typecheck`
- `pnpm --filter @shadowob/website build`
- pre-push repository checks