### PR TITLE
docs(website): tell Clipper browsing workspace story

### DIFF
--- a/website/docs/en/apps/clipper/index.mdx
+++ b/website/docs/en/apps/clipper/index.mdx
@@ -10,21 +10,24 @@ import {
 } from '../../../../components/docs'
 
 <PublicDocPage lang="en" title="Shadow Clipper">
-  <LegalUpdated>See something worth reading? Save it for later.</LegalUpdated>
+  <LegalUpdated>Turn scattered browsing into a clear next step.</LegalUpdated>
 
-  <p className="font-medium">Some things on the web are worth reading, even when you do not have time right now. Save the current page with Shadow Clipper and it will be waiting in your reading library. Come back when you are ready and continue where you left off.</p>
+  <p className="font-medium">Open tabs are rarely just things to read later. They are several unfinished threads competing for attention. Shadow Clipper connects active browsing, later decisions, and long-term material so every new tab shows what to do next.</p>
 
-  <LegalSectionHeading>Save it before it slips away</LegalSectionHeading>
-  <p className="font-medium">You can close the tab without losing the page. The saved article and its original source stay together in your library until you are ready to return.</p>
+  <LegalSectionHeading>Let your browser remember what you are doing</LegalSectionHeading>
+  <p className="font-medium">Open pages are grouped by site, window, task, or time. Continue the work already in motion, save a group as a browsing session, or move a page to read later—right from the new tab.</p>
 
-  <LegalSectionHeading>Read without the clutter</LegalSectionHeading>
-  <p className="font-medium">A clean reading view keeps the page out of the way. Highlight an important passage or add a note while the thought is fresh.</p>
+  <LegalSectionHeading>Tidy up without judging every page yourself</LegalSectionHeading>
+  <p className="font-medium">Exact duplicates, temporary pages, and pages you have not revisited are proposed first. The current page, playing media, and pinned tabs stay protected. You confirm every action, and cleaned-up pages remain recoverable.</p>
 
-  <LegalSectionHeading>Find it again with a few words</LegalSectionHeading>
-  <p className="font-medium">Later, a phrase or a few keywords can bring the page back from its title, article, or your notes.</p>
+  <LegalSectionHeading>Let the sources you follow bring new material to you</LegalSectionHeading>
+  <p className="font-medium">Choose a website, public list, trending page, or feed, then decide when it should run. Shadow Clipper keeps collecting on your schedule, and every task can be paused, changed, or removed.</p>
+
+  <LegalSectionHeading>Keep what deserves to become lasting material</LegalSectionHeading>
+  <p className="font-medium">Saved pages remain available for reading, search, organization, and notes. They become material you can continue using in later reading, research, or creative work.</p>
 
   <LegalSectionHeading>Your library stays in your browser by default</LegalSectionHeading>
-  <p className="font-medium">The core experience needs no account and has no ads or usage analytics. Shadow Clipper does not automatically upload your saved pages to the developer.</p>
+  <p className="font-medium">The core experience needs no account and has no ads or usage analytics. Shadow Clipper does not automatically upload your library to the developer.</p>
 
   <LegalSectionHeading>Learn more</LegalSectionHeading>
   <ul className="list-disc pl-6 space-y-2 font-medium">

--- a/website/docs/en/apps/clipper/privacy.mdx
+++ b/website/docs/en/apps/clipper/privacy.mdx
@@ -12,7 +12,7 @@ import {
 <PublicDocPage lang="en" title="Clipper Privacy Policy">
   <LegalUpdated>Effective: August 9, 2026 · Contact: volthesitan@gmail.com</LegalUpdated>
 
-  <p className="font-medium">This policy explains how the Clipper Chrome extension handles user data. Clipper has one purpose: saving web content selected by the user, or named in sources configured by the user, into a personal reading library for reading, organization, export, and synchronization or sharing initiated by the user.</p>
+  <p className="font-medium">This policy explains how the Clipper Chrome extension handles user data. Clipper has one purpose: helping users continue, organize, and safely close active browsing work, then saving user-selected web content or configured sources into a personal library for later reading, organization, export, and synchronization or sharing initiated by the user.</p>
   <p className="font-medium">Core features do not require an account. A user may choose to sign in to Shadow to use an official model or send explicitly selected clips to a Buddy in a community. Clipper has no advertising or usage analytics.</p>
 
   <LegalSectionHeading>1. Information Clipper handles</LegalSectionHeading>

--- a/website/docs/zh/apps/clipper/index.mdx
+++ b/website/docs/zh/apps/clipper/index.mdx
@@ -10,21 +10,24 @@ import {
 } from '../../../../components/docs'
 
 <PublicDocPage lang="zh" title="虾豆剪藏">
-  <LegalUpdated>遇到想读的，先收下来</LegalUpdated>
+  <LegalUpdated>把散乱的浏览，收成下一步</LegalUpdated>
 
-  <p className="font-medium">网上总有些内容想读，但眼下没有时间。点一下虾豆剪藏，当前网页就会收进你的阅读资料库。等有空再打开，从上次停下的地方继续。</p>
+  <p className="font-medium">浏览器里开着的页面，往往不是“以后再看”，而是几件还没做完的事。虾豆剪藏把当前浏览、稍后处理和长期资料连在一起，让你每次打开新标签页，都知道接下来要做什么。</p>
 
-  <LegalSectionHeading>看到好内容，先收下来</LegalSectionHeading>
-  <p className="font-medium">不用一直留着标签页，也不用事后翻浏览记录。保存过的网页和原始来源会一起留在资料库里，想读的时候再回来。</p>
+  <LegalSectionHeading>让浏览器记得，你正在做什么</LegalSectionHeading>
+  <p className="font-medium">打开的页面会按网站、窗口、任务或时间归在一起。继续手上的事、把一组页面留成浏览会话，还是稍后再读，都可以从新标签页直接决定。</p>
 
-  <LegalSectionHeading>读的时候，少一点干扰</LegalSectionHeading>
-  <p className="font-medium">干净的阅读视图会去掉页面干扰。读到重要的地方，可以直接高亮，顺手写下当时的想法。</p>
+  <LegalSectionHeading>该收口时，不必一页页判断</LegalSectionHeading>
+  <p className="font-medium">完全重复、暂时不用和久未查看的页面会先列清楚。当前页、正在播放和固定页面会受到保护；每一项都由你确认，整理后也可以恢复。</p>
 
-  <LegalSectionHeading>记得几个字，就能找回来</LegalSectionHeading>
-  <p className="font-medium">以后只要还记得一句话或几个关键词，就能从标题、正文和批注里把那篇内容搜回来。</p>
+  <LegalSectionHeading>让关注的来源自己带回新内容</LegalSectionHeading>
+  <p className="font-medium">选好网站、公开列表、热榜或订阅，再决定何时运行。虾豆会按你的节奏持续收集；任务随时可以暂停、修改或删除。</p>
+
+  <LegalSectionHeading>真正值得留下的，继续沉淀</LegalSectionHeading>
+  <p className="font-medium">网页收进资料库后，可以继续阅读、搜索、整理和批注。零散的页面不再只是收藏，而会成为下一次阅读、研究或创作能接着用的资料。</p>
 
   <LegalSectionHeading>资料默认留在你的浏览器</LegalSectionHeading>
-  <p className="font-medium">核心功能不需要注册账号，也没有广告或使用分析。虾豆剪藏不会自动把你的收藏上传给开发者。</p>
+  <p className="font-medium">核心功能不需要注册账号，也没有广告或使用分析。虾豆剪藏不会自动把你的资料上传给开发者。</p>
 
   <LegalSectionHeading>了解更多</LegalSectionHeading>
   <ul className="list-disc pl-6 space-y-2 font-medium">

--- a/website/docs/zh/apps/clipper/privacy.mdx
+++ b/website/docs/zh/apps/clipper/privacy.mdx
@@ -12,7 +12,7 @@ import {
 <PublicDocPage lang="zh" title="虾豆剪藏隐私政策">
   <LegalUpdated>生效日期：2026 年 8 月 9 日 · 联系邮箱：volthesitan@gmail.com</LegalUpdated>
 
-  <p className="font-medium">本政策说明虾豆剪藏 Chrome 扩展如何处理用户数据。虾豆剪藏的单一用途是把用户选择或配置来源中的网页内容保存到个人阅读资料库，并用于阅读、整理、导出和用户主动发起的同步或分享。</p>
+  <p className="font-medium">本政策说明虾豆剪藏 Chrome 扩展如何处理用户数据。虾豆剪藏的单一用途是帮助用户继续、整理和安全收口当前浏览工作，并把用户选择或配置来源中的网页内容保存到个人资料库，用于后续阅读、整理、导出和用户主动发起的同步或分享。</p>
   <p className="font-medium">核心功能不要求账号。用户可以选择登录虾豆，以使用官方模型或把明确选择的剪藏交给社区中的 Buddy 处理。虾豆剪藏不包含广告或使用分析。</p>
 
   <LegalSectionHeading>一、虾豆剪藏处理的信息</LegalSectionHeading>

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -92,9 +92,9 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
         'Get help with Zen practice plans, scripture reading, instruments, temple records, widgets, and App Store purchases.',
     },
     '/apps/clipper': {
-      title: 'Shadow Clipper - Save Now, Read Later',
+      title: 'Shadow Clipper - Turn Browsing into a Clear Next Step',
       description:
-        'Save a page when it catches your eye. Read without clutter, highlight what matters, and find it later with a few words.',
+        'Organize open pages, close distractions safely, and keep up with the web sources that matter.',
     },
     '/apps/clipper/privacy': {
       title: 'Clipper Privacy Policy - Shadow',
@@ -104,7 +104,7 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
     '/apps/clipper/support': {
       title: 'Clipper Support - Shadow',
       description:
-        'Get help saving pages, reading without clutter, searching the library, and protecting local data.',
+        'Get help organizing tabs, collecting sources, searching the library, and protecting local data.',
     },
     '/platform/cloud': {
       title: 'Cloud Docs - Templates, Plugins, CLI, and Deployments',
@@ -171,9 +171,8 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
       description: '查看功课、经文、法器、寺院记录、小组件和 App Store 购买的帮助信息。',
     },
     '/apps/clipper': {
-      title: '虾豆剪藏 - 收藏网页，稍后好好读',
-      description:
-        '遇到想读的网页，先收下来。有空时安静读完，随手高亮和批注，之后用几个关键词就能找回来。',
+      title: '虾豆剪藏 - 把散乱的浏览收成下一步',
+      description: '归拢打开的页面，安心收掉干扰，让关注的来源持续带回新内容。',
     },
     '/apps/clipper/privacy': {
       title: '虾豆剪藏隐私政策',
@@ -181,7 +180,7 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
     },
     '/apps/clipper/support': {
       title: '虾豆剪藏支持',
-      description: '查看保存网页、专注阅读、搜索资料库和保护本地数据的帮助信息。',
+      description: '查看整理标签页、持续采集、搜索资料库和保护本地数据的帮助信息。',
     },
     '/platform/cloud': {
       title: '云文档 - 模版、插件、CLI 与部署',


### PR DESCRIPTION
## Summary

- reposition Clipper around active browsing, recoverable cleanup, and ongoing collection
- update Chinese and English product pages and SEO copy
- align the privacy purpose statement with the visible browsing workspace

## Verification

- pnpm --filter @shadowob/website typecheck
- pnpm --filter @shadowob/website build