### PR TITLE
docs(website): refine Clipper store copy

### DIFF
--- a/website/docs/en/apps/clipper/index.mdx
+++ b/website/docs/en/apps/clipper/index.mdx
@@ -10,28 +10,25 @@ import {
 } from '../../../../components/docs'
 
 <PublicDocPage lang="en" title="Shadow Clipper">
-  <LegalUpdated>Web clipping and a local Markdown library</LegalUpdated>
+  <LegalUpdated>See something worth reading? Save it for later.</LegalUpdated>
 
-  <p className="font-medium">Save worthwhile web pages, feeds, and PDFs into a library you control. Clipper keeps content in your current Chrome profile by default, with tools for focused reading, search, organization, export, and synchronization you choose.</p>
+  <p className="font-medium">Some things on the web are worth reading, even when you do not have time right now. Save the current page with Shadow Clipper and it will be waiting in your reading library. Come back when you are ready and continue where you left off.</p>
 
-  <LegalSectionHeading>Keep the useful parts of the web</LegalSectionHeading>
-  <ul className="list-disc pl-6 space-y-2 font-medium">
-    <li>Save the current page in one click, including its source details, readable text, images, PDFs, and page snapshots when available.</li>
-    <li>Collect public pages and RSS feeds on demand or on a schedule you create.</li>
-    <li>Read Markdown in a focused view, then add folders, favorites, tags, highlights, notes, and reading state.</li>
-    <li>Search across the local library and review earlier versions of saved content.</li>
-  </ul>
+  <LegalSectionHeading>Save it before it slips away</LegalSectionHeading>
+  <p className="font-medium">You can close the tab without losing the page. The saved article and its original source stay together in your library until you are ready to return.</p>
 
-  <LegalSectionHeading>Local by default, connected by choice</LegalSectionHeading>
-  <p className="font-medium">No account is required for the core library. You can export a portable ZIP or choose to connect Google Drive, GitHub, or HTTPS WebDAV. Optional AI tools work only after you select a service and start an action. You may also sign in to Shadow to use an official model or send selected clips to a community Buddy.</p>
+  <LegalSectionHeading>Read without the clutter</LegalSectionHeading>
+  <p className="font-medium">A clean reading view keeps the page out of the way. Highlight an important passage or add a note while the thought is fresh.</p>
 
-  <LegalSectionHeading>Your data, your controls</LegalSectionHeading>
-  <p className="font-medium">Clipper has no ads or usage analytics and does not automatically upload your library to the developer. Extra browser access is requested when a feature first needs it, and can be declined or revoked. API keys, passwords, and sign-in credentials are kept only for the current browser session.</p>
+  <LegalSectionHeading>Find it again with a few words</LegalSectionHeading>
+  <p className="font-medium">Later, a phrase or a few keywords can bring the page back from its title, article, or your notes.</p>
+
+  <LegalSectionHeading>Your library stays in your browser by default</LegalSectionHeading>
+  <p className="font-medium">The core experience needs no account and has no ads or usage analytics. Shadow Clipper does not automatically upload your saved pages to the developer.</p>
 
   <LegalSectionHeading>Learn more</LegalSectionHeading>
   <ul className="list-disc pl-6 space-y-2 font-medium">
     <li>Read the <a href="/apps/clipper/privacy" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Clipper Privacy Policy</a>.</li>
     <li>Visit <a href="/apps/clipper/support" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Clipper Support</a>.</li>
-    <li>View the <a href="https://github.com/buggyblues/clipper" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>Clipper project on GitHub</a>.</li>
   </ul>
 </PublicDocPage>

--- a/website/docs/en/apps/clipper/privacy.mdx
+++ b/website/docs/en/apps/clipper/privacy.mdx
@@ -12,7 +12,7 @@ import {
 <PublicDocPage lang="en" title="Clipper Privacy Policy">
   <LegalUpdated>Effective: August 9, 2026 · Contact: volthesitan@gmail.com</LegalUpdated>
 
-  <p className="font-medium">This policy explains how the Clipper Chrome extension handles user data. Clipper has one purpose: saving web content selected by the user, or named in sources configured by the user, into a local Markdown library for reading, organization, export, and synchronization or sharing initiated by the user.</p>
+  <p className="font-medium">This policy explains how the Clipper Chrome extension handles user data. Clipper has one purpose: saving web content selected by the user, or named in sources configured by the user, into a personal reading library for reading, organization, export, and synchronization or sharing initiated by the user.</p>
   <p className="font-medium">Core features do not require an account. A user may choose to sign in to Shadow to use an official model or send explicitly selected clips to a Buddy in a community. Clipper has no advertising or usage analytics.</p>
 
   <LegalSectionHeading>1. Information Clipper handles</LegalSectionHeading>

--- a/website/docs/zh/apps/clipper/index.mdx
+++ b/website/docs/zh/apps/clipper/index.mdx
@@ -10,28 +10,25 @@ import {
 } from '../../../../components/docs'
 
 <PublicDocPage lang="zh" title="虾豆剪藏">
-  <LegalUpdated>网页剪藏与本地 Markdown 资料库</LegalUpdated>
+  <LegalUpdated>遇到想读的，先收下来</LegalUpdated>
 
-  <p className="font-medium">把值得保留的网页、RSS 和 PDF 存进自己掌控的资料库。内容默认保存在当前 Chrome 资料中，方便专注阅读、搜索、整理、导出和按需同步。</p>
+  <p className="font-medium">网上总有些内容想读，但眼下没有时间。点一下虾豆剪藏，当前网页就会收进你的阅读资料库。等有空再打开，从上次停下的地方继续。</p>
 
-  <LegalSectionHeading>留下网页中真正有用的部分</LegalSectionHeading>
-  <ul className="list-disc pl-6 space-y-2 font-medium">
-    <li>一键保存当前页面，并按来源保留正文、来源信息、图片、PDF 和网页快照。</li>
-    <li>为公开网页和 RSS 创建按需或定时采集任务。</li>
-    <li>在专注阅读视图中阅读 Markdown，并添加文件夹、收藏、标签、高亮、批注和阅读状态。</li>
-    <li>搜索本地资料库，并查看已保存内容的历史版本。</li>
-  </ul>
+  <LegalSectionHeading>看到好内容，先收下来</LegalSectionHeading>
+  <p className="font-medium">不用一直留着标签页，也不用事后翻浏览记录。保存过的网页和原始来源会一起留在资料库里，想读的时候再回来。</p>
 
-  <LegalSectionHeading>默认留在本地，连接由你选择</LegalSectionHeading>
-  <p className="font-medium">使用核心资料库不需要账号。你可以导出便于迁移的 ZIP，也可以选择连接 Google Drive、GitHub 或 HTTPS WebDAV。可选 AI 工具只会在你选择服务并主动运行后工作。你也可以登录虾豆，使用官方模型，或把明确选择的剪藏交给社区 Buddy 处理。</p>
+  <LegalSectionHeading>读的时候，少一点干扰</LegalSectionHeading>
+  <p className="font-medium">干净的阅读视图会去掉页面干扰。读到重要的地方，可以直接高亮，顺手写下当时的想法。</p>
 
-  <LegalSectionHeading>你的资料，你来控制</LegalSectionHeading>
-  <p className="font-medium">虾豆剪藏不包含广告或使用分析，也不会自动把资料库上传给开发者。额外的浏览器访问权限会在功能首次需要时申请，你可以拒绝或随时撤销。API Key、密码和登录凭据只保留在当前浏览器会话中。</p>
+  <LegalSectionHeading>记得几个字，就能找回来</LegalSectionHeading>
+  <p className="font-medium">以后只要还记得一句话或几个关键词，就能从标题、正文和批注里把那篇内容搜回来。</p>
+
+  <LegalSectionHeading>资料默认留在你的浏览器</LegalSectionHeading>
+  <p className="font-medium">核心功能不需要注册账号，也没有广告或使用分析。虾豆剪藏不会自动把你的收藏上传给开发者。</p>
 
   <LegalSectionHeading>了解更多</LegalSectionHeading>
   <ul className="list-disc pl-6 space-y-2 font-medium">
     <li>查看<a href="/zh/apps/clipper/privacy" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>《虾豆剪藏隐私政策》</a>。</li>
     <li>前往<a href="/zh/apps/clipper/support" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>虾豆剪藏支持</a>。</li>
-    <li>在 GitHub 查看<a href="https://github.com/buggyblues/clipper" target="_blank" rel="noreferrer" className="text-cyan-500 hover:text-cyan-600" style={{ textDecoration: 'none' }}>虾豆剪藏项目</a>。</li>
   </ul>
 </PublicDocPage>

--- a/website/docs/zh/apps/clipper/privacy.mdx
+++ b/website/docs/zh/apps/clipper/privacy.mdx
@@ -12,7 +12,7 @@ import {
 <PublicDocPage lang="zh" title="虾豆剪藏隐私政策">
   <LegalUpdated>生效日期：2026 年 8 月 9 日 · 联系邮箱：volthesitan@gmail.com</LegalUpdated>
 
-  <p className="font-medium">本政策说明虾豆剪藏 Chrome 扩展如何处理用户数据。虾豆剪藏的单一用途是把用户选择或配置来源中的网页内容保存为本地 Markdown 资料库，并用于阅读、整理、导出和用户主动发起的同步或分享。</p>
+  <p className="font-medium">本政策说明虾豆剪藏 Chrome 扩展如何处理用户数据。虾豆剪藏的单一用途是把用户选择或配置来源中的网页内容保存到个人阅读资料库，并用于阅读、整理、导出和用户主动发起的同步或分享。</p>
   <p className="font-medium">核心功能不要求账号。用户可以选择登录虾豆，以使用官方模型或把明确选择的剪藏交给社区中的 Buddy 处理。虾豆剪藏不包含广告或使用分析。</p>
 
   <LegalSectionHeading>一、虾豆剪藏处理的信息</LegalSectionHeading>

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -92,19 +92,19 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
         'Get help with Zen practice plans, scripture reading, instruments, temple records, widgets, and App Store purchases.',
     },
     '/apps/clipper': {
-      title: 'Shadow Clipper - Local Markdown Web Clipper',
+      title: 'Shadow Clipper - Save Now, Read Later',
       description:
-        'Save web pages, feeds, and PDFs to a local Markdown library for focused reading, search, organization, export, and optional sync.',
+        'Save a page when it catches your eye. Read without clutter, highlight what matters, and find it later with a few words.',
     },
     '/apps/clipper/privacy': {
       title: 'Clipper Privacy Policy - Shadow',
       description:
-        'Read how Clipper handles local library content, browser permissions, session credentials, optional sync, AI tools, and Shadow community sharing.',
+        'Read how Clipper stores saved pages, requests browser access, and keeps users in control of their reading library.',
     },
     '/apps/clipper/support': {
       title: 'Clipper Support - Shadow',
       description:
-        'Get help with web clipping, capture tasks, local library data, export, synchronization, AI connections, and account access.',
+        'Get help saving pages, reading without clutter, searching the library, and protecting local data.',
     },
     '/platform/cloud': {
       title: 'Cloud Docs - Templates, Plugins, CLI, and Deployments',
@@ -171,18 +171,17 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
       description: '查看功课、经文、法器、寺院记录、小组件和 App Store 购买的帮助信息。',
     },
     '/apps/clipper': {
-      title: '虾豆剪藏 - 本地 Markdown 网页剪藏',
+      title: '虾豆剪藏 - 收藏网页，稍后好好读',
       description:
-        '把网页、RSS 和 PDF 保存到本地 Markdown 资料库，用于阅读、搜索、整理、导出和按需同步。',
+        '遇到想读的网页，先收下来。有空时安静读完，随手高亮和批注，之后用几个关键词就能找回来。',
     },
     '/apps/clipper/privacy': {
       title: '虾豆剪藏隐私政策',
-      description:
-        '了解虾豆剪藏如何处理本地资料、浏览器权限、会话凭据、可选同步、AI 工具和社区分享。',
+      description: '了解虾豆剪藏如何保存网页、申请浏览器权限，并让用户掌控自己的阅读资料。',
     },
     '/apps/clipper/support': {
       title: '虾豆剪藏支持',
-      description: '查看网页剪藏、采集任务、本地资料、导出、同步、AI 连接和账号访问的帮助信息。',
+      description: '查看保存网页、专注阅读、搜索资料库和保护本地数据的帮助信息。',
     },
     '/platform/cloud': {
       title: '云文档 - 模版、插件、CLI 与部署',


### PR DESCRIPTION
## Summary
- rewrite the Clipper landing page around saving, focused reading, and finding pages again
- remove secondary feature language from the product story
- keep privacy wording accurate while avoiding implementation terms in the introduction
- refresh English and Chinese SEO descriptions

## Checks
- pnpm --dir website typecheck
- repository pre-push checks