### PR TITLE
docs(website): refresh Clipper store materials

### DIFF
--- a/website/docs/en/apps/clipper/index.mdx
+++ b/website/docs/en/apps/clipper/index.mdx
@@ -10,24 +10,30 @@ import {
 } from '../../../../components/docs'
 
 <PublicDocPage lang="en" title="Shadow Clipper">
-  <LegalUpdated>Turn scattered browsing into a clear next step.</LegalUpdated>
+  <LegalUpdated>Collect across the web, then research and write with AI.</LegalUpdated>
 
-  <p className="font-medium">Open tabs are rarely just things to read later. They are several unfinished threads competing for attention. Shadow Clipper connects active browsing, later decisions, and long-term material so every new tab shows what to do next.</p>
+  <p className="font-medium">Shadow Clipper brings saved items, subscriptions, and search results from different platforms into one library on your computer. When it is time to research or write, search, read, and organize everything together instead of reopening each platform.</p>
 
-  <LegalSectionHeading>Let your browser remember what you are doing</LegalSectionHeading>
-  <p className="font-medium">Open pages are grouped by site, window, task, or time. Continue the work already in motion, save a group as a browsing session, or move a page to read later—right from the new tab.</p>
+  <LegalSectionHeading>Let new material collect itself</LegalSectionHeading>
+  <p className="font-medium">Choose a website, saved list, trending page, feed, or keyword, then decide when it should run. Shadow Clipper collects from Xiaohongshu, Zhihu, Bilibili, YouTube, GitHub, Reddit, and other sources while keeping text, images, and original links together.</p>
 
-  <LegalSectionHeading>Tidy up without judging every page yourself</LegalSectionHeading>
-  <p className="font-medium">Exact duplicates, temporary pages, and pages you have not revisited are proposed first. The current page, playing media, and pinned tabs stay protected. You confirm every action, and cleaned-up pages remain recoverable.</p>
+  <LegalSectionHeading>Keep a growing library manageable</LegalSectionHeading>
+  <p className="font-medium">Review articles, posts, videos, papers, and open-source projects in one place. Items from the same automation stay grouped together, and the library can be filtered by platform, reading state, or saved state.</p>
 
-  <LegalSectionHeading>Let the sources you follow bring new material to you</LegalSectionHeading>
-  <p className="font-medium">Choose a website, public list, trending page, or feed, then decide when it should run. Shadow Clipper keeps collecting on your schedule, and every task can be paused, changed, or removed.</p>
+  <LegalSectionHeading>Continue the work with AI</LegalSectionHeading>
+  <p className="font-medium">Summarize key points, merge duplicates, and compare conclusions directly from the library. When important material is missing, search the public web and keep sources with the answer for later checking.</p>
 
-  <LegalSectionHeading>Keep what deserves to become lasting material</LegalSectionHeading>
-  <p className="font-medium">Saved pages remain available for reading, search, organization, and notes. They become material you can continue using in later reading, research, or creative work.</p>
+  <LegalSectionHeading>Move from research to writing with guided tasks</LegalSectionHeading>
+  <p className="font-medium">Studio includes web-wide research, multi-source comparison, weekly brief, topic document, and other guided work. Choose a task, answer the subject and scope questions, then use library material and public-web research to create the result.</p>
+
+  <LegalSectionHeading>See useful information on every new tab</LegalSectionHeading>
+  <p className="font-medium">Keep weather, market quotes, the date, pinned websites, and information feeds close at hand. Add, move, and resize widgets to fit your routine.</p>
+
+  <LegalSectionHeading>Keep page actions close at hand</LegalSectionHeading>
+  <p className="font-medium">Use the floating tool or extension popup to save a page, add it to Read Later, open reading mode, or ask AI about what you are viewing. Page translation can show the original and translation together or the translation alone.</p>
 
   <LegalSectionHeading>Your library stays in your browser by default</LegalSectionHeading>
-  <p className="font-medium">The core experience needs no account and has no ads or usage analytics. Shadow Clipper does not automatically upload your library to the developer.</p>
+  <p className="font-medium">Core features need no account and have no ads or usage analytics. Selected content is sent to an external service only when you choose to use AI, sync, or another connected service.</p>
 
   <LegalSectionHeading>Learn more</LegalSectionHeading>
   <ul className="list-disc pl-6 space-y-2 font-medium">

--- a/website/docs/en/apps/clipper/privacy.mdx
+++ b/website/docs/en/apps/clipper/privacy.mdx
@@ -10,9 +10,9 @@ import {
 } from '../../../../components/docs'
 
 <PublicDocPage lang="en" title="Clipper Privacy Policy">
-  <LegalUpdated>Effective: August 11, 2026 · Contact: volthesitan@gmail.com</LegalUpdated>
+  <LegalUpdated>Effective: August 17, 2026 · Contact: volthesitan@gmail.com</LegalUpdated>
 
-  <p className="font-medium">This policy explains how the Clipper Chrome extension handles user data. Clipper has one purpose: saving user-selected web content and configured sources into a personal working library, then helping users continue reading, organize, compare, and research that material through the new tab, the in-page floating assistant, and AI tasks they choose to configure.</p>
+  <p className="font-medium">This policy explains how the Clipper Chrome extension handles user data. Clipper has one purpose: saving user-selected web content and configured sources into a personal working library, then helping users continue reading, translate, organize, compare, and research that material through the new tab, the in-page floating assistant, page translation, and AI tasks they choose to configure.</p>
   <p className="font-medium">Core features do not require an account. A user may choose to sign in to Shadow to use an official model or send explicitly selected clips to a Buddy in a community. Clipper has no advertising or usage analytics.</p>
 
   <LegalSectionHeading>1. Information Clipper handles</LegalSectionHeading>
@@ -27,7 +27,7 @@ import {
   </ul>
 
   <LegalSectionHeading>2. How information is used</LegalSectionHeading>
-  <p className="font-medium">Clipper uses this information only to provide visible features: extracting and saving content, building a local index, displaying the library, running capture tasks created by the user, organizing tabs, showing selected widgets, exporting files, connecting to services chosen by the user, and completing AI, sync, or community actions started by the user.</p>
+  <p className="font-medium">Clipper uses this information only to provide visible features: extracting and saving content, translating pages selected by the user, building a local index, displaying the library, running capture tasks created by the user, organizing tabs, showing selected widgets, exporting files, connecting to services chosen by the user, and completing AI, sync, or community actions started by the user.</p>
   <p className="font-medium">Clipper does not sell user data, serve ads, create advertising profiles, or use data for creditworthiness, lending, or unrelated analytics.</p>
 
   <LegalSectionHeading>3. Storage and retention</LegalSectionHeading>
@@ -38,7 +38,7 @@ import {
   <p className="font-medium">Most features run in the browser. Information leaves the browser only when needed for a feature the user configures, authorizes, or starts:</p>
   <ul className="list-disc pl-6 space-y-2 font-medium">
     <li><strong>Source websites</strong> receive requests for pages, public interfaces, images, transcripts, PDFs, or other attachments. Requests may use an existing Chrome sign-in for that site.</li>
-    <li><strong>Remote AI providers</strong> receive selected content, instructions, model settings, and the required key after the user chooses a provider and runs an action.</li>
+    <li><strong>Remote AI providers</strong> receive selected content, page segments to translate, instructions, model settings, and the required key after the user chooses a provider and runs an AI action or page translation. When browser translation is used, content is not sent to a remote AI service configured by the user for that reason.</li>
     <li><strong>Sync destinations</strong> receive selected archive files and required credentials after the user starts synchronization to Google Drive, GitHub, or HTTPS WebDAV. Google Drive access is limited to files Clipper created or the user explicitly provided to it.</li>
     <li><strong>Shadow</strong> receives authorization and profile requests after sign-in. When the user sends clips to a community Buddy, the selected titles, sources, text, metadata, instructions, and task status are sent to that community.</li>
     <li><strong>Google Calendar, Open-Meteo, geocoding, and market-data services</strong> receive only the limited calendar-page request, chosen city or coordinates, place name, or public ticker needed for the widget or lookup the user opens.</li>
@@ -49,11 +49,11 @@ import {
 
   <LegalSectionHeading>5. Permissions and user control</LegalSectionHeading>
   <p className="font-medium">Clipper uses current-page, script, snapshot, scheduling, identity, and storage access to complete requested features. It uses tab access for the visible tab workspace, jobs created by the user, and recognition of an optional source for the current site.</p>
-  <p className="font-medium">Website source access is not all granted at installation. Settings and Studio use the same source groups: everyday sources are preselected on a fresh install, while other sources can be enabled individually or as a group. Chrome requests the corresponding site access only when a source or group is enabled. Studio actions remain inactive until the source is enabled and authorized, and a click can request access and continue. When a supported site is visited, Clipper may show an enable reminder no more than once per source in 24 hours; the user can choose <strong>Do not remind me again</strong>. Bookmarks, Reading List, browsing history, calendar pages, and custom service addresses are also requested separately when the related feature first needs them. Users can decline or revoke optional access; only the related feature will stop working.</p>
+  <p className="font-medium">Public HTTPS page access is granted at installation so public-web research, user-initiated clipping, and page translation can work without a separate prompt on every site. This does not make Clipper read every page automatically: auto-save is off by default, and scheduled collection runs only after the user creates a task. Bookmarks, Reading List, browsing history, local services, and account connections that need separate authorization are still requested when the corresponding feature first needs them. Users can decline or revoke optional access; only the related feature will stop working.</p>
 
   <LegalSectionHeading>6. Sharing and Limited Use</LegalSectionHeading>
   <p className="font-medium">Except for source websites, AI providers, sync destinations, Shadow communities, local destinations, and widget services selected by the user, the developer does not receive or sell Clipper data. Support personnel review specific data only when the user submits it, when needed for security, or when required by law.</p>
-  <p className="font-medium">Clipper's use and transfer of user data are limited to providing or improving the clipping, local organization, export, synchronization, AI, and user-initiated sharing features disclosed here and in its store listing. Clipper complies with the Chrome Web Store User Data Policy, including Limited Use requirements.</p>
+  <p className="font-medium">Clipper's use and transfer of user data are limited to providing or improving the clipping, page translation, local organization, export, synchronization, AI, and user-initiated sharing features disclosed here and in its store listing. Clipper complies with the Chrome Web Store User Data Policy, including Limited Use requirements.</p>
 
   <LegalSectionHeading>7. Deleting information</LegalSectionHeading>
   <p className="font-medium">Users can delete archive items, clear credentials, sign out of Shadow, revoke permissions, and delete exported diagnostic files. Uninstalling normally removes the extension's local data from the current Chrome profile. Copies sent to another service must be deleted at that destination.</p>

--- a/website/docs/en/apps/clipper/support.mdx
+++ b/website/docs/en/apps/clipper/support.mdx
@@ -17,10 +17,13 @@ import {
   <p className="font-medium">Do not post clipped private content, API keys, passwords, sign-in tokens, cookies, or private community information in a public issue. Support will never ask for your account password or a complete local library.</p>
 
   <LegalSectionHeading>A page does not clip correctly</LegalSectionHeading>
-  <p className="font-medium">Reload the page, open Clipper from the toolbar, and allow access to that website if Chrome asks. Try saving readable text first. Some sign-in pages, protected media, embedded documents, and pages that change while loading may not be fully available to an extension.</p>
+  <p className="font-medium">Reload the page, then open Clipper from the toolbar. Try saving readable text first. Some sign-in pages, protected media, embedded documents, and pages that change while loading may not be fully available to an extension.</p>
+
+  <LegalSectionHeading>A page does not translate</LegalSectionHeading>
+  <p className="font-medium">Reload the page, reopen the extension popup, and check the target language and display mode. Browser translation depends on the language support available in the current Chrome version. You can also select a configured remote model under <strong>Settings → Translation</strong>; page segments to translate are sent to that service when it is used.</p>
 
   <LegalSectionHeading>A scheduled source is not updating</LegalSectionHeading>
-  <p className="font-medium">Confirm that the task is enabled, Chrome is running, and the source is still publicly reachable. Open the source once to resolve any consent screen or changed address, then run the task again.</p>
+  <p className="font-medium">Confirm that the automation is enabled, Chrome is running, and the source is still reachable. Open the source once to resolve any sign-in, verification, consent screen, or changed address, then run it again.</p>
 
   <LegalSectionHeading>Sync or AI connection problems</LegalSectionHeading>
   <p className="font-medium">Reconnect the service and enter its credential again; credentials are intentionally kept only for the current browser session. Confirm that the service address uses HTTPS and that the selected account has access to the destination.</p>

--- a/website/docs/zh/apps/clipper/index.mdx
+++ b/website/docs/zh/apps/clipper/index.mdx
@@ -10,24 +10,30 @@ import {
 } from '../../../../components/docs'
 
 <PublicDocPage lang="zh" title="虾豆剪藏">
-  <LegalUpdated>把散乱的浏览，收成下一步</LegalUpdated>
+  <LegalUpdated>全网内容自动收集，再用 AI 整理和写作</LegalUpdated>
 
-  <p className="font-medium">浏览器里开着的页面，往往不是“以后再看”，而是几件还没做完的事。虾豆剪藏把当前浏览、稍后处理和长期资料连在一起，让你每次打开新标签页，都知道接下来要做什么。</p>
+  <p className="font-medium">虾豆剪藏把散落在不同平台的收藏、订阅和搜索结果，持续收进电脑上的同一个资料库。需要查资料、做调研或写文章时，可以统一搜索、阅读和整理，不必逐个平台翻找。</p>
 
-  <LegalSectionHeading>让浏览器记得，你正在做什么</LegalSectionHeading>
-  <p className="font-medium">打开的页面会按网站、窗口、任务或时间归在一起。继续手上的事、把一组页面留成浏览会话，还是稍后再读，都可以从新标签页直接决定。</p>
+  <LegalSectionHeading>让关注的内容自己进资料库</LegalSectionHeading>
+  <p className="font-medium">选好网站、收藏、热榜、订阅或关键词，再决定何时运行。小红书、知乎、B 站、YouTube、GitHub、Reddit 等来源的新内容会按计划收集，标题、正文、配图和原始链接会一起保留。</p>
 
-  <LegalSectionHeading>该收口时，不必一页页判断</LegalSectionHeading>
-  <p className="font-medium">完全重复、暂时不用和久未查看的页面会先列清楚。当前页、正在播放和固定页面会受到保护；每一项都由你确认，整理后也可以恢复。</p>
+  <LegalSectionHeading>资料多了，也不会越堆越乱</LegalSectionHeading>
+  <p className="font-medium">文章、帖子、视频、论文和开源项目集中显示在资料库中。同一次自动收集的内容会归在一组，还可以按平台、阅读状态或收藏状态筛选，并搜索标题和正文。</p>
 
-  <LegalSectionHeading>让关注的来源自己带回新内容</LegalSectionHeading>
-  <p className="font-medium">选好网站、公开列表、热榜或订阅，再决定何时运行。虾豆会按你的节奏持续收集；任务随时可以暂停、修改或删除。</p>
+  <LegalSectionHeading>让 AI 接着查和整理</LegalSectionHeading>
+  <p className="font-medium">直接从资料库归纳重点、合并重复信息、比较不同来源的结论；资料不够时，再查找公开网页并补齐出处。回答会保留来源，方便随时回到原文核对。</p>
 
-  <LegalSectionHeading>真正值得留下的，继续沉淀</LegalSectionHeading>
-  <p className="font-medium">网页收进资料库后，可以继续阅读、搜索、整理和批注。零散的页面不再只是收藏，而会成为下一次阅读、研究或创作能接着用的资料。</p>
+  <LegalSectionHeading>从调研到写作，按步骤完成</LegalSectionHeading>
+  <p className="font-medium">工作室提供全网调研、多来源对照、本周简报、专题文稿等任务。选好任务后，按步骤填写主题、范围和成品要求，虾豆会结合资料库与公开网页完成调研、分析和写作。</p>
+
+  <LegalSectionHeading>新标签页里的常用信息</LegalSectionHeading>
+  <p className="font-medium">天气、市场行情、日期、常用网站和热门资讯，打开新标签页就能看到。小组件可以自由增减、移动和调整大小。</p>
+
+  <LegalSectionHeading>浏览网页时，常用操作就在手边</LegalSectionHeading>
+  <p className="font-medium">用悬浮球或扩展弹窗收藏当前网页、加入稍后阅读、打开阅读模式，或直接针对页面向 AI 提问。需要时还可以翻译当前页面，在原文对照和只看译文之间切换。</p>
 
   <LegalSectionHeading>资料默认留在你的浏览器</LegalSectionHeading>
-  <p className="font-medium">核心功能不需要注册账号，也没有广告或使用分析。虾豆剪藏不会自动把你的资料上传给开发者。</p>
+  <p className="font-medium">核心功能不需要注册账号，也没有广告或使用分析。只有在你主动使用 AI、同步或其他外部服务时，所选内容才会发送给你选择的服务。</p>
 
   <LegalSectionHeading>了解更多</LegalSectionHeading>
   <ul className="list-disc pl-6 space-y-2 font-medium">

--- a/website/docs/zh/apps/clipper/privacy.mdx
+++ b/website/docs/zh/apps/clipper/privacy.mdx
@@ -10,9 +10,9 @@ import {
 } from '../../../../components/docs'
 
 <PublicDocPage lang="zh" title="虾豆剪藏隐私政策">
-  <LegalUpdated>生效日期：2026 年 8 月 11 日 · 联系邮箱：volthesitan@gmail.com</LegalUpdated>
+  <LegalUpdated>生效日期：2026 年 8 月 17 日 · 联系邮箱：volthesitan@gmail.com</LegalUpdated>
 
-  <p className="font-medium">本政策说明虾豆剪藏 Chrome 扩展如何处理用户数据。虾豆剪藏的单一用途是把用户选择或配置来源中的网页内容保存为个人工作资料库，并通过新标签页、网页悬浮球和用户主动配置的 AI 任务，帮助用户继续阅读、整理、比较和调研这些资料。</p>
+  <p className="font-medium">本政策说明虾豆剪藏 Chrome 扩展如何处理用户数据。虾豆剪藏的单一用途是把用户选择或配置来源中的网页内容保存为个人工作资料库，并通过新标签页、网页悬浮球、网页翻译和用户主动配置的 AI 任务，帮助用户继续阅读、整理、比较和调研这些资料。</p>
   <p className="font-medium">核心功能不要求账号。用户可以选择登录虾豆，以使用官方模型或把明确选择的剪藏交给社区中的 Buddy 处理。虾豆剪藏不包含广告或使用分析。</p>
 
   <LegalSectionHeading>一、虾豆剪藏处理的信息</LegalSectionHeading>
@@ -27,7 +27,7 @@ import {
   </ul>
 
   <LegalSectionHeading>二、信息用途</LegalSectionHeading>
-  <p className="font-medium">虾豆剪藏仅将这些信息用于用户可见的功能：提取和保存内容、建立本地索引、显示资料库、执行用户创建的采集任务、整理标签页、显示用户选择的小组件、导出文件、连接用户选择的服务，以及完成用户主动开始的 AI、同步或社区处理操作。</p>
+  <p className="font-medium">虾豆剪藏仅将这些信息用于用户可见的功能：提取和保存内容、翻译用户选择的网页、建立本地索引、显示资料库、执行用户创建的采集任务、整理标签页、显示用户选择的小组件、导出文件、连接用户选择的服务，以及完成用户主动开始的 AI、同步或社区处理操作。</p>
   <p className="font-medium">虾豆剪藏不出售用户数据，不投放广告，不建立广告画像，也不把数据用于信用评估、借贷或无关分析。</p>
 
   <LegalSectionHeading>三、保存与保留期限</LegalSectionHeading>
@@ -38,7 +38,7 @@ import {
   <p className="font-medium">大多数功能在浏览器中运行。只有在用户配置、授权或主动开始对应功能后，信息才会按需要离开浏览器：</p>
   <ul className="list-disc pl-6 space-y-2 font-medium">
     <li><strong>来源网站</strong>会收到页面、公开接口、图片、字幕、PDF 或其他附件请求；请求可能使用该网站在当前 Chrome 中已有的登录状态。</li>
-    <li><strong>远程 AI 服务</strong>会在用户选择供应商并运行操作后，收到所选内容、操作说明、模型设置和所需 Key。</li>
+    <li><strong>远程 AI 服务</strong>会在用户选择供应商并运行 AI 操作或网页翻译后，收到所选内容、需要翻译的网页片段、操作说明、模型设置和所需 Key。使用浏览器内置翻译时，内容不会因此发送给用户配置的远程 AI 服务。</li>
     <li><strong>同步目标</strong>会在用户开始同步后，收到所选归档文件和所需凭据，包括 Google Drive、GitHub 或 HTTPS WebDAV。Google Drive 访问仅限虾豆剪藏创建或用户明确交给它的文件。</li>
     <li><strong>虾豆</strong>会在用户登录后收到授权和资料请求。用户把剪藏交给社区 Buddy 后，所选标题、来源、正文、元数据、操作说明和任务状态会发送到该社区。</li>
     <li><strong>Google 日历、Open-Meteo、地理编码和行情服务</strong>只会收到用户打开的小组件或查询所需的有限日历页面请求、城市或坐标、地点名称或公开证券代码。</li>
@@ -49,11 +49,11 @@ import {
 
   <LegalSectionHeading>五、权限与用户控制</LegalSectionHeading>
   <p className="font-medium">虾豆剪藏使用当前页面、脚本、网页快照、定时任务、身份和存储权限完成用户请求的功能；使用标签页权限提供可见的标签页工作区、执行用户创建的任务，并识别当前网站是否支持可选来源。</p>
-  <p className="font-medium">来源网站权限不会在安装时全部授予。设置页和工作室使用相同分组：常用来源在新安装时预先选中，其余来源可单独或按组启用，Chrome 只在启用时请求相应网站访问。未启用或未获授权的来源在工作室中会显示为不可用，用户点击后可授权并继续。访问受支持网站时，虾豆剪藏可能显示启用提醒；同一来源最多每 24 小时提醒一次，用户可以选择“不再提醒”。书签、阅读列表、浏览记录、日历页面和自定义服务地址也会在对应功能首次需要时单独申请。用户可以拒绝或撤销可选权限，只有依赖该权限的功能会停止。</p>
+  <p className="font-medium">公开 HTTPS 网页访问会在安装时开通，使公开网页调研、用户主动剪藏和网页翻译可以直接使用。这不代表虾豆剪藏会自动读取所有网页：自动保存默认关闭，定时采集也只会在用户创建任务后运行。书签、阅读列表、浏览记录、本机服务和需要单独授权的账号连接，仍会在对应功能首次需要时申请。用户可以拒绝或撤销可选权限，只有依赖该权限的功能会停止。</p>
 
   <LegalSectionHeading>六、共享与 Limited Use</LegalSectionHeading>
   <p className="font-medium">除用户选择的来源网站、AI 服务、同步目标、虾豆社区、本机目标和小组件服务外，开发者不会接收或出售虾豆剪藏数据。支持人员只有在用户主动提交、为安全调查所需或法律要求时才会查看特定数据。</p>
-  <p className="font-medium">虾豆剪藏对用户数据的使用和传输仅限于提供或改进本政策和商店页面披露的剪藏、本地整理、导出、同步、AI 和用户主动分享功能，并遵守 Chrome Web Store User Data Policy，包括 Limited Use 要求。</p>
+  <p className="font-medium">虾豆剪藏对用户数据的使用和传输仅限于提供或改进本政策和商店页面披露的剪藏、网页翻译、本地整理、导出、同步、AI 和用户主动分享功能，并遵守 Chrome Web Store User Data Policy，包括 Limited Use 要求。</p>
 
   <LegalSectionHeading>七、删除信息</LegalSectionHeading>
   <p className="font-medium">用户可以删除归档、清除凭据、退出虾豆、撤销权限并删除导出的诊断文件。卸载扩展通常会删除当前 Chrome 资料中的本地数据。发送到其他服务的副本需要在对应目标中删除。</p>

--- a/website/docs/zh/apps/clipper/support.mdx
+++ b/website/docs/zh/apps/clipper/support.mdx
@@ -17,10 +17,13 @@ import {
   <p className="font-medium">请勿在公开 Issue 中提交私人剪藏、API Key、密码、登录 Token、Cookie 或非公开社区信息。支持人员不会索要你的账号密码或完整本地资料库。</p>
 
   <LegalSectionHeading>页面无法正常剪藏</LegalSectionHeading>
-  <p className="font-medium">请刷新页面，从工具栏打开虾豆剪藏，并在 Chrome 询问时允许访问该网站。可以先尝试只保存可阅读正文。登录页、受保护媒体、嵌入文档或加载时持续变化的页面，可能无法被扩展完整获取。</p>
+  <p className="font-medium">请刷新页面，再从工具栏打开虾豆剪藏。可以先尝试只保存可阅读正文。登录页、受保护媒体、嵌入文档或加载时持续变化的页面，可能无法被扩展完整获取。</p>
+
+  <LegalSectionHeading>网页无法翻译</LegalSectionHeading>
+  <p className="font-medium">请刷新页面后重新打开扩展弹窗，并确认目标语言与显示方式。浏览器内置翻译需要当前 Chrome 支持相应语言；也可以在“设置 → 翻译”中选择已经配置好的远程模型。使用远程模型时，需要翻译的网页片段会发送给该服务。</p>
 
   <LegalSectionHeading>定时来源没有更新</LegalSectionHeading>
-  <p className="font-medium">请确认任务已经启用、Chrome 正在运行，并且来源仍可公开访问。可以先手动打开一次来源，处理可能出现的同意页面或地址变化，再重新运行任务。</p>
+  <p className="font-medium">请确认自动化已经启用、Chrome 正在运行，并且来源仍可访问。可以先手动打开一次来源，处理可能出现的登录、验证、同意页面或地址变化，再重新运行。</p>
 
   <LegalSectionHeading>同步或 AI 连接失败</LegalSectionHeading>
   <p className="font-medium">请重新连接服务并再次输入凭据；凭据只会保留在当前浏览器会话中。确认服务地址使用 HTTPS，所选账号也有权访问目标位置。</p>

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -92,19 +92,19 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
         'Get help with Zen practice plans, scripture reading, instruments, temple records, widgets, and App Store purchases.',
     },
     '/apps/clipper': {
-      title: 'Shadow Clipper - Turn Browsing into a Clear Next Step',
+      title: 'Shadow Clipper - Collect, Research, and Write with AI',
       description:
-        'Organize open pages, close distractions safely, and keep up with the web sources that matter.',
+        'Automatically collect saved items, feeds, and search results across platforms, then research, organize, and write with AI.',
     },
     '/apps/clipper/privacy': {
       title: 'Clipper Privacy Policy - Shadow',
       description:
-        'Read how Clipper stores saved pages, requests browser access, and keeps users in control of their reading library.',
+        'Read how Clipper handles saved pages, translation, browser access, AI services, and local library data.',
     },
     '/apps/clipper/support': {
       title: 'Clipper Support - Shadow',
       description:
-        'Get help organizing tabs, collecting sources, searching the library, and protecting local data.',
+        'Get help collecting sources, searching the library, using Studio and translation, and protecting local data.',
     },
     '/platform/cloud': {
       title: 'Cloud Docs - Templates, Plugins, CLI, and Deployments',
@@ -171,16 +171,17 @@ const ROUTE_SEO: Record<'en' | 'zh', Record<string, SeoMeta>> = {
       description: '查看功课、经文、法器、寺院记录、小组件和 App Store 购买的帮助信息。',
     },
     '/apps/clipper': {
-      title: '虾豆剪藏 - 把散乱的浏览收成下一步',
-      description: '归拢打开的页面，安心收掉干扰，让关注的来源持续带回新内容。',
+      title: '虾豆剪藏 - 自动收集全网内容，用 AI 整理和写作',
+      description:
+        '自动收集各个平台的收藏、订阅和搜索结果，集中保存到电脑，再用 AI 查资料、做调研、写简报。',
     },
     '/apps/clipper/privacy': {
       title: '虾豆剪藏隐私政策',
-      description: '了解虾豆剪藏如何保存网页、申请浏览器权限，并让用户掌控自己的阅读资料。',
+      description: '了解虾豆剪藏如何处理网页剪藏、翻译、浏览器权限、AI 服务和本地资料库。',
     },
     '/apps/clipper/support': {
       title: '虾豆剪藏支持',
-      description: '查看整理标签页、持续采集、搜索资料库和保护本地数据的帮助信息。',
+      description: '查看全网采集、资料库搜索、工作室、网页翻译和本地数据保护的帮助信息。',
     },
     '/platform/cloud': {
       title: '云文档 - 模版、插件、CLI 与部署',


### PR DESCRIPTION
## 变更

- 更新虾豆剪藏中英文官网文案，聚焦全网自动收集、AI 整理与工作室任务
- 补充资讯小组件、网页翻译和当前权限说明
- 同步支持页、隐私政策与 SEO 描述

## 验证

- `pnpm --filter @shadowob/website build`
- 提交与推送前检查全部通过